### PR TITLE
Calcium Corrected

### DIFF
--- a/gdl2/Calcium_corrected.v1.gdl2.json
+++ b/gdl2/Calcium_corrected.v1.gdl2.json
@@ -100,10 +100,6 @@
           "gt0008": {
             "id": "gt0008",
             "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0092]"
-          },
-          "gt0011": {
-            "id": "gt0011",
-            "path": "/data/events/time"
           }
         }
       }
@@ -117,7 +113,6 @@
           "$gt0004|Albumin|.unit=='gm/l'"
         ],
         "then": [
-          "$gt0011|Event time|=$currentDateTime",
           "$gt0008|Calcium_corrected|.unit='mg/dl'",
           "$gt0008|Calcium_corrected|.precision=2",
           "$gt0008|Calcium_corrected|.magnitude=(((40-$gt0004.magnitude)/10)*0.8)+$gt0006.magnitude"
@@ -216,11 +211,6 @@
             "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
           }
         }
-      }
-    },
-    "term_bindings": {
-      "SNOMEDCT": {
-        "id": "SNOMEDCT"
       }
     }
   }

--- a/gdl2/Calcium_corrected.v1.gdl2.json
+++ b/gdl2/Calcium_corrected.v1.gdl2.json
@@ -1,0 +1,227 @@
+{
+  "id": "Calcium_corrected.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2016-10-06",
+      "name": "Eneimi Allwell-Brown",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "other_contributors": [
+      "Dennis Forslund",
+      "Jimmy Axelsson"
+    ],
+    "lifecycle_state": "Author draft",
+    "details": {
+      "sv": {
+        "id": "sv",
+        "purpose": "Att beräkna albuminkorrigerat kalcium hos patient med hypoalbuminemi.",
+        "keywords": [
+          "klinisk kemi",
+          "Extracellulärt kalcium",
+          "Joniserat kalcium",
+          "Ca",
+          "Cakorr"
+        ],
+        "use": "Använd för att beräkna albuminkorrigerat kalcium hos patienter med känd albumin- och kalciumnivå. Formeln är utvecklad av Payne et al och ger en beräkning enligt: korrigerat kalcium = serum-kalcium  + 0.8 * [(40 - serum-albumin) / 10]. Kalcium anges i mg/dl, albumin i g/L (40 är ett givet värde för normalt albumin). För att konvertera albuminvärde från g/dl till g/L, multiplicera med tio.",
+        "misuse": "Ej avsedd att användas för patienter med hyperalbuminemi. Serum-albumin kan endast beräknas i enhet g/dl. För att konvertera albuminvärde från g/dl till g/L, multiplicera med tio.",
+        "copyright": "© Cambio Healthcare Systems"
+      },
+      "en": {
+        "id": "en",
+        "purpose": "To calculate the corrected calcium level in a sample, commonly serum or plasma, in individuals with hypoalbuminaemia.",
+        "keywords": [
+          "clinical chemistry",
+          "extracellular calcium",
+          "protein-bound calcium",
+          "ionized (free) calcium",
+          "chelated (complexed) calcium"
+        ],
+        "use": "Use to calculate \\\"corrected calcium\\\" in individuals with known albumin and calcium levels.\nThe formula used arises from work done by Payne et al and is given as; corrected calcium = serum calcium  + 0.8 * [(40 - serum albumin) / 10], where calcium measurements are in mg/dl, measured serum albumin is in g/L and 40 (g/L) is the assumed population normal for albumin. \nThis guide only accepts input albumin measurements as g/L. \nTo convert from g/dl to g/L, multiply by ten (10).",
+        "misuse": "Not to be used to calculate corrected calcium in individuals with hyperalbuminaemia.\nDo not enter serum albumin as g/dl.",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Payne RB, Little AJ, Williams RB, Milner JR. Interpretation of serum calcium in patients with abnormal serum proteins. Br Med J. 1973 Dec 15;4(5893):643-6."
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0003": {
+        "id": "gt0003",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-liver_function.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-liver_function.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0004": {
+            "id": "gt0004",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.7]"
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0005": {
+        "id": "gt0005",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-calcium_phosphate.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-calcium_phosphate.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0006": {
+            "id": "gt0006",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078]"
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0007": {
+        "id": "gt0007",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-calcium_phosphate.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-calcium_phosphate.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0008": {
+            "id": "gt0008",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0092]"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "path": "/data/events/time"
+          }
+        }
+      }
+    },
+    "rules": {
+      "gt0002": {
+        "id": "gt0002",
+        "priority": 1,
+        "when": [
+          "$gt0006|Calcium|.unit=='mg/dl'",
+          "$gt0004|Albumin|.unit=='gm/l'"
+        ],
+        "then": [
+          "$gt0011|Event time|=$currentDateTime",
+          "$gt0008|Calcium_corrected|.unit='mg/dl'",
+          "$gt0008|Calcium_corrected|.precision=2",
+          "$gt0008|Calcium_corrected|.magnitude=(((40-$gt0004.magnitude)/10)*0.8)+$gt0006.magnitude"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "sv": {
+        "id": "sv",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Albuminkorrigerat kalcium",
+            "description": "Albuminkorrigerat kalcium utgör den totala kalciumkoncentrationen hos en patient med hypoalbuminemi. Eftersom serum-kalcium i huvudsak är bundet till albumin, genererar en hypoalbuminemi ett falskt lågt värde av total kalciumkoncentration. Med hjälp av Paynes formel kan man korrigera för detta; albuminkorrigerat kalcium = serum-kalcium + 0.8 * [(40 – serum-albumin) / 10]. Serum-kalcium anges i mg/dl, serum-albumin i g/L. I ekvationen står 40 (g/L) för normalt referensvärde för albumin."
+          },
+          "gt0002": {
+            "id": "gt0002",
+            "text": "Beräkna albuminkorrigerat kalcium",
+            "description": "*(en) This rule contains the expression logic for calculating corrected calcium level."
+          },
+          "gt0004": {
+            "id": "gt0004",
+            "text": "Albumin",
+            "description": "*(en) Albumin level in the sample."
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Kalcium",
+            "description": "*(en) The calcium level in the sample."
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Albuminkorrigerat kalcium",
+            "description": "*(en) The calculated corrected-calcium level in the sample."
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      },
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Calcium Corrected",
+            "description": "Corrected calcium is the total calcium concentration in an individual when adjusted for the presence of hypoalbuminaemia in that individual. Because serum calcium (part of total calcium concentration) is principally bound to the plasma protein albumin, when levels of albumin are low it results in a falsely low total calcium concentration. The Payne formula performs the necessary adjustments to determine the actual total calcium concentration in individuals with hypoalbuminaemia: corrected calcium = serum calcium  + 0.8 * [(40 - serum albumin) / 10]. Serum calcium is measured in mg/dl, serum albumin is measured in g/L and 40 in the equation refers to 40 g/L which is the assumed population normal for albumin."
+          },
+          "gt0002": {
+            "id": "gt0002",
+            "text": "Calculate corrected calcium",
+            "description": "This rule contains the expression logic for calculating corrected calcium level."
+          },
+          "gt0004": {
+            "id": "gt0004",
+            "text": "Albumin",
+            "description": "Albumin level in the sample."
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Calcium",
+            "description": "The calcium level in the sample."
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Calcium_corrected",
+            "description": "The calculated corrected-calcium level in the sample."
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      }
+    },
+    "term_bindings": {
+      "SNOMEDCT": {
+        "id": "SNOMEDCT"
+      }
+    }
+  }
+}

--- a/gdl2/Calcium_corrected.v1.test.yml
+++ b/gdl2/Calcium_corrected.v1.test.yml
@@ -11,8 +11,7 @@ test_cases:
   expected_output:
     1:
       gt0008|Calcium_corrected: 9.00,mg/dl
-      gt0011|Event time: 2019-02-22T17:42:08.928[UTC]
-
+      
 
 - id: albumin(normal)-calcium(low)
   input:
@@ -24,7 +23,6 @@ test_cases:
   expected_output:
     1:
       gt0008|Calcium_corrected: 4.00,mg/dl
-      gt0011|Event time: 2019-02-22T17:47:09.295Z[UTC]
 
 
 - id: albumin(normal)-calcium(high)
@@ -37,8 +35,6 @@ test_cases:
   expected_output:
     1:
       gt0008|Calcium_corrected: 15.00,mg/dl
-      gt0011|Event time: 2019-02-22T17:47:53.547Z[UTC]
-
 
 
 - id: albumin(low)-calcium(normal)
@@ -51,7 +47,6 @@ test_cases:
   expected_output:
     1:
       gt0008|Calcium_corrected: 10.60,mg/dl
-      gt0011|Event time: 2019-02-22T17:43:42.020Z[UTC]
 
 
 - id: albumin(low)-calcium(low)
@@ -64,7 +59,6 @@ test_cases:
   expected_output:
     1:
       gt0008|Calcium_corrected: 5.60,mg/dl
-      gt0011|Event time: 2019-02-22T17:49:21.192Z[UTC]
 
 
 - id: albumin(low)-calcium(high)
@@ -77,7 +71,6 @@ test_cases:
   expected_output:
     1:
       gt0008|Calcium_corrected: 16.60,mg/dl
-      gt0011|Event time: 2019-02-22T17:49:37.491Z[UTC]
 
 
 - id: albumin(high)-calcium(normal)
@@ -90,7 +83,6 @@ test_cases:
   expected_output:
     1:
       gt0008|Calcium_corrected: 6.60,mg/dl
-      gt0011|Event time: 2019-02-22T17:45:00.860Z[UTC]
 
 
 - id: albumin(high)-calcium(low)
@@ -103,7 +95,6 @@ test_cases:
   expected_output:
     1:
       gt0008|Calcium_corrected: 0.80,mg/dl
-      gt0011|Event time: 2019-02-22T17:50:44.409Z[UTC]
 
 
 - id: albumin(high)-calcium(high)
@@ -116,5 +107,4 @@ test_cases:
   expected_output:
     1:
       gt0008|Calcium_corrected: 11.80,mg/dl
