### PR TITLE
MEWS - Fixed error on binding to openEHR-EHR-OBSERVATION.urine_output.v1.

### DIFF
--- a/guidelines/MEWS.v1.2.gdl
+++ b/guidelines/MEWS.v1.2.gdl
@@ -118,7 +118,7 @@
 				domain = <"EHR">
 				elements = <
 					["gt0022"] = (ELEMENT_BINDING) <
-						path = <"/data[at0001]/events[at0002]/data[at0003]/items[at0005]">
+						path = <"/data[at0001]/events[at0002]/data[at0003]/items[at0004]">
 					>
 				>
 				predicates = <"max(/data/events/time)",...>


### PR DESCRIPTION
The MEWS score was not possible to open in GDL editor. There where no expections in UI. But when I run from commandline I saw the problem:

_Caused by: se.cambio.openehr.util.exceptions.InternalErrorException: Internal error : Element 'openEHR-EHR-OBSERVATION.urine_output.v1/data[at0001]/events[at0002]/data[at0003]/items[at0005]' not found!_

I fixed the GDL to reference at0004 instead. 