### PR TITLE
FeverPain migrated - not all test works though

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+guidelines/0archetypes.zip

--- a/gdl2/FeverPAIN_Assessment.v1.gdl2.json
+++ b/gdl2/FeverPAIN_Assessment.v1.gdl2.json
@@ -1,0 +1,234 @@
+{
+  "id": "FeverPAIN_Assessment.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2017-07-08",
+      "name": "Syeeda S Farruque",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "other_contributors": [
+      "Dennis Forslund, Cambio Healthcare Systems"
+    ],
+    "lifecycle_state": "Author draft",
+    "details": {
+      "sv": {
+        "id": "sv",
+        "purpose": "FeverPAIN Score identifierar patienter med streptokock-orsakad faryngit.",
+        "keywords": [
+          "streptokocker",
+          "faryngit",
+          "primärvård",
+          "FeverPAIN"
+        ],
+        "use": "Använd för att identifiera patienter med fayngit orsakad av streptokocker. \r\n\r\nInstrumentet baseras på följande faktorer:\r\n\r\nHistorik:\r\nFeber senaste 24 timmarna\r\nFrånvaro av hosta eller snuva\r\nSymtomdebut ≤3 dagar\r\n\r\nUndersökningsfynd:\r\nBeläggningar på tonsillerna\r\nSvårt inflammerade tonsiller\r\n\r\nResultatet tolkas enligt:\r\n\r\n0-1p - associerat med streptokocker i 13-18% av fallen (nära bärarfrekvens). Antibiotika ej rekommenderat.\r\n\r\n2p - associerat med streptokocker i 30-35% av fallen. Antibiotika kan vara lämpligt om utdraget förlopp.\r\n\r\n3p - associerat med streptokocker i 39-48% av fallen. Antibiotika kan vara lämpligt om utdraget förlopp.\r\n\r\n4p eller mer - associerat med streptokocker i 62-65% av fallen. Överväg antibiotika om svåra symtom, alternativt om en lätt fördröjd förskrivning (48h) kan vara lämpligt.\r\n",
+        "misuse": "För bruk av FeverPAIN krävs samtliga efterfrågade uppgifter inkl. klinisk undersökning.",
+        "copyright": "© Cambio Healthcare Systems"
+      },
+      "en": {
+        "id": "en",
+        "purpose": "The FeverPAIN Score for Strep Pharyngitis identifies patients with streptococcal pharyngitis specifically",
+        "keywords": [
+          "streptococcus",
+          "pharyngitis",
+          "antibiotics",
+          "FeverPAIN score"
+        ],
+        "use": "This model evaluates the FeverPAIN score:\n\nScore interpretation:\n\nA score of 0-1 is associated with 13-18% isolation of streptococcus (close to background carriage rates).\nNo antibiotics recommended.\n\nA score of 2 is associated with 30-35% isolation of streptococcus.\nDelayed antibiotic may be appropriate.\n\nA score of 3 is associated with 39-48% isolation of streptococcus.\nDelayed antibiotic may be appropriate.\n\nA score of 4 or more is associated with 62-65% isolation of streptococcus.\nConsider antibiotics if symptoms are severe or a short delayed prescribing strategy may be appropriate (48 hours).\n",
+        "misuse": "The FeverPAIN Score requires detailed history taking and examination of the pharynx and shouldn't be used without these parts of the investigation in place.",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Ref. 1: Little P, et al. Incidence and clinical variables associated with streptococcal throat infections: a prospective diagnostic cohort study. Br J Gen Pract. 2012 Nov;62(604):e787-94."
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0002": {
+        "id": "gt0002",
+        "model_id": "openEHR-EHR-EVALUATION.feverpain_strep_assessment.v1",
+        "template_id": "openEHR-EHR-EVALUATION.feverpain_strep_assessment.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0006": {
+            "id": "gt0006",
+            "path": "/data[at0001]/items[at0002]"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "path": "/data[at0001]/items[at0003]"
+          }
+        }
+      },
+      "gt0003": {
+        "id": "gt0003",
+        "model_id": "openEHR-EHR-OBSERVATION.feverpain_for_strep_throat.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.feverpain_for_strep_throat.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0008": {
+            "id": "gt0008",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0009]"
+          }
+        }
+      }
+    },
+    "rules": {
+      "gt0010": {
+        "id": "gt0010",
+        "priority": 4,
+        "when": [
+          "$gt0008|Total score|<=1",
+          "$gt0008|Total score|>=0"
+        ],
+        "then": [
+          "$gt0006|Percentage Isolation of Streptococcus|=0|local::at0005|13-18% isolation of streptococcus|",
+          "$gt0007|Recommendation|=0|local::at0009|No antibiotics recommended.|"
+        ]
+      },
+      "gt0011": {
+        "id": "gt0011",
+        "priority": 3,
+        "when": [
+          "$gt0008|Total score|==2"
+        ],
+        "then": [
+          "$gt0006|Percentage Isolation of Streptococcus|=1|local::at0006| 30-35% isolation of streptococcus|",
+          "$gt0007|Recommendation|=1|local::at0010|Delayed antibiotic may be appropriate.|"
+        ]
+      },
+      "gt0012": {
+        "id": "gt0012",
+        "priority": 2,
+        "when": [
+          "$gt0008|Total score|==3"
+        ],
+        "then": [
+          "$gt0006|Percentage Isolation of Streptococcus|=2|local::at0007|39-48% isolation of streptococcus|",
+          "$gt0007|Recommendation|=1|local::at0010|Delayed antibiotic may be appropriate.|"
+        ]
+      },
+      "gt0013": {
+        "id": "gt0013",
+        "priority": 1,
+        "when": [
+          "$gt0008|Total score|>=4"
+        ],
+        "then": [
+          "$gt0006|Percentage Isolation of Streptococcus|=3|local::at0008| 62-65% isolation of streptococcus|",
+          "$gt0007|Recommendation|=2|local::at0011|Consider antibiotics|"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "sv": {
+        "id": "sv",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "FeverPAIN - utvärdering",
+            "description": "Utvärdering av poäng genererad i enlighet med FeverPAIN Score. Rekommendation av åtgärd baserat på ackumulerad poäng."
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Poäng",
+            "description": "*(en) Total sum of the individual scores. Range is 0 to 5"
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Andel av fall med påvisade streptokocker",
+            "description": "*(en) Percentage Isolation of Streptococcus"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Rekommendation",
+            "description": "*(en) Recommendation"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Poäng",
+            "description": "*(en) Total sum of the individual scores. Range is 0 to 5"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "*(en) score"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "CDS 13-18% med påvisade streptokocker"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "CDS 30-35% med påvisade streptokocker"
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "CDS 39-48% med påvisade streptokocker"
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "CDS 62-65% med påvisade streptokocker"
+          }
+        }
+      },
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "FeverPAIN Assessment",
+            "description": "The FeverPAIN score predicts likelihood of strep throat and provides treatment management based on the scores produced"
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Total score",
+            "description": "Total sum of the individual scores. Range is 0 to 5"
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Percentage Isolation of Streptococcus",
+            "description": "Percentage Isolation of Streptococcus"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Recommendation",
+            "description": "Recommendation"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Total score",
+            "description": "Total sum of the individual scores. Range is 0 to 5"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "score"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Set 13-18% isolation of streptococcus "
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Set 30-35% isolation of streptococcus"
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "Set 39-48% isolation of streptococcus"
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "Set 62-65% isolation of streptococcus"
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/FeverPAIN_Assessment.v1.test.yml
+++ b/gdl2/FeverPAIN_Assessment.v1.test.yml
@@ -1,0 +1,35 @@
+guidelines:
+  1: FeverPAIN_Assessment.v1
+test_cases:
+- id: 0
+  input:
+    1:
+      gt0008|Total score: 0
+  expected_output:
+    1:
+      gt0006|Percentage Isolation of Streptococcus: 0|local::at0005|13-18% isolation of streptococcus|
+      gt0007|Recommendation: 0|local::at0009|No antibiotics recommended.|
+- id: 1
+  input:
+    1:
+      gt0008|Total score: 1
+  expected_output:
+    1:
+      gt0006|Percentage Isolation of Streptococcus: 0|local::at0005|13-18% isolation of streptococcus|
+      gt0007|Recommendation: 0|local::at0009|No antibiotics recommended.|
+- id: 4
+  input:
+    1:
+      gt0008|Total score: 4
+  expected_output:
+    1:
+      gt0006|Percentage Isolation of Streptococcus: 3|local::at0008| 62-65% isolation of streptococcus|
+      gt0007|Recommendation: 2|local::at0011|Consider antibiotics|
+- id: 5
+  input:
+    1:
+      gt0008|Total score: 5
+  expected_output:
+    1:
+      gt0006|Percentage Isolation of Streptococcus: 3|local::at0008| 62-65% isolation of streptococcus|
+      gt0007|Recommendation: 2|local::at0011|Consider antibiotics|

--- a/gdl2/FeverPAIN_Assessment.v1.test.yml
+++ b/gdl2/FeverPAIN_Assessment.v1.test.yml
@@ -17,6 +17,22 @@ test_cases:
     1:
       gt0006|Percentage Isolation of Streptococcus: 0|local::at0005|13-18% isolation of streptococcus|
       gt0007|Recommendation: 0|local::at0009|No antibiotics recommended.|
+- id: 2
+  input:
+    1:
+      gt0008|Total score: 2
+  expected_output:
+    1:
+      gt0006|Percentage Isolation of Streptococcus: 1|local::at0006| 30-35% isolation of streptococcus|
+      gt0007|Recommendation: 1|local::at0010|Delayed antibiotic may be appropriate.|
+- id: 3
+  input:
+    1:
+      gt0008|Total score: 3
+  expected_output:
+    1:
+      gt0006|Percentage Isolation of Streptococcus: 2|local::at0007|39-48% isolation of streptococcus|
+      gt0007|Recommendation: 1|local::at0010|Delayed antibiotic may be appropriate.|
 - id: 4
   input:
     1:

--- a/gdl2/FeverPAIN_Strep.v1.gdl2.json
+++ b/gdl2/FeverPAIN_Strep.v1.gdl2.json
@@ -1,0 +1,380 @@
+{
+  "id": "FeverPAIN_Strep.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2017-07-08",
+      "name": "Syeeda S Farruque",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "other_contributors": [
+      "Dennis Forslund, Cambio Healthcare Systems"
+    ],
+    "lifecycle_state": "Author draft",
+    "details": {
+      "sv": {
+        "id": "sv",
+        "purpose": "FeverPAIN Score identifierar patienter med streptokock-orsakad faryngit.",
+        "keywords": [
+          "streptokocker",
+          "FeverPAIN",
+          "faryngit",
+          "primärvård"
+        ],
+        "use": "Använd för att identifiera patienter med fayngit orsakad av streptokocker. \r\n\r\nInstrumentet baseras på följande faktorer:\r\n\r\nHistorik:\r\nFeber senaste 24 timmarna\r\nFrånvaro av hosta eller snuva\r\nSymtomdebut ≤3 dagar\r\n\r\nUndersökningsfynd:\r\nBeläggningar på tonsillerna\r\nSvårt inflammerade tonsiller\r\n\r\nResultatet tolkas enligt:\r\n\r\n0-1p - associerat med streptokocker i 13-18% av fallen (nära bärarfrekvens). Antibiotika ej rekommenderat.\r\n\r\n2p - associerat med streptokocker i 30-35% av fallen. Antibiotika kan vara lämpligt om utdraget förlopp.\r\n\r\n3p - associerat med streptokocker i 39-48% av fallen. Antibiotika kan vara lämpligt om utdraget förlopp.\r\n\r\n4p eller mer - associerat med streptokocker i 62-65% av fallen. Överväg antibiotika om svåra symtom, alternativt om en lätt fördröjd förskrivning (48h) kan vara lämpligt.\r\n",
+        "misuse": "För bruk av FeverPAIN krävs samtliga efterfrågade uppgifter inkl. klinisk undersökning.",
+        "copyright": "© Cambio Healthcare Systems"
+      },
+      "en": {
+        "id": "en",
+        "purpose": "The FeverPAIN Score for Strep Pharyngitis identifies patients with streptococcal pharyngitis specifically",
+        "keywords": [
+          "streptococcus",
+          "strep throat",
+          "pharyngitis",
+          "FeverPAIN score"
+        ],
+        "use": "Identifying patients with Strep pharyngitis can help reduce the unnecessary use of antibiotics.\r\n\r\n2 Sections of questions split between History and Physical findings with Y/N binary questions (scores 0,1):\r\n\r\nHistory:\r\nFever in past 24 hours\r\nAbsence of cough or coryza\r\nSymptom onset ≤3 days\r\n\r\nPhysical findings:\r\nPurulent tonsils\r\nSevere tonsil inflammation\r\n\r\nScore interpretation:\r\n\r\nA score of 0-1 is associated with 13-18% isolation of streptococcus (close to background carriage rates).\r\nNo antibiotics recommended.\r\n\r\nA score of 2 is associated with 30-35% isolation of streptococcus.\r\nDelayed antibiotic may be appropriate.\r\n\r\nA score of 3 is associated with 39-48% isolation of streptococcus.\r\nDelayed antibiotic may be appropriate.\r\n\r\nA score of 4 or more is associated with 62-65% isolation of streptococcus.\r\nConsider antibiotics if symptoms are severe or a short delayed prescribing strategy may be appropriate (48 hours).",
+        "misuse": "The FeverPAIN Score requires detailed history taking and examination of the pharynx and shouldn't be used without these parts of the investigation in place.",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Ref. 1: Little P, et al. Incidence and clinical variables associated with streptococcal throat infections: a prospective diagnostic cohort study. Br J Gen Pract. 2012 Nov;62(604):e787-94."
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0002": {
+        "id": "gt0002",
+        "model_id": "openEHR-EHR-OBSERVATION.feverpain_for_strep_throat.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.feverpain_for_strep_throat.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0009": {
+            "id": "gt0009",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0011]/items[at0006]"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0011]/items[at0005]"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0011]/items[at0004]"
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0012]/items[at0008]"
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0012]/items[at0007]"
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0009]"
+          }
+        }
+      },
+      "gt0003": {
+        "id": "gt0003",
+        "model_id": "openEHR-EHR-OBSERVATION.feverpain_for_strep_throat.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.feverpain_for_strep_throat.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0004": {
+            "id": "gt0004",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0011]/items[at0006]"
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0011]/items[at0005]"
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0011]/items[at0004]"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0012]/items[at0008]"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0012]/items[at0007]"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      }
+    },
+    "default_actions": [
+      "$gt0009|Symptom onset ≤3 days|=0|local::at0013|No|",
+      "$gt0010|Absence of cough or coryza|=0|local::at0015|No|",
+      "$gt0011|Fever in past 24 hours|=0|local::at0017|No|",
+      "$gt0012|Purulent tonsils|=0|local::at0019|No|",
+      "$gt0013|Severe tonsil inflammation|=0|local::at0021|No|"
+    ],
+    "rules": {
+      "gt0015": {
+        "id": "gt0015",
+        "priority": 6,
+        "when": [
+          "$gt0004|Symptom onset ≤3 days|!=null"
+        ],
+        "then": [
+          "$gt0009|Symptom onset ≤3 days|=$gt0004|Symptom onset ≤3 days|"
+        ]
+      },
+      "gt0016": {
+        "id": "gt0016",
+        "priority": 5,
+        "when": [
+          "$gt0005|Absence of cough or coryza|!=null"
+        ],
+        "then": [
+          "$gt0010|Absence of cough or coryza|=$gt0005|Absence of cough or coryza|"
+        ]
+      },
+      "gt0017": {
+        "id": "gt0017",
+        "priority": 4,
+        "when": [
+          "$gt0006|Fever in past 24 hours|!=null"
+        ],
+        "then": [
+          "$gt0011|Fever in past 24 hours|=$gt0006|Fever in past 24 hours|"
+        ]
+      },
+      "gt0018": {
+        "id": "gt0018",
+        "priority": 3,
+        "when": [
+          "$gt0007|Purulent tonsils|!=null"
+        ],
+        "then": [
+          "$gt0012|Purulent tonsils|=$gt0007|Purulent tonsils|"
+        ]
+      },
+      "gt0019": {
+        "id": "gt0019",
+        "priority": 2,
+        "when": [
+          "$gt0008|Severe tonsil inflammation|!=null"
+        ],
+        "then": [
+          "$gt0013|Severe tonsil inflammation|=$gt0008|Severe tonsil inflammation|"
+        ]
+      },
+      "gt0020": {
+        "id": "gt0020",
+        "priority": 1,
+        "then": [
+          "$gt0014|Total score|.magnitude=((($gt0009.value+$gt0010.value)+$gt0011.value)+$gt0012.value)+$gt0013.value"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "sv": {
+        "id": "sv",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "FeverPAIN Score",
+            "description": "FeverPAIN Score identifierar patienter med streptokock-orsakad faryngit."
+          },
+          "gt0004": {
+            "id": "gt0004",
+            "text": "Symtomdebut ≤3 dagar",
+            "description": "*(en) *"
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Frånvaro av hosta eller snuva",
+            "description": "*(en) *"
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Feber senaste 24 timmarna",
+            "description": "*(en) *"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Beläggningar på tonsillerna",
+            "description": "*(en) *"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Svårt inflammerade tonsiller",
+            "description": "*(en) *"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Symtomdebut ≤3 dagar",
+            "description": "*(en) *"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Frånvaro av hosta eller snuva",
+            "description": "*(en) *"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Feber senaste 24 timmarna",
+            "description": "*(en) *"
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "Beläggningar på tonsillerna",
+            "description": "*(en) *"
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "Svårt inflammerade tonsiller",
+            "description": "*(en) *"
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "Poäng",
+            "description": "*(en) Total sum of the individual scores. Range is 0 to 5"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "CDS Symtomdebut ≤3 dagar"
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "CDS Frånvaro av hosta eller snuva"
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "text": "CDS Feber senaste 24 timmarna"
+          },
+          "gt0018": {
+            "id": "gt0018",
+            "text": "CDS Beläggningar på tonsillerna"
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "text": "CDS Svårt inflammerade tonsiller"
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "Beräkna poäng"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      },
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "FeverPAIN Strep",
+            "description": "Predicts likelihood of strep throat."
+          },
+          "gt0004": {
+            "id": "gt0004",
+            "text": "Symptom onset ≤3 days",
+            "description": "*"
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Absence of cough or coryza",
+            "description": "*"
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Fever in past 24 hours",
+            "description": "*"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Purulent tonsils",
+            "description": "*"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Severe tonsil inflammation",
+            "description": "*"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Symptom onset ≤3 days",
+            "description": "*"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Absence of cough or coryza",
+            "description": "*"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Fever in past 24 hours",
+            "description": "*"
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "Purulent tonsils",
+            "description": "*"
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "Severe tonsil inflammation",
+            "description": "*"
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "Total score",
+            "description": "Total sum of the individual scores. Range is 0 to 5"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "Set Symptom onset"
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "Set Absence of cough"
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "text": "Set Fever"
+          },
+          "gt0018": {
+            "id": "gt0018",
+            "text": "Set Purulent tonsils"
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "text": "Set Severe tonsil inflammation"
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "Calculate total score"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/FeverPAIN_Strep.v1.test.yml
+++ b/gdl2/FeverPAIN_Strep.v1.test.yml
@@ -1,0 +1,128 @@
+guidelines:
+  1: FeverPAIN_Strep.v1
+test_cases:
+- id: case_1
+  input:
+    1:
+      gt0004|Symptom onset ≤3 days: 0|local::at0013|No|
+      gt0021|Event time: 2019-02-20T10:40Z
+  expected_output:
+    1:
+      gt0011|Fever in past 24 hours: 0|local::at0017|No|
+      gt0014|Total score: 0
+      gt0010|Absence of cough or coryza: 0|local::at0015|No|
+      gt0009|Symptom onset ≤3 days: 0|local::at0013|No|
+      gt0013|Severe tonsil inflammation: 0|local::at0021|No|
+      gt0012|Purulent tonsils: 0|local::at0019|No|
+- id: case_2
+  input:
+    1:
+      gt0004|Symptom onset ≤3 days: 0|local::at0013|No|
+      gt0005|Absence of cough or coryza: 0|local::at0015|No|
+      gt0021|Event time: 2019-02-20T10:40Z
+  expected_output:
+    1:
+      gt0011|Fever in past 24 hours: 0|local::at0017|No|
+      gt0014|Total score: 0
+      gt0010|Absence of cough or coryza: 0|local::at0015|No|
+      gt0009|Symptom onset ≤3 days: 0|local::at0013|No|
+      gt0013|Severe tonsil inflammation: 0|local::at0021|No|
+      gt0012|Purulent tonsils: 0|local::at0019|No|
+- id: case_3
+  input:
+    1:
+      gt0004|Symptom onset ≤3 days: 0|local::at0013|No|
+      gt0005|Absence of cough or coryza: 0|local::at0015|No|
+      gt0006|Fever in past 24 hours: 0|local::at0017|No|
+      gt0021|Event time: 2019-02-20T10:40Z
+  expected_output:
+    1:
+      gt0011|Fever in past 24 hours: 0|local::at0017|No|
+      gt0014|Total score: 0
+      gt0010|Absence of cough or coryza: 0|local::at0015|No|
+      gt0009|Symptom onset ≤3 days: 0|local::at0013|No|
+      gt0013|Severe tonsil inflammation: 0|local::at0021|No|
+- id: case_4
+  input:
+    1:
+      gt0004|Symptom onset ≤3 days: 0|local::at0013|No|
+      gt0005|Absence of cough or coryza: 0|local::at0015|No|
+      gt0006|Fever in past 24 hours: 0|local::at0017|No|
+      gt0007|Purulent tonsils: 0|local::at0019|No|
+      gt0021|Event time: 2019-02-20T10:40Z
+  expected_output:
+    1:
+      gt0011|Fever in past 24 hours: 0|local::at0017|No|
+      gt0014|Total score: 0
+      gt0010|Absence of cough or coryza: 0|local::at0015|No|
+      gt0009|Symptom onset ≤3 days: 0|local::at0013|No|
+      gt0013|Severe tonsil inflammation: 0|local::at0021|No|
+      gt0012|Purulent tonsils: 0|local::at0019|No|
+      gt0012|Purulent tonsils: 0|local::at0019|No|
+- id: case_5
+  input:
+    1:
+      gt0004|Symptom onset ≤3 days: 0|local::at0013|No|
+      gt0005|Absence of cough or coryza: 0|local::at0015|No|
+      gt0006|Fever in past 24 hours: 0|local::at0017|No|
+      gt0007|Purulent tonsils: 0|local::at0019|No|
+      gt0008|Severe tonsil inflammation: 0|local::at0021|No|
+      gt0021|Event time: 2019-02-20T10:40Z
+  expected_output:
+    1:
+      gt0011|Fever in past 24 hours: 0|local::at0017|No|
+      gt0014|Total score: 0
+      gt0010|Absence of cough or coryza: 0|local::at0015|No|
+      gt0009|Symptom onset ≤3 days: 0|local::at0013|No|
+      gt0013|Severe tonsil inflammation: 0|local::at0021|No|
+      gt0012|Purulent tonsils: 0|local::at0019|No|
+- id: case_6
+  input:
+    1:
+      gt0004|Symptom onset ≤3 days: 1|local::at0014|Yes|
+      gt0005|Absence of cough or coryza: 1|local::at0016|Yes|
+      gt0007|Purulent tonsils: 0|local::at0019|No|
+      gt0008|Severe tonsil inflammation: 0|local::at0021|No|
+      gt0021|Event time: 2019-02-20T11:16Z
+  expected_output:
+    1:
+      gt0011|Fever in past 24 hours: 0|local::at0017|No|
+      gt0014|Total score: 2
+      gt0010|Absence of cough or coryza: 1|local::at0016|Yes|
+      gt0009|Symptom onset ≤3 days: 1|local::at0014|Yes|
+      gt0013|Severe tonsil inflammation: 0|local::at0021|No|
+      gt0012|Purulent tonsils: 0|local::at0019|No|
+- id: case_7
+  input:
+    1:
+      gt0004|Symptom onset ≤3 days: 1|local::at0014|Yes|
+      gt0005|Absence of cough or coryza: 1|local::at0016|Yes|
+      gt0006|Fever in past 24 hours: 1|local::at0018|Yes|
+      gt0007|Purulent tonsils: 0|local::at0019|No|
+      gt0008|Severe tonsil inflammation: 0|local::at0021|No|
+      gt0021|Event time: 2019-02-20T11:16Z
+  expected_output:
+    1:
+      gt0011|Fever in past 24 hours: 1|local::at0018|Yes|
+      gt0014|Total score: 3
+      gt0010|Absence of cough or coryza: 1|local::at0016|Yes|
+      gt0009|Symptom onset ≤3 days: 1|local::at0014|Yes|
+      gt0013|Severe tonsil inflammation: 0|local::at0021|No|
+      gt0012|Purulent tonsils: 0|local::at0019|No|
+- id: case_8
+  input:
+    1:
+      gt0004|Symptom onset ≤3 days: 1|local::at0014|Yes|
+      gt0005|Absence of cough or coryza: 1|local::at0016|Yes|
+      gt0006|Fever in past 24 hours: 1|local::at0018|Yes|
+      gt0007|Purulent tonsils: 1|local::at0020|Yes|
+      gt0008|Severe tonsil inflammation: 1|local::at0022|Yes|
+      gt0021|Event time: 2019-02-20T11:16Z
+  expected_output:
+    1:
+      gt0011|Fever in past 24 hours: 1|local::at0018|Yes|
+      gt0014|Total score: 5
+      gt0010|Absence of cough or coryza: 1|local::at0016|Yes|
+      gt0009|Symptom onset ≤3 days: 1|local::at0014|Yes|
+      gt0013|Severe tonsil inflammation: 1|local::at0022|Yes|
+      gt0012|Purulent tonsils: 1|local::at0020|Yes|


### PR DESCRIPTION
In FeverPain_Assessment two rules can not be tested, as the "==" sign does not function correctly.
Otherwise a couple of tests work fine with both guidelines.