-      gt0011|Event time: 2019-02-22T17:50:27.839Z[UTC]
 

--- a/gdl2/Calcium_corrected.v1.test.yml
+++ b/gdl2/Calcium_corrected.v1.test.yml
@@ -1,0 +1,120 @@
+guidelines:
+  1: Calcium_corrected.v1
+test_cases:
+- id: albumin(normal)-calcium(normal)
+  input:
+    1:
+      gt0004|Albumin: 40,gm/l
+      gt0012|Event time: 2019-02-22T18:39Z
+      gt0006|Calcium: 9,mg/dl
+      gt0013|Event time: 2019-02-22T18:39Z
+  expected_output:
+    1:
+      gt0008|Calcium_corrected: 9.00,mg/dl
+      gt0011|Event time: 2019-02-22T17:42:08.928[UTC]
+
+
+- id: albumin(normal)-calcium(low)
+  input:
+    1:
+      gt0004|Albumin: 40,gm/l
+      gt0012|Event time: 2019-02-22T18:39Z
+      gt0006|Calcium: 4,mg/dl
+      gt0013|Event time: 2019-02-22T18:39Z
+  expected_output:
+    1:
+      gt0008|Calcium_corrected: 4.00,mg/dl
+      gt0011|Event time: 2019-02-22T17:47:09.295Z[UTC]
+
+
+- id: albumin(normal)-calcium(high)
+  input:
+    1:
+      gt0004|Albumin: 40,gm/l
+      gt0012|Event time: 2019-02-22T18:39Z
+      gt0006|Calcium: 15,mg/dl
+      gt0013|Event time: 2019-02-22T18:39Z
+  expected_output:
+    1:
+      gt0008|Calcium_corrected: 15.00,mg/dl
+      gt0011|Event time: 2019-02-22T17:47:53.547Z[UTC]
+
+
+
+- id: albumin(low)-calcium(normal)
+  input:
+    1:
+      gt0004|Albumin: 20,gm/l
+      gt0012|Event time: 2019-02-22T18:39Z
+      gt0006|Calcium: 9,mg/dl
+      gt0013|Event time: 2019-02-22T18:39Z
+  expected_output:
+    1:
+      gt0008|Calcium_corrected: 10.60,mg/dl
+      gt0011|Event time: 2019-02-22T17:43:42.020Z[UTC]
+
+
+- id: albumin(low)-calcium(low)
+  input:
+    1:
+      gt0004|Albumin: 20,gm/l
+      gt0012|Event time: 2019-02-22T18:39Z
+      gt0006|Calcium: 4,mg/dl
+      gt0013|Event time: 2019-02-22T18:39Z
+  expected_output:
+    1:
+      gt0008|Calcium_corrected: 5.60,mg/dl
+      gt0011|Event time: 2019-02-22T17:49:21.192Z[UTC]
+
+
+- id: albumin(low)-calcium(high)
+  input:
+    1:
+      gt0004|Albumin: 20,gm/l
+      gt0012|Event time: 2019-02-22T18:39Z
+      gt0006|Calcium: 15,mg/dl
+      gt0013|Event time: 2019-02-22T18:39Z
+  expected_output:
+    1:
+      gt0008|Calcium_corrected: 16.60,mg/dl
+      gt0011|Event time: 2019-02-22T17:49:37.491Z[UTC]
+
+
+- id: albumin(high)-calcium(normal)
+  input:
+    1:
+      gt0004|Albumin: 70,gm/l
+      gt0012|Event time: 2019-02-22T18:39Z
+      gt0006|Calcium: 9,mg/dl
+      gt0013|Event time: 2019-02-22T18:39Z
+  expected_output:
+    1:
+      gt0008|Calcium_corrected: 6.60,mg/dl
+      gt0011|Event time: 2019-02-22T17:45:00.860Z[UTC]
+
+
+- id: albumin(high)-calcium(low)
+  input:
+    1:
+      gt0004|Albumin: 80,gm/l
+      gt0012|Event time: 2019-02-22T18:39Z
+      gt0006|Calcium: 4,mg/dl
+      gt0013|Event time: 2019-02-22T18:39Z
+  expected_output:
+    1:
+      gt0008|Calcium_corrected: 0.80,mg/dl
+      gt0011|Event time: 2019-02-22T17:50:44.409Z[UTC]
+
+
+- id: albumin(high)-calcium(high)
+  input:
+    1:
+      gt0004|Albumin: 80,gm/l
+      gt0012|Event time: 2019-02-22T18:39Z
+      gt0006|Calcium: 15,mg/dl
+      gt0013|Event time: 2019-02-22T18:39Z
+  expected_output:
+    1:
+      gt0008|Calcium_corrected: 11.80,mg/dl
+      gt0011|Event time: 2019-02-22T17:50:27.839Z[UTC]
+


### PR DESCRIPTION
Dear Isabelle, this branch contains the migrated Calcium_corrected.v1 along with its test fixtures. It should be noted that the "current event time" output always fails in the test fixtures because it doesn't match with the current test system time. Kindly please check and review it. Thank you. 