### PR TITLE
FLIPI and FLIPI assessment migrated

### DIFF
--- a/gdl2/FLIPI.v1.gdl2.json
+++ b/gdl2/FLIPI.v1.gdl2.json
@@ -1,0 +1,372 @@
+{
+  "id": "FLIPI.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2017-11-19",
+      "name": "Syeeda S Farruque",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "lifecycle_state": "Author draft",
+    "details": {
+      "en": {
+        "id": "en",
+        "purpose": "Follicular Lymphoma International Prognostic Index (FLIPI) provides an overall estimate of survival among follicular lymphoma patients based on clinical information such as clinical evaluation, laboratory testing, and imaging. ",
+        "keywords": [
+          "Follicular Lymphoma International Prognostic Index (FLIPI)"
+        ],
+        "use": "Risk stratification of patients with follicular lymphoma is based on clinical information such as clinical evaluation, laboratory testing, and imaging. \r\n\r\n\r\nScore Interpetation\r\n\r\nScore \tRisk Group \t10-year Overall Survival\r\n≤1 \tLow \t                   70%\r\n2 \tIntermediate \t50%\r\n≥3 \tHigh \t                   35%",
+        "misuse": "Do not use the score on its own for diagnostic purposes without supporting evidence",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Ref. 1: Solal-Celigny et al. Follicular Lymphoma International Prognostic Index. Blood 104:1258-1265. (2004)"
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0002": {
+        "id": "gt0002",
+        "model_id": "openEHR-EHR-OBSERVATION.follicular_lymphoma_international_prognostic_index.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.follicular_lymphoma_international_prognostic_index.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0003": {
+            "id": "gt0003",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0005]"
+          },
+          "gt0004": {
+            "id": "gt0004",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0006]"
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0008]"
+          },
+          "gt0031": {
+            "id": "gt0031",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0006": {
+        "id": "gt0006",
+        "model_id": "openEHR-EHR-OBSERVATION.follicular_lymphoma_international_prognostic_index.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.follicular_lymphoma_international_prognostic_index.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0007": {
+            "id": "gt0007",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0004]"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0005]"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0006]"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0007]"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0008]"
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0019]"
+          }
+        }
+      },
+      "gt0013": {
+        "id": "gt0013",
+        "model_id": "openEHR-EHR-OBSERVATION.basic_demographic.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.basic_demographic.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0014": {
+            "id": "gt0014",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0008]"
+          },
+          "gt0032": {
+            "id": "gt0032",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0015": {
+        "id": "gt0015",
+        "model_id": "openEHR-EHR-OBSERVATION.basic_demographic.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.basic_demographic.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0016": {
+            "id": "gt0016",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0013]"
+          }
+        }
+      },
+      "gt0017": {
+        "id": "gt0017",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-full_blood_count.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-full_blood_count.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0018": {
+            "id": "gt0018",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.4]"
+          },
+          "gt0033": {
+            "id": "gt0033",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      }
+    },
+    "rules": {
+      "gt0019": {
+        "id": "gt0019",
+        "priority": 9,
+        "when": [
+          "$gt0014|Birthdate|!=null"
+        ],
+        "then": [
+          "$gt0016|Age|.unit='a'",
+          "$gt0016|Age|.magnitude=$currentDateTime.year-$gt0014.year"
+        ]
+      },
+      "gt0022": {
+        "id": "gt0022",
+        "priority": 8,
+        "when": [
+          "$gt0016|Age|<=60,a"
+        ],
+        "then": [
+          "$gt0007|Age > 60 years|=0|local::at0013|No|"
+        ]
+      },
+      "gt0023": {
+        "id": "gt0023",
+        "priority": 7,
+        "when": [
+          "$gt0016|Age|>60,a"
+        ],
+        "then": [
+          "$gt0007|Age > 60 years|=1|local::at0014|Yes|"
+        ]
+      },
+      "gt0020": {
+        "id": "gt0020",
+        "priority": 6,
+        "when": [
+          "$gt0018|Haemoglobin|>=120,gm/l"
+        ],
+        "then": [
+          "$gt0010|Hemoglobin <120 g/L or 12 g/dL|=0|local::at0011|No|"
+        ]
+      },
+      "gt0021": {
+        "id": "gt0021",
+        "priority": 5,
+        "when": [
+          "$gt0018|Haemoglobin|<120,gm/l"
+        ],
+        "then": [
+          "$gt0010|Hemoglobin <120 g/L or 12 g/dL|=1|local::at0012|Yes|"
+        ]
+      },
+      "gt0024": {
+        "id": "gt0024",
+        "priority": 4,
+        "when": [
+          "$gt0003|>4 nodal sites|!=null"
+        ],
+        "then": [
+          "$gt0008|>4 nodal sites|=$gt0003|>4 nodal sites|"
+        ]
+      },
+      "gt0026": {
+        "id": "gt0026",
+        "priority": 3,
+        "when": [
+          "$gt0004|LDH elevated|!=null"
+        ],
+        "then": [
+          "$gt0009|LDH elevated|=$gt0004|LDH elevated|"
+        ]
+      },
+      "gt0028": {
+        "id": "gt0028",
+        "priority": 2,
+        "when": [
+          "$gt0005|Stage III-IV|!=null"
+        ],
+        "then": [
+          "$gt0011|Stage III-IV|=$gt0005|Stage III-IV|"
+        ]
+      },
+      "gt0030": {
+        "id": "gt0030",
+        "priority": 1,
+        "then": [
+          "$gt0012|Total score|.magnitude=((($gt0010.value+$gt0011.value)+$gt0007.value)+$gt0008.value)+$gt0009.value"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Follicular Lymphoma International Prognostic Index (FLIPI)",
+            "description": "Follicular Lymphoma International Prognostic Index (FLIPI) provides an overall estimate of survival among lymphoma patients based on clinical information."
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": ">4 nodal sites",
+            "description": "See ref 1 for more information on nodal sites"
+          },
+          "gt0004": {
+            "id": "gt0004",
+            "text": "LDH elevated",
+            "description": "LDH elevated"
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Stage III-IV",
+            "description": "Stage III: disease involves both sides of the diaphragm, including one organ or area near the lymph nodes or the spleen.\r\nStage IV: diffuse or disseminated involvement of one or more extranodal organs, with or without associated lymph node involvement."
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Age > 60 years",
+            "description": "Age > 60 years"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": ">4 nodal sites",
+            "description": "See ref 1 for more information on nodal sites"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "LDH elevated",
+            "description": "LDH elevated"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Hemoglobin <120 g/L or 12 g/dL",
+            "description": "Hemoglobin <120 g/L or 12 g/dL"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Stage III-IV",
+            "description": "Stage III: disease involves both sides of the diaphragm, including one organ or area near the lymph nodes or the spleen.\r\nStage IV: diffuse or disseminated involvement of one or more extranodal organs, with or without associated lymph node involvement."
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "Total score",
+            "description": "Sum of the individual scores"
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "Birthdate",
+            "description": "The patient's date of birth."
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "Age",
+            "description": "Age in years, and for babies: months, weeks or days"
+          },
+          "gt0018": {
+            "id": "gt0018",
+            "text": "Haemoglobin",
+            "description": "The mass concentration of haemoglobin"
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "text": "Calculate age"
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "Set Haemoglobin - No"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "text": "Set Haemoglobin - Yes"
+          },
+          "gt0022": {
+            "id": "gt0022",
+            "text": "Set Age - No"
+          },
+          "gt0023": {
+            "id": "gt0023",
+            "text": "Set Age - Yes"
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "text": "Set > 4 nodal sites"
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "text": "Set > 4 nodal sites - Yes"
+          },
+          "gt0026": {
+            "id": "gt0026",
+            "text": "Set LDH elevated "
+          },
+          "gt0027": {
+            "id": "gt0027",
+            "text": "Set LDH elevated - Yes"
+          },
+          "gt0028": {
+            "id": "gt0028",
+            "text": "Set Stage III-IV"
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "text": "Set Stage III-IV - Yes"
+          },
+          "gt0030": {
+            "id": "gt0030",
+            "text": "Calculate Total Score"
+          },
+          "gt0031": {
+            "id": "gt0031",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0032": {
+            "id": "gt0032",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0033": {
+            "id": "gt0033",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/FLIPI.v1.test.yml
+++ b/gdl2/FLIPI.v1.test.yml
@@ -1,0 +1,144 @@
+guidelines:
+  1: FLIPI.v1
+test_cases:
+- id: All no
+  input:
+    1:
+      gt0003|>4 nodal sites: 0|local::at0015|No|
+      gt0004|LDH elevated: 0|local::at0017|No|
+      gt0005|Stage III-IV: 0|local::at0009|No|
+      gt0031|Event time: 2019-02-21T10:04Z
+      gt0014|Birthdate: 1959-04-09T10:02Z
+      gt0032|Event time: 2019-02-23T10:03Z
+      gt0018|Haemoglobin: 100,gm/l
+      gt0033|Event time: 2019-02-22T10:03Z
+  expected_output:
+    1:
+      gt0011|Stage III-IV: 0|local::at0009|No|
+      gt0007|Age > 60 years: 0|local::at0013|No|
+      gt0009|LDH elevated: 0|local::at0017|No|
+      gt0008|>4 nodal sites: 0|local::at0015|No|
+      gt0010|Hemoglobin <120 g/L or 12 g/dL: 1|local::at0012|Yes|
+      gt0012|Total score: 1
+      gt0016|Age: 60,a
+- id: 4+ nodal sites
+  input:
+    1:
+      gt0003|>4 nodal sites: 1|local::at0016|Yes|
+      gt0004|LDH elevated: 0|local::at0017|No|
+      gt0005|Stage III-IV: 0|local::at0009|No|
+      gt0031|Event time: 2019-02-21T10:04Z
+      gt0014|Birthdate: 1959-04-09T10:02Z
+      gt0032|Event time: 2019-02-23T10:03Z
+      gt0018|Haemoglobin: 100,gm/l
+      gt0033|Event time: 2019-02-22T10:03Z
+  expected_output:
+    1:
+      gt0011|Stage III-IV: 0|local::at0009|No|
+      gt0007|Age > 60 years: 0|local::at0013|No|
+      gt0009|LDH elevated: 0|local::at0017|No|
+      gt0008|>4 nodal sites: 1|local::at0016|Yes|
+      gt0010|Hemoglobin <120 g/L or 12 g/dL: 1|local::at0012|Yes|
+      gt0012|Total score: 2
+      gt0016|Age: 60,a
+- id: LDH elevated
+  input:
+    1:
+      gt0003|>4 nodal sites: 1|local::at0016|Yes|
+      gt0004|LDH elevated: 1|local::at0018|Yes|
+      gt0005|Stage III-IV: 0|local::at0009|No|
+      gt0031|Event time: 2019-02-21T10:04Z
+      gt0014|Birthdate: 1959-04-09T10:02Z
+      gt0032|Event time: 2019-02-23T10:03Z
+      gt0018|Haemoglobin: 100,gm/l
+      gt0033|Event time: 2019-02-22T10:03Z
+  expected_output:
+    1:
+      gt0011|Stage III-IV: 0|local::at0009|No|
+      gt0007|Age > 60 years: 0|local::at0013|No|
+      gt0009|LDH elevated: 1|local::at0018|Yes|
+      gt0008|>4 nodal sites: 1|local::at0016|Yes|
+      gt0010|Hemoglobin <120 g/L or 12 g/dL: 1|local::at0012|Yes|
+      gt0012|Total score: 3
+      gt0016|Age: 60,a
+- id: Stage 3-4
+  input:
+    1:
+      gt0003|>4 nodal sites: 1|local::at0016|Yes|
+      gt0004|LDH elevated: 1|local::at0018|Yes|
+      gt0005|Stage III-IV: 1|local::at0010|Yes|
+      gt0031|Event time: 2019-02-21T10:04Z
+      gt0014|Birthdate: 1959-04-09T10:02Z
+      gt0032|Event time: 2019-02-23T10:03Z
+      gt0018|Haemoglobin: 100,gm/l
+      gt0033|Event time: 2019-02-22T10:03Z
+  expected_output:
+    1:
+      gt0011|Stage III-IV: 1|local::at0010|Yes|
+      gt0007|Age > 60 years: 0|local::at0013|No|
+      gt0009|LDH elevated: 1|local::at0018|Yes|
+      gt0008|>4 nodal sites: 1|local::at0016|Yes|
+      gt0010|Hemoglobin <120 g/L or 12 g/dL: 1|local::at0012|Yes|
+      gt0012|Total score: 4
+      gt0016|Age: 60,a
+
+- id: Age over 60
+  input:
+    1:
+      gt0003|>4 nodal sites: 1|local::at0016|Yes|
+      gt0004|LDH elevated: 1|local::at0018|Yes|
+      gt0005|Stage III-IV: 1|local::at0010|Yes|
+      gt0031|Event time: 2019-02-21T10:04Z
+      gt0014|Birthdate: 1958-04-09T10:02Z
+      gt0032|Event time: 2019-02-23T10:03Z
+      gt0018|Haemoglobin: 100,gm/l
+      gt0033|Event time: 2019-02-22T10:03Z
+  expected_output:
+    1:
+      gt0011|Stage III-IV: 1|local::at0010|Yes|
+      gt0007|Age > 60 years: 1|local::at0014|Yes|
+      gt0009|LDH elevated: 1|local::at0018|Yes|
+      gt0008|>4 nodal sites: 1|local::at0016|Yes|
+      gt0010|Hemoglobin <120 g/L or 12 g/dL: 1|local::at0012|Yes|
+      gt0012|Total score: 5
+      gt0016|Age: 61,a
+- id: Age close to 60 case 1
+  input:
+    1:
+      gt0003|>4 nodal sites: 1|local::at0016|Yes|
+      gt0004|LDH elevated: 1|local::at0018|Yes|
+      gt0005|Stage III-IV: 1|local::at0010|Yes|
+      gt0031|Event time: 2019-02-21T10:04Z
+      gt0014|Birthdate: 1958-12-31T10:02Z
+      gt0032|Event time: 2019-02-23T10:03Z
+      gt0018|Haemoglobin: 100,gm/l
+      gt0033|Event time: 2019-02-22T10:03Z
+  expected_output:
+    1:
+      gt0011|Stage III-IV: 1|local::at0010|Yes|
+      gt0007|Age > 60 years: 1|local::at0014|Yes|
+      gt0009|LDH elevated: 1|local::at0018|Yes|
+      gt0008|>4 nodal sites: 1|local::at0016|Yes|
+      gt0010|Hemoglobin <120 g/L or 12 g/dL: 1|local::at0012|Yes|
+      gt0012|Total score: 5
+      gt0016|Age: 61,a
+- id: Age close to 60 case 2
+  input:
+    1:
+      gt0003|>4 nodal sites: 1|local::at0016|Yes|
+      gt0004|LDH elevated: 1|local::at0018|Yes|
+      gt0005|Stage III-IV: 1|local::at0010|Yes|
+      gt0031|Event time: 2019-02-21T10:04Z
+      gt0014|Birthdate: 1959-01-01T10:02Z
+      gt0032|Event time: 2019-02-23T10:03Z
+      gt0018|Haemoglobin: 100,gm/l
+      gt0033|Event time: 2019-02-22T10:03Z
+  expected_output:
+    1:
+      gt0011|Stage III-IV: 1|local::at0010|Yes|
+      gt0007|Age > 60 years: 0|local::at0013|No|
+      gt0009|LDH elevated: 1|local::at0018|Yes|
+      gt0008|>4 nodal sites: 1|local::at0016|Yes|
+      gt0010|Hemoglobin <120 g/L or 12 g/dL: 1|local::at0012|Yes|
+      gt0012|Total score: 4
+      gt0016|Age: 60,a

--- a/gdl2/FLIPI_Assessment.v1.gdl2.json
+++ b/gdl2/FLIPI_Assessment.v1.gdl2.json
@@ -1,0 +1,149 @@
+{
+  "id": "FLIPI_Assessment.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2017-11-25",
+      "name": "Syeeda S Farruque",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "lifecycle_state": "Author draft",
+    "details": {
+      "en": {
+        "id": "en",
+        "purpose": "Follicular Lymphoma International Prognostic Index (FLIPI) provides an overall estimate of survival among follicular lymphoma patients based on clinical information such as clinical evaluation, laboratory testing, and imaging. ",
+        "keywords": [
+          "Follicular Lymphoma International Prognostic Index (FLIPI)"
+        ],
+        "use": "Score Interpetation\r\n\r\nScore \tRisk Group \t10-year Overall Survival\r\n≤1 \tLow \t                   70%\r\n2 \tIntermediate \t50%\r\n≥3 \tHigh \t                   35%",
+        "misuse": "Do not use the score on its own for diagnostic purposes without supporting evidence",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Ref. 1: Solal-Celigny et al. Follicular Lymphoma International Prognostic Index. Blood 104:1258-1265. (2004)"
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0002": {
+        "id": "gt0002",
+        "model_id": "openEHR-EHR-EVALUATION.follicular_lymphoma_index_assessment.v1",
+        "template_id": "openEHR-EHR-EVALUATION.follicular_lymphoma_index_assessment.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0007": {
+            "id": "gt0007",
+            "path": "/data[at0001]/items[at0002]"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "path": "/data[at0001]/items[at0005]"
+          }
+        }
+      },
+      "gt0003": {
+        "id": "gt0003",
+        "model_id": "openEHR-EHR-OBSERVATION.follicular_lymphoma_international_prognostic_index.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.follicular_lymphoma_international_prognostic_index.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0006": {
+            "id": "gt0006",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0019]"
+          }
+        }
+      }
+    },
+    "rules": {
+      "gt0010": {
+        "id": "gt0010",
+        "priority": 3,
+        "when": [
+          "$gt0006|Total score|<=1"
+        ],
+        "then": [
+          "$gt0007|Risk Group|=0|local::at0003|Low|",
+          "$gt0008|10 Year Overall Survival|=0|local::at0007|70%|"
+        ]
+      },
+      "gt0011": {
+        "id": "gt0011",
+        "priority": 2,
+        "when": [
+          "$gt0006|Total score|==2"
+        ],
+        "then": [
+          "$gt0007|Risk Group|=1|local::at0004|Intermediate|",
+          "$gt0008|10 Year Overall Survival|=1|local::at0008|50%|"
+        ]
+      },
+      "gt0012": {
+        "id": "gt0012",
+        "priority": 1,
+        "when": [
+          "$gt0006|Total score|>=3"
+        ],
+        "then": [
+          "$gt0007|Risk Group|=2|local::at0006|High|",
+          "$gt0008|10 Year Overall Survival|=2|local::at0009|35%|"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Follicular Lymphoma Index Assessment",
+            "description": "Follicular Lymphoma International Prognostic Index (FLIPI) provides an overall estimate of survival among lymphoma patients based on clinical information."
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Total score",
+            "description": "Sum of the individual scores"
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Total score",
+            "description": "Sum of the individual scores"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Risk Group",
+            "description": "Risk group"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "10 Year Overall Survival",
+            "description": "10-year Overall Survival"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "score"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Set Low risk"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Set Intermediate risk"
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "Set High risk"
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/FLIPI_Assessment.v1.test.yml
+++ b/gdl2/FLIPI_Assessment.v1.test.yml
@@ -1,0 +1,44 @@
+guidelines:
+  1: FLIPI_Assessment.v1
+test_cases:
+- id: score 1
+  input:
+    1:
+      gt0006|Total score: 1
+  expected_output:
+    1:
+      gt0007|Risk Group: 0|local::at0003|Low|
+      gt0008|10 Year Overall Survival: 0|local::at0007|70%|
+- id: score 0
+  input:
+    1:
+      gt0006|Total score: 0
+  expected_output:
+    1:
+      gt0007|Risk Group: 0|local::at0003|Low|
+      gt0008|10 Year Overall Survival: 0|local::at0007|70%|
+- id: score 3
+  input:
+    1:
+      gt0006|Total score: 3
+  expected_output:
+    1:
+      gt0007|Risk Group: 2|local::at0006|High|
+      gt0008|10 Year Overall Survival: 2|local::at0009|35%|
+- id: score 4
+  input:
+    1:
+      gt0006|Total score: 4
+  expected_output:
+    1:
+      gt0007|Risk Group: 2|local::at0006|High|
+      gt0008|10 Year Overall Survival: 2|local::at0009|35%|	  
+
+- id: score 2
+  input:
+    1:
+      gt0006|Total score: 2
+  expected_output:
+    1:
+      gt0007|Risk Group: 1|local::at0004|Intermediate|
+      gt0008|10 Year Overall Survival: 1|local::at0008|50%|	  


### PR DESCRIPTION
-FLIPI:
-- timeEvents handling updated
-- bug/feature: age > 60 is calculated from substracting birthday year from current year. It may not be very important though.
-FLIPI:
--unable to execute score 2 case as the corresponding rule don't fire because of "==" sign. In the test however, it works.