### PR TITLE
ACR Calculation

### DIFF
--- a/gdl2/ACR_Calculation.v1.gdl2.json
+++ b/gdl2/ACR_Calculation.v1.gdl2.json
@@ -1,0 +1,211 @@
+{
+  "id": "ACR_Calculation.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2016-10-13",
+      "name": "Eneimi Allwell-Brown",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "other_contributors": [
+      "Jimmy Axelsson",
+      "Dennis Forslund"
+    ],
+    "lifecycle_state": "Author draft",
+    "details": {
+      "sv": {
+        "id": "sv",
+        "purpose": "Att beräkna urin-albumin/kreatinin-kvot.",
+        "keywords": [
+          "albuminuri",
+          "albumin",
+          "kronisk njursvikt",
+          "albumin/kreatinin-kvot",
+          "kreatinin"
+        ],
+        "use": "Använd för att beräkna urin-albumin/kreatinin-kvot (angiven i mg/g) från givna värden av u-albumin (angivet i mg/L) och kreatinin (angivet i mg/L). Kan även användas för att beräkna utsöndring av albumin via urinen, då värdet på denna motsvarar albumin/kreatinin-kvoten, men angivet i mg/dygn.\n\nFör att omvandla albumin/kreatinin-kvoten från mg/g till mg/mmol, dividera med 10.\n\nKan med fördel sammanvägas tillsammans med glomerulär filtrationshastighet (GFR) för gradering och utvärdering av progressionsrisk av kronisk njursvikt.",
+        "misuse": "",
+        "copyright": "© Cambio Healthcare Systems"
+      },
+      "en": {
+        "id": "en",
+        "purpose": "This guide calculates urinary albumin:creatinine ratio (ACR).",
+        "keywords": [
+          "albuminuria",
+          "albumin excretion rate",
+          "chronic kidney disease",
+          "CKD",
+          "albumin:creatinine ratio",
+          "ACR",
+          "KDIGO",
+          "CKD classification",
+          "AER"
+        ],
+        "use": "Use to calculate urinary albumin:creatinine ratio (measured in mg/g) from given values of urinary albumin (measured in mg/dl) and urinary creatinine (measured in mg/dl). Also for use to calculate albumin excretion rate (AER) which is approximately equal to the albumin:creatinine ratio, but with unit: mg/24hrs.\nTo obtain ACR in mg/mmol, divide ACR in mg/g by 10.\n\nFor use in concert with glomerular filtration rate (GFR) to stage and evaluate the risk of progression of chronic kidney disease (CKD).",
+        "misuse": "",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Eknoyan G, Lameire N, Eckardt KU, Kasiske BL, Wheeler DC, Levin A, Stevens PE, Bilous RW, Lamb EJ, Coresh J, Levey AS. KDIGO 2012 clinical practice guideline for the evaluation and management of chronic kidney disease. Kidney Int. 2013;3:5-14."
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0003": {
+        "id": "gt0003",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-microalbumin.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-microalbumin.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0004": {
+            "id": "gt0004",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.3]"
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.2]"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0006": {
+        "id": "gt0006",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-microalbumin.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-microalbumin.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0007": {
+            "id": "gt0007",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.1]"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "path": "/data/events/time"
+          }
+        }
+      }
+    },
+    "rules": {
+      "gt0002": {
+        "id": "gt0002",
+        "priority": 1,
+        "when": [
+          "$gt0005|Urine creatinine|.unit=='mg/dl'",
+          "$gt0004|Urine microalbumin|.unit=='mg/dl'"
+        ],
+        "then": [
+          "$gt0010|Event time|=$currentDateTime",
+          "$gt0007|Urine albumin:creatinine ratio|.precision=0",
+          "$gt0007|Urine albumin:creatinine ratio|.unit='mg/gm'",
+          "$gt0007|Urine albumin:creatinine ratio|.magnitude=($gt0004.magnitude/$gt0005.magnitude)*1000"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "sv": {
+        "id": "sv",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Beräkning av U-Albumin/kreatinin-kvot",
+            "description": "Beräknar urin-albumin/kreatinin-kvot (ACR). ACR är ett komplement till mikroalbuminuri och kan användas som screening för och monitorering av njursjukdom. Kan med fördel sammanvägas tillsammans med glomerulär filtrationshastighet (GFR) för gradering och utvärdering av progressionsrisk av kronisk njursvikt."
+          },
+          "gt0002": {
+            "id": "gt0002",
+            "text": "Beräkna U-albumin/kreatinin-kvot",
+            "description": "*(en) Contains the expression logic for calculating and categorizing ACR."
+          },
+          "gt0004": {
+            "id": "gt0004",
+            "text": "U-albumin",
+            "description": "*(en) Microalbumin level in this specimen."
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "U-kreatinin",
+            "description": "*(en) Creatinine level in this urine specimen."
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "U-albumin/kreatinin-kvot",
+            "description": "*(en) Ratio of albumin and creatinine in this specimen."
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      },
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "albumin/creatinine ratio (ACR) calculator",
+            "description": "Calculates urinary albumin:creatinine ratio (ACR). The ACR is a surrogate for microalbuminuria and can be used for screening and monitoring individuals with conditions such as diabetes and hypertension which put them at higher risk of developing kidney disease. ACR is typically used for staging and monitoring the progression of kidney disease."
+          },
+          "gt0002": {
+            "id": "gt0002",
+            "text": "Calculate urinary ACR",
+            "description": "Contains the expression logic for calculating and categorizing ACR."
+          },
+          "gt0004": {
+            "id": "gt0004",
+            "text": "Urine microalbumin",
+            "description": "Microalbumin level in this specimen."
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Urine creatinine",
+            "description": "Creatinine level in this urine specimen."
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Urine albumin:creatinine ratio",
+            "description": "Ratio of albumin and creatinine in this specimen."
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/ACR_Calculation.v1.gdl2.json
+++ b/gdl2/ACR_Calculation.v1.gdl2.json
@@ -71,8 +71,8 @@
             "id": "gt0005",
             "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.2]"
           },
-          "gt0011": {
-            "id": "gt0011",
+          "gt0010": {
+            "id": "gt0010",
             "path": "/data/events/time"
           }
         },
@@ -89,10 +89,6 @@
           "gt0007": {
             "id": "gt0007",
             "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.1]"
-          },
-          "gt0010": {
-            "id": "gt0010",
-            "path": "/data/events/time"
           }
         }
       }
@@ -106,7 +102,6 @@
           "$gt0004|Urine microalbumin|.unit=='mg/dl'"
         ],
         "then": [
-          "$gt0010|Event time|=$currentDateTime",
           "$gt0007|Urine albumin:creatinine ratio|.precision=0",
           "$gt0007|Urine albumin:creatinine ratio|.unit='mg/gm'",
           "$gt0007|Urine albumin:creatinine ratio|.magnitude=($gt0004.magnitude/$gt0005.magnitude)*1000"
@@ -153,11 +148,6 @@
             "id": "gt0010",
             "text": "*(en) Event time",
             "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
-          },
-          "gt0011": {
-            "id": "gt0011",
-            "text": "*(en) Event time",
-            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
           }
         }
       },
@@ -196,11 +186,6 @@
           },
           "gt0010": {
             "id": "gt0010",
-            "text": "Event time",
-            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
-          },
-          "gt0011": {
-            "id": "gt0011",
             "text": "Event time",
             "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
           }

--- a/gdl2/ACR_Calculation.v1.test.yml
+++ b/gdl2/ACR_Calculation.v1.test.yml
@@ -6,11 +6,10 @@ test_cases:
     1:
       gt0004|Urine microalbumin: 20,mg/dl
       gt0005|Urine creatinine: 50,mg/dl
-      gt0011|Event time: 2019-02-22T19:02Z
+      gt0010|Event time: 2019-02-22T19:02Z
   expected_output:
     1:
       gt0007|Urine albumin:creatinine ratio: 400,mg/gm
-      gt0010|Event time: 2019-02-22T18:07:21.231Z[UTC]
 
 
 - id: urine-microalbumin(normal)_creatinine(low)
@@ -18,11 +17,10 @@ test_cases:
     1:
       gt0004|Urine microalbumin: 20,mg/dl
       gt0005|Urine creatinine: 15,mg/dl
-      gt0011|Event time: 2019-02-22T19:02Z
+      gt0010|Event time: 2019-02-22T19:02Z
   expected_output:
     1:
       gt0007|Urine albumin:creatinine ratio: 1333,mg/gm
-      gt0010|Event time: 2019-02-22T18:11:21.473Z[UTC]
 
 
 - id: urine-microalbumin(normal)_creatinine(high)
@@ -30,11 +28,10 @@ test_cases:
     1:
       gt0004|Urine microalbumin: 20,mg/dl
       gt0005|Urine creatinine: 350,mg/dl
-      gt0011|Event time: 2019-02-22T19:02Z
+      gt0010|Event time: 2019-02-22T19:02Z
   expected_output:
     1:
       gt0007|Urine albumin:creatinine ratio: 57,mg/gm
-      gt0010|Event time: 2019-02-22T18:11:38.305Z[UTC]
 
 
 - id: urine-microalbumin(high)_creatinine(normal)
@@ -42,11 +39,10 @@ test_cases:
     1:
       gt0004|Urine microalbumin: 35,mg/dl
       gt0005|Urine creatinine: 50,mg/dl
-      gt0011|Event time: 2019-02-22T19:02Z
+      gt0010|Event time: 2019-02-22T19:02Z
   expected_output:
     1:
       gt0007|Urine albumin:creatinine ratio: 700,mg/gm
-      gt0010|Event time: 2019-02-22T18:08:44.626Z[UTC]
 
 
 - id: urine-microalbumin(high)_creatinine(low)
@@ -54,11 +50,10 @@ test_cases:
     1:
       gt0004|Urine microalbumin: 35,mg/dl
       gt0005|Urine creatinine: 20,mg/dl
-      gt0011|Event time: 2019-02-22T19:02Z
+      gt0010|Event time: 2019-02-22T19:02Z
   expected_output:
     1:
       gt0007|Urine albumin:creatinine ratio: 1750,mg/gm
-      gt0010|Event time: 2019-02-22T18:13:21.510Z[UTC]
 
 
 - id: urine-microalbumin(high)_creatinine(high)
@@ -66,10 +61,9 @@ test_cases:
     1:
       gt0004|Urine microalbumin: 35,mg/dl
       gt0005|Urine creatinine: 350,mg/dl
-      gt0011|Event time: 2019-02-22T19:02Z
+      gt0010|Event time: 2019-02-22T19:02Z
   expected_output:
     1:
       gt0007|Urine albumin:creatinine ratio: 100,mg/gm
-      gt0010|Event time: 2019-02-22T18:13:39.413Z[UTC]
 
 

--- a/gdl2/ACR_Calculation.v1.test.yml
+++ b/gdl2/ACR_Calculation.v1.test.yml
@@ -1,0 +1,75 @@
+guidelines:
+  1: ACR_Calculation.v1
+test_cases:
+- id: urine-microalbumin(normal)_creatinine(normal)
+  input:
+    1:
+      gt0004|Urine microalbumin: 20,mg/dl
+      gt0005|Urine creatinine: 50,mg/dl
+      gt0011|Event time: 2019-02-22T19:02Z
+  expected_output:
+    1:
+      gt0007|Urine albumin:creatinine ratio: 400,mg/gm
+      gt0010|Event time: 2019-02-22T18:07:21.231Z[UTC]
+
+
+- id: urine-microalbumin(normal)_creatinine(low)
+  input:
+    1:
+      gt0004|Urine microalbumin: 20,mg/dl
+      gt0005|Urine creatinine: 15,mg/dl
+      gt0011|Event time: 2019-02-22T19:02Z
+  expected_output:
+    1:
+      gt0007|Urine albumin:creatinine ratio: 1333,mg/gm
+      gt0010|Event time: 2019-02-22T18:11:21.473Z[UTC]
+
+
+- id: urine-microalbumin(normal)_creatinine(high)
+  input:
+    1:
+      gt0004|Urine microalbumin: 20,mg/dl
+      gt0005|Urine creatinine: 350,mg/dl
+      gt0011|Event time: 2019-02-22T19:02Z
+  expected_output:
+    1:
+      gt0007|Urine albumin:creatinine ratio: 57,mg/gm
+      gt0010|Event time: 2019-02-22T18:11:38.305Z[UTC]
+
+
+- id: urine-microalbumin(high)_creatinine(normal)
+  input:
+    1:
+      gt0004|Urine microalbumin: 35,mg/dl
+      gt0005|Urine creatinine: 50,mg/dl
+      gt0011|Event time: 2019-02-22T19:02Z
+  expected_output:
+    1:
+      gt0007|Urine albumin:creatinine ratio: 700,mg/gm
+      gt0010|Event time: 2019-02-22T18:08:44.626Z[UTC]
+
+
+- id: urine-microalbumin(high)_creatinine(low)
+  input:
+    1:
+      gt0004|Urine microalbumin: 35,mg/dl
+      gt0005|Urine creatinine: 20,mg/dl
+      gt0011|Event time: 2019-02-22T19:02Z
+  expected_output:
+    1:
+      gt0007|Urine albumin:creatinine ratio: 1750,mg/gm
+      gt0010|Event time: 2019-02-22T18:13:21.510Z[UTC]
+
+
+- id: urine-microalbumin(high)_creatinine(high)
+  input:
+    1:
+      gt0004|Urine microalbumin: 35,mg/dl
+      gt0005|Urine creatinine: 350,mg/dl
+      gt0011|Event time: 2019-02-22T19:02Z
+  expected_output:
+    1:
+      gt0007|Urine albumin:creatinine ratio: 100,mg/gm
+      gt0010|Event time: 2019-02-22T18:13:39.413Z[UTC]
+
+


### PR DESCRIPTION
Dear Isabelle, this branch contains the migrated ACR_Calculation.v1 along with its test fixtures. I managed to solve the output event time by setting an event time element within the output archetype (instead of using a different archetype like in the previous version). I learned of this setting from the Corrected_calcium app. This setting does not affect the calculation. However, the test fixtures will always fail the output event time due to the current test system time. Kindly please check and review it. Thank you. 