### PR TITLE
Fractional excretion guidelines migrated

### DIFF
--- a/gdl2/Fractional_sodium_excretion_Assessment.v1.gdl2.json
+++ b/gdl2/Fractional_sodium_excretion_Assessment.v1.gdl2.json
@@ -1,0 +1,183 @@
+{
+  "id": "Fractional_sodium_excretion_Assessment.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2017-01-13",
+      "name": "Eneimi Allwell-Brown",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "other_contributors": [
+      "Dennis Forslund",
+      "Jimmy Axelsson"
+    ],
+    "lifecycle_state": "Author draft",
+    "details": {
+      "sv": {
+        "id": "sv",
+        "purpose": "Utvärdering av beräknat värde för natriumutsöndring (FENa), vilket är den andel natrium filtrerad i njurarna som utsöndras med urinen, och därigenom differentiera mellan prerenal, renal och postrenal orsak till akut njursvikt. ",
+        "keywords": [
+          "akut njursvikt",
+          "njursvikt",
+          "azotemi",
+          "FENa",
+          "nefrologi"
+        ],
+        "use": "Använd för värdering av beräknat värde för natriumutsöndring (FENa), vilket är den andel natrium filtrerad i njurarna som utsöndras med urinen, och därigenom differentiera mellan prerenal, renal och postrenal orsak till akut njursvikt. \n\nEn patient med akut azotemi och:\nFENa < 1% och U-Na < 20mmol/L indikerar prerenal etiologi; \nFENa > 1% och U-Na > 40mmol/L indikerar renal etiologi; \nFENa > 4% och uNa > 40mmol/L indikerar postrenal etiologi.\n\nFENa-värdet registreras med hjälp av separat arketyp: openEHR-EHR-OBSERVATION.lab_test-fractional_sodium_excretion.v1\n",
+        "misuse": "FENa är endast tillämpbar på fall av akut njursvikt, ej kronisk. Dess kliniska värde är begränsat i de fall patienten behandlas med diuretika; i dessa fall bör istället beräkning av urea-utsöndring (FEUrea) användas.\n",
+        "copyright": "© Cambio Healthcare Systems"
+      },
+      "en": {
+        "id": "en",
+        "purpose": "To determine whether renal failure/acute kidney injury is due to pre-renal, intrinsic renal or post-renal pathology. ",
+        "keywords": [
+          "acute kidney injury",
+          "renal failure",
+          "AKI",
+          "acute azotemia",
+          "FEUrea"
+        ],
+        "use": "To assess FENa and determine if renal failure/kidney injury is due to prerenal (FENa < 1%), intrinsic renal (FENa > 1%) or postrenal (FENa > 4%) etiology.\r A patient with acute azotemia and:\nFENa < 1% and uNa < 20mmol/L suggests kidney injury of prerenal etiology; \nFENa > 1% and uNa > 40mmol/L suggests an intrinsic renal etiology; \nFENa > 4% and uNa > 40mmol/L suggests a postrenal etiology.\n\nFENa < 1% may also represent normal renal function with moderate salt intake, or may be due to specific intrinsic renal, postrenal causes, or even non-renal causes. Etiology of AKI should therefore be based upon the totality of the presentation (history, clinical examination, urine microscopy, and, when appropriate, response to volume resuscitation), not just on the FENa. FEN is calculated by a separate application: Fractional_sodium_excretion_Calculation.v1.\n",
+        "misuse": "FENa is only useful in acute renal failure, not chronic renal failure.\r\nFENa is less useful in patients on diuretics, and fractional excretion of urea (FEUrea) should be used instead.",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Steiner RW. Interpreting the fractional excretion of sodium. The American journal of medicine. 1984 Oct 31;77(4):699-702."
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0002": {
+        "id": "gt0002",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-fractional_sodium_excretion.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-fractional_sodium_excretion.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0003": {
+            "id": "gt0003",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.1.1]"
+          }
+        }
+      },
+      "gt0005": {
+        "id": "gt0005",
+        "model_id": "openEHR-EHR-EVALUATION.fractional_sodium_excretion.v1",
+        "template_id": "openEHR-EHR-EVALUATION.fractional_sodium_excretion.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0006": {
+            "id": "gt0006",
+            "path": "/data[at0001]/items[at0002]"
+          }
+        }
+      }
+    },
+    "rules": {
+      "gt0007": {
+        "id": "gt0007",
+        "priority": 3,
+        "when": [
+          "$gt0003|Fractional excretion of sodium (FENa)|<1,%"
+        ],
+        "then": [
+          "$gt0006|Cause of ARF|=local::at0003|Prerenal etiology|"
+        ]
+      },
+      "gt0008": {
+        "id": "gt0008",
+        "priority": 2,
+        "when": [
+          "$gt0003|Fractional excretion of sodium (FENa)|<4,%",
+          "$gt0003|Fractional excretion of sodium (FENa)|>1,%"
+        ],
+        "then": [
+          "$gt0006|Cause of ARF|=local::at0004|Intrinsic renal etiology|"
+        ]
+      },
+      "gt0009": {
+        "id": "gt0009",
+        "priority": 1,
+        "when": [
+          "$gt0003|Fractional excretion of sodium (FENa)|>4,%"
+        ],
+        "then": [
+          "$gt0006|Cause of ARF|=local::at0005|Postrenal etiology|"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "sv": {
+        "id": "sv",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Fractional Excretion of Sodium (FENa) utvärdering",
+            "description": "Utvärdering av beräknat värde för natriumutsöndring (FENa) vilket är den andel natrium filtrerad i njurarna som utsöndras med urinen. FENa kan användas för att differentiera mellan prerenal, renal och postrenal orsak till akut njursvikt. För beräkningen krävs kända värden av koncentration natrium och kreatinin i serum och urin. FENa <1% och U-Na <20mmol/l indikerar prerenal, FENa >1% och U-Na >40mmol/l renal, och FENa >4% och U-Na >40mmol/l postrenal etiologi."
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "Fractional excretion of sodium (FENa)",
+            "description": "*(en) Percentage of filtered sodium that is excreted in the urine."
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Etiologi",
+            "description": "*(en) *"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "CDS prerenal etiologi"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "CDS renal etiologi"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "CDS postrenal etiologi"
+          }
+        }
+      },
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Fractional Excretion of Sodium (FENa) Assessment",
+            "description": "Calculates the fractional excretion of sodium (FENa) which is the percentage of the sodium filtered by the kidney which is excreted in the urine. FENa helps distinguish between prerenal, intrinsic renal and postrenal causes of renal failure, and is widely used to differentiate prerenal disease (decreased renal perfusion) from acute tubular necrosis (ATN) as the cause of acute kidney injury (AKI). The calculation requires serum (sNa) and urine (uNa) sodium concentrations (mmol/L), and serum (sCr) and urine (uCr) creatinine concentrations (umol/L or mg/dl). A patient with acute azotemia and: FENa < 1% and uNa < 20mmol/L suggests kidney injury of prerenal etiology; FENa > 1% and uNa > 40mmol/L suggests an intrinsic renal etiology; while FENa > 4% and uNa > 40mmol/L suggests a postrenal etiology."
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "Fractional excretion of sodium (FENa)",
+            "description": "Percentage of filtered sodium that is excreted in the urine."
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Cause of ARF",
+            "description": "*"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Set prerenal ARF"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Set intrensic renal ARF"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Set postrenal ARF"
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/Fractional_sodium_excretion_Assessment.v1.test.yml
+++ b/gdl2/Fractional_sodium_excretion_Assessment.v1.test.yml
@@ -1,0 +1,24 @@
+guidelines:
+  1: Fractional_sodium_excretion_Assessment.v1
+test_cases:
+- id: below 1 %
+  input:
+    1:
+      gt0003|Fractional excretion of sodium (FENa): 0.2,%
+  expected_output:
+    1:
+      gt0006|Cause of ARF: local::at0003|Prerenal etiology|
+- id: between 1 and 4%
+  input:
+    1:
+      gt0003|Fractional excretion of sodium (FENa): 2,%
+  expected_output:
+    1:
+      gt0006|Cause of ARF: local::at0004|Intrinsic renal etiology|
+- id: above 4%
+  input:
+    1:
+      gt0003|Fractional excretion of sodium (FENa): 5,%
+  expected_output:
+    1:
+      gt0006|Cause of ARF: local::at0005|Postrenal etiology|

--- a/gdl2/Fractional_sodium_excretion_Calculation.v1.gdl2.json
+++ b/gdl2/Fractional_sodium_excretion_Calculation.v1.gdl2.json
@@ -1,0 +1,385 @@
+{
+  "id": "Fractional_sodium_excretion_Calculation.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2017-01-13",
+      "name": "Eneimi Allwell-Brown",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "other_contributors": [
+      "Dennis Forslund",
+      "Jimmy Axelsson"
+    ],
+    "lifecycle_state": "Author draft",
+    "details": {
+      "sv": {
+        "id": "sv",
+        "purpose": "Att avgöra andel natrium som utsöndras i urinen jämfört med total mängd som filtreras via njurarna, och därigenom underlätta differentiering mellan prerenal, renal och postrenal etiologi till njursvikt.",
+        "keywords": [
+          "akut njursvikt",
+          "njursvikt",
+          "azotemi",
+          "FENa"
+        ],
+        "use": "Använd för att beräkna FENa (%) med hjälp av givna värden för natrium och kreatinin uppmätt i serum och urin, och därigenom avgöra huruvida njursvikten har prerenal (FENa <1%), renal (FENa >1%) eller postrenal (FENa >4%) etiologi.\r\nFENa <1% kan även tolkas som normal njurfunktion med lågt till måttligt saltintag, alternativt är beroende av specifik renal, postrenal eller annan orsak. FENa är endast avsedd för understödja klinisk bedömning.",
+        "misuse": "FENa är endast tillämpbar på fall av akut njursvikt, ej kronisk. Dess kliniska värde är begränsat i de fall patienten behandlas med diuretika; i dessa fall bör istället beräkning av urea-utsöndring (FEUrea) användas.",
+        "copyright": "© Cambio Healthcare Systems"
+      },
+      "en": {
+        "id": "en",
+        "purpose": "To determine the proportion of sodium excreted in the urine compared with the total amount of sodium filtered by the kidneys, and help differentiate between pre-renal, intrinsic renal and post-renal causes of renal failure and acute kidney injury.",
+        "keywords": [
+          "acute kidney injury",
+          "renal failure",
+          "AKI",
+          "acute azotemia",
+          "FENa"
+        ],
+        "use": "To calculate FENa (%) from given values of sodium (mmol/L) and creatinine (umol/L or mg/dl) detected in serum and urine samples. To determine if renal failure/kidney injury is due to prerenal (FENa < 1%), intrinsic renal (FENa > 1%) or postrenal (FENa > 4%) etiology.\r\nFENa < 1% may also represent normal renal function with moderate salt intake, or may be due to specific intrinsic renal, postrenal causes, or even non-renal causes. Etiology of AKI should therefore be based upon the totality of the presentation (history, clinical examination, urine microscopy, and, when appropriate, response to volume resuscitation), not just on the FENa.",
+        "misuse": "FENa is only useful in acute renal failure, not chronic renal failure.\r\nFENa is less useful in patients on diuretics, and fractional excretion of urea (FEUrea) should be used instead.",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Steiner RW. Interpreting the fractional excretion of sodium. The American journal of medicine. 1984 Oct 31;77(4):699-702."
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0002": {
+        "id": "gt0002",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-fractional_sodium_excretion.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-fractional_sodium_excretion.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0003": {
+            "id": "gt0003",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.5.1]"
+          },
+          "gt0004": {
+            "id": "gt0004",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.4.1]"
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.3.1]"
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.2.1]"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0007": {
+        "id": "gt0007",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-fractional_sodium_excretion.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-fractional_sodium_excretion.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0008": {
+            "id": "gt0008",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.5.1]"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.4.1]"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.3.1]"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.2.1]"
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.1.1]"
+          }
+        }
+      }
+    },
+    "rules": {
+      "gt0014": {
+        "id": "gt0014",
+        "priority": 7,
+        "when": [
+          "$gt0003|serum Sodium (sNa)|!=null"
+        ],
+        "then": [
+          "$gt0008|serum Sodium (sNa)|=$gt0003|serum Sodium (sNa)|"
+        ]
+      },
+      "gt0015": {
+        "id": "gt0015",
+        "priority": 6,
+        "when": [
+          "$gt0004|urine Sodium (uNa)|!=null"
+        ],
+        "then": [
+          "$gt0009|urine Sodium (uNa)|=$gt0004|urine Sodium (uNa)|"
+        ]
+      },
+      "gt0016": {
+        "id": "gt0016",
+        "priority": 5,
+        "when": [
+          "$gt0005|serum Creatinine (sCr)|.unit=='umol/l'",
+          "$gt0005|serum Creatinine (sCr)|!=null"
+        ],
+        "then": [
+          "$gt0010|serum Creatinine (sCr)|.unit='umol/l'",
+          "$gt0010|serum Creatinine (sCr)|.precision=2",
+          "$gt0010|serum Creatinine (sCr)|=$gt0005|serum Creatinine (sCr)|"
+        ]
+      },
+      "gt0017": {
+        "id": "gt0017",
+        "priority": 4,
+        "when": [
+          "$gt0005|serum Creatinine (sCr)|.unit=='mg/dl'",
+          "$gt0005|serum Creatinine (sCr)|!=null"
+        ],
+        "then": [
+          "$gt0010|serum Creatinine (sCr)|.unit='umol/l'",
+          "$gt0010|serum Creatinine (sCr)|.precision=2",
+          "$gt0010|serum Creatinine (sCr)|.magnitude=$gt0005.magnitude*88.42"
+        ]
+      },
+      "gt0018": {
+        "id": "gt0018",
+        "priority": 3,
+        "when": [
+          "$gt0006|urine Creatinine (uCr)|.unit=='umol/l'",
+          "$gt0006|urine Creatinine (uCr)|!=null"
+        ],
+        "then": [
+          "$gt0011|urine Creatinine (uCr)|.precision=2",
+          "$gt0011|urine Creatinine (uCr)|.unit='umol/l'",
+          "$gt0011|urine Creatinine (uCr)|=$gt0006|urine Creatinine (uCr)|"
+        ]
+      },
+      "gt0019": {
+        "id": "gt0019",
+        "priority": 2,
+        "when": [
+          "$gt0006|urine Creatinine (uCr)|.unit=='mg/dl'",
+          "$gt0006|urine Creatinine (uCr)|!=null"
+        ],
+        "then": [
+          "$gt0011|urine Creatinine (uCr)|.unit='umol/l'",
+          "$gt0011|urine Creatinine (uCr)|.precision=2",
+          "$gt0011|urine Creatinine (uCr)|.magnitude=$gt0006.magnitude*88.42"
+        ]
+      },
+      "gt0020": {
+        "id": "gt0020",
+        "priority": 1,
+        "when": [
+          "$gt0009|urine Sodium (uNa)|>0,mmol/l",
+          "$gt0008|serum Sodium (sNa)|>0,mmol/l",
+          "$gt0011|urine Creatinine (uCr)|>0,umol/l",
+          "$gt0010|serum Creatinine (sCr)|>0,umol/l"
+        ],
+        "then": [
+          "$gt0012|Fractional excretion of sodium (FENa)|.unit='%'",
+          "$gt0012|Fractional excretion of sodium (FENa)|.precision=2",
+          "$gt0012|Fractional excretion of sodium (FENa)|.magnitude=(($gt0010.magnitude*$gt0009.magnitude)/($gt0008.magnitude*$gt0011.magnitude))*100"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "sv": {
+        "id": "sv",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Natriumutsöndring",
+            "description": "Beräknar natriumutsöndring (FENa) vilket är den andel natrium filtrerad i njurarna som utsöndras med urinen. FENa kan användas för att differentiera mellan prerenal, renal och postrenal orsak till njursvikt. För beräkningen krävs kända värden av koncentration natrium och kreatinin i serum och urin. FENa <1% och U-Na <20mmol/l indikerar prerenal, FENa >1% och U-Na >40mmol/l renal, och FENa >4% och U-Na >40mmol/l postrenal etiologi."
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "Serum-Natrium (S-Na)",
+            "description": "*(en) Sodium level in this specimen."
+          },
+          "gt0004": {
+            "id": "gt0004",
+            "text": "Urin-Natrium (U-Na)",
+            "description": "*(en) Sodium level in this specimen."
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Serum-Kreatinin (S-Krea)",
+            "description": "*(en) Creatinine level in this specimen"
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Urin-Kreatinin (U-Krea)",
+            "description": "*(en) Bicarbonate level in this specimen."
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Serum-Natrium (S-Na)",
+            "description": "*(en) Sodium level in this specimen."
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Urin-Natrium (U-Na)",
+            "description": "*(en) Sodium level in this specimen."
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Serum-Kreatinin (S-Krea)",
+            "description": "*(en) Creatinine level in this specimen"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Urin-Kreatinin (U-Krea)",
+            "description": "*(en) Bicarbonate level in this specimen."
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "Natriumutsöndring (FENa)",
+            "description": "*(en) Percentage of filtered sodium that is excreted in the urine."
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "CDS S-Na"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "CDS U-Na"
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "CDS S-Krea utan enhetsomvandling "
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "text": "CDS S-Krea med enhetsomvandling "
+          },
+          "gt0018": {
+            "id": "gt0018",
+            "text": "CDS U-Krea utan enhetsomvandling "
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "text": "CDS U-Krea med enhetsomvandling "
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "Beräkna FENa"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      },
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Fractional Excretion of Sodium (FENa) Calculator",
+            "description": "Calculates the fractional excretion of sodium (FENa) which is the percentage of the sodium filtered by the kidney which is excreted in the urine. FENa helps distinguish between prerenal, intrinsic renal and postrenal causes of renal failure, and is widely used to differentiate prerenal disease (decreased renal perfusion) from acute tubular necrosis (ATN) as the cause of acute kidney injury (AKI). The calculation requires serum (sNa) and urine (uNa) sodium concentrations (mmol/L), and serum (sCr) and urine (uCr) creatinine concentrations (umol/L or mg/dl). FENa < 1% and uNa < 20mmol/L suggests kidney injury of prerenal etiology; FENa > 1% and uNa > 40mmol/L suggests an intrinsic renal etiology; while FENa > 4% and uNa > 40mmol/L suggests a postrenal etiology."
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "serum Sodium (sNa)",
+            "description": "Sodium level in this specimen."
+          },
+          "gt0004": {
+            "id": "gt0004",
+            "text": "urine Sodium (uNa)",
+            "description": "Sodium level in this specimen."
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "serum Creatinine (sCr)",
+            "description": "Creatinine level in this specimen"
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "urine Creatinine (uCr)",
+            "description": "Bicarbonate level in this specimen."
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "serum Sodium (sNa)",
+            "description": "Sodium level in this specimen."
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "urine Sodium (uNa)",
+            "description": "Sodium level in this specimen."
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "serum Creatinine (sCr)",
+            "description": "Creatinine level in this specimen"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "urine Creatinine (uCr)",
+            "description": "Bicarbonate level in this specimen."
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "Fractional excretion of sodium (FENa)",
+            "description": "Percentage of filtered sodium that is excreted in the urine."
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "Set sNa"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "Set uNa"
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "Set sCr without unit conversion"
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "text": "Set sCr with unit conversion"
+          },
+          "gt0018": {
+            "id": "gt0018",
+            "text": "Set uCr without unit conversion"
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "text": "Set uCr with unit conversion"
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "Calculate FENa"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/Fractional_sodium_excretion_Calculation.v1.test.yml
+++ b/gdl2/Fractional_sodium_excretion_Calculation.v1.test.yml
@@ -1,0 +1,79 @@
+guidelines:
+  1: Fractional_sodium_excretion_Calculation.v1
+test_cases:
+- id: Low urine sodium
+  input:
+    1:
+      gt0003|serum Sodium (sNa): 136,mmol/l
+      gt0004|urine Sodium (uNa): 35,mmol/l
+      gt0005|serum Creatinine (sCr): 60,umol/l
+      gt0006|urine Creatinine (uCr): 1768,umol/l
+      gt0021|Event time: 2019-02-23T11:54Z
+  expected_output:
+    1:
+      gt0008|serum Sodium (sNa): 136,mmol/l
+      gt0011|urine Creatinine (uCr): 1768,umol/l
+      gt0010|serum Creatinine (sCr): 60,umol/l
+      gt0009|urine Sodium (uNa): 35,mmol/l
+      gt0012|Fractional excretion of sodium (FENa): 0.87,%
+- id: Normal
+  input:
+    1:
+      gt0003|serum Sodium (sNa): 136,mmol/l
+      gt0004|urine Sodium (uNa): 70,mmol/l
+      gt0005|serum Creatinine (sCr): 60,umol/l
+      gt0006|urine Creatinine (uCr): 1768,umol/l
+      gt0021|Event time: 2019-02-23T11:54Z
+  expected_output:
+    1:
+      gt0008|serum Sodium (sNa): 136,mmol/l
+      gt0011|urine Creatinine (uCr): 1768,umol/l
+      gt0010|serum Creatinine (sCr): 60,umol/l
+      gt0009|urine Sodium (uNa): 70,mmol/l
+      gt0012|Fractional excretion of sodium (FENa): 1.75,%
+- id: High urine sodium
+  input:
+    1:
+      gt0003|serum Sodium (sNa): 136,mmol/l
+      gt0004|urine Sodium (uNa): 120,mmol/l
+      gt0005|serum Creatinine (sCr): 60,umol/l
+      gt0006|urine Creatinine (uCr): 1768,umol/l
+      gt0021|Event time: 2019-02-23T11:54Z
+  expected_output:
+    1:
+      gt0008|serum Sodium (sNa): 136,mmol/l
+      gt0011|urine Creatinine (uCr): 1768,umol/l
+      gt0010|serum Creatinine (sCr): 60,umol/l
+      gt0009|urine Sodium (uNa): 120,mmol/l
+      gt0012|Fractional excretion of sodium (FENa): 2.99,%
+- id: High serum sodium
+  input:
+    1:
+      gt0003|serum Sodium (sNa): 160,mmol/l
+      gt0004|urine Sodium (uNa): 70,mmol/l
+      gt0005|serum Creatinine (sCr): 60,umol/l
+      gt0006|urine Creatinine (uCr): 1768,umol/l
+      gt0021|Event time: 2019-02-23T11:54Z
+  expected_output:
+    1:
+      gt0008|serum Sodium (sNa): 160,mmol/l
+      gt0011|urine Creatinine (uCr): 1768,umol/l
+      gt0010|serum Creatinine (sCr): 60,umol/l
+      gt0009|urine Sodium (uNa): 70,mmol/l
+      gt0012|Fractional excretion of sodium (FENa): 1.48,%
+
+- id: High urine creatinine
+  input:
+    1:
+      gt0003|serum Sodium (sNa): 160,mmol/l
+      gt0004|urine Sodium (uNa): 70,mmol/l
+      gt0005|serum Creatinine (sCr): 60,umol/l
+      gt0006|urine Creatinine (uCr): 30000,umol/l
+      gt0021|Event time: 2019-02-23T11:54Z
+  expected_output:
+    1:
+      gt0008|serum Sodium (sNa): 160,mmol/l
+      gt0011|urine Creatinine (uCr): 30000,umol/l
+      gt0010|serum Creatinine (sCr): 60,umol/l
+      gt0009|urine Sodium (uNa): 70,mmol/l
+      gt0012|Fractional excretion of sodium (FENa): 0.09,%

--- a/gdl2/Fractional_urea_excretion_Assessment.v1.gdl2.json
+++ b/gdl2/Fractional_urea_excretion_Assessment.v1.gdl2.json
@@ -1,0 +1,163 @@
+{
+  "id": "Fractional_urea_excretion_Assessment.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2017-01-18",
+      "name": "Eneimi Allwell-Brown",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "other_contributors": [
+      "Dennis Forslund",
+      "Jimmy Axelsson"
+    ],
+    "lifecycle_state": "Author draft",
+    "details": {
+      "sv": {
+        "id": "sv",
+        "purpose": "Utvärdering av beräknat värde för Fractional Excretion of Urea (FEUrea) är den andel urea i blodet som utsöndras i urinen efter filtrering i njurarna, och därigenom differentiera mellan prerenal och renal orsak till akut njursvikt, med specifikt avseende på prerenal azotemi och akut tubulär nekros.",
+        "keywords": [
+          "akut njursvikt",
+          "FEUrea",
+          "azotemi",
+          "nefrologi"
+        ],
+        "use": "Använd för utvärdering av beräknat värde för Fractional Excretion of Urea (FEUrea) är den andel urea i blodet som utsöndras i urinen efter filtrering i njurarna, och därigenom differentiera mellan prerenal och renal orsak till akut njursvikt, med specifikt avseende på prerenal azotemi och akut tubulär nekros.\r\n\r\nEn patient med akut azotemi och:\r\nFEUrea ≤ 35% indikerar prerenal etiologi; \r\nFEUrea > 50% indikerar renal etiologi; \r\nFEUrea-värdet registreras med hjälp av separat arketyp: openEHR-EHR-OBSERVATION.lab_test-fractional_urea_excretion.v1",
+        "misuse": "Endast avsedd för utvärdering av akut njursvikt, ej kronisk.",
+        "copyright": "© Cambio Healthcare Systems"
+      },
+      "en": {
+        "id": "en",
+        "purpose": "To assess fractional excretion of urea and possible etiology of acute renal failure/acute azotemia. ",
+        "keywords": [
+          "acute kidney injury",
+          "FEUN",
+          "FENa",
+          "acute tubular necrosis",
+          "prerenal azotemia"
+        ],
+        "use": "To assess FEUrea and determine if acute renal failure/kidney injury is due to prerenal or intrinsic renal pathology. A patient with acute azotemia and:\r\nFEUrea <= 35% suggests kidney injury of prerenal etiology;\r\nFEUrea > 50% suggests an intrinsic renal etiology.\r\nEtiology of acute kidney injury (AKI) should be based upon the totality of the presentation (history, clinical examination, urine microscopy, and, when appropriate, response to volume resuscitation), not just on the FEUrea. FEUrea is calculated by a separate application: Fractional_urea_excretion_Assessment.v1.",
+        "misuse": "FEUrea is a useful discriminator in acute renal failure, not chronic renal failure.",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Carvounis CP, Nisar S, Guro-Razuman S. Significance of the fractional excretion of urea in the differential diagnosis of acute renal failure. Kidney international. 2002 Dec 31;62(6):2223-9."
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0002": {
+        "id": "gt0002",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-fractional_urea_excretion.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-fractional_urea_excretion.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0003": {
+            "id": "gt0003",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0.0.18]"
+          }
+        }
+      },
+      "gt0004": {
+        "id": "gt0004",
+        "model_id": "openEHR-EHR-EVALUATION.fractional_urea_excretion.v1",
+        "template_id": "openEHR-EHR-EVALUATION.fractional_urea_excretion.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0005": {
+            "id": "gt0005",
+            "path": "/data[at0001]/items[at0002]"
+          }
+        }
+      }
+    },
+    "rules": {
+      "gt0006": {
+        "id": "gt0006",
+        "priority": 2,
+        "when": [
+          "$gt0003|Fractional excretion of urea (FEUrea)|<=35,%"
+        ],
+        "then": [
+          "$gt0005|Cause of ARF|=local::at0004|Prerenal etiology|"
+        ]
+      },
+      "gt0007": {
+        "id": "gt0007",
+        "priority": 1,
+        "when": [
+          "$gt0003|Fractional excretion of urea (FEUrea)|>50,%"
+        ],
+        "then": [
+          "$gt0005|Cause of ARF|=local::at0005|Intrinsic renal etiology|"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "sv": {
+        "id": "sv",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Fractional Excretion of Urea (FEUrea) utvärdering",
+            "description": "Utvärdering av beräknat värde för Fractional Excretion of Urea (FEUrea) är den andel urea i blodet som utsöndras i urinen efter filtrering i njurarna. Värdet kan användas för att differentiera mellan prerenal och renal orsak till akut njursvikt, med specifikt avseende på prerenal azotemi och akut tubulär nekros. Dess bruk är idag mindre omfattande än natriumutsöndring men har högre specificitet och sensitivitet, och har ett potentiellt högre värde i utredning då utsöndring av urea till skillnad från natrium inte påverkas av diuretika i signifikant utsträckning. För beräkningen krävs kända värden av koncentration urea och kreatinin i såväl blod som urin. FEUrea ≤ 35% indikerar prerenal orsak till njurskada medan >50% indikerar renal etiologi."
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "Fractional excretion of urea (FEUrea)",
+            "description": "*(en) Percentage of filtered urea that is excreted in the urine."
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Etiologi",
+            "description": "*(en) Possible etiology of ARF based on FEUrea."
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "CDS prerenal etiologi"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "CDS renal etiologi"
+          }
+        }
+      },
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Fractional Excretion of Urea (FEUrea) Assessment",
+            "description": "Fractional excretion of urea (FEUrea) is the percentage of blood urea nitrogen filtered by the kidney which is excreted in the urine. FEUrea helps distinguish between prerenal and intrinsic renal causes of acute renal failure, specifically prerenal azotemia and acute tubular nerosis (ATN). Though less common than fractional excretion of sodium (FENa), it is more specific and sensitive and potentially more useful because urea excretion (unlike sodium) is not significantly affected by diuretics. The calculation requires blood urea nitrogen (BUN) and urine urea (uUrea) concentrations (mmol/L or mg/dl), and serum (sCr) and urine (uCr) creatinine concentrations (umol/L or mg/dl). FEUrea <= 35% suggests kidney injury of prerenal etiology while FEUrea > 50% suggests an intrinsic renal etiology."
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "Fractional excretion of urea (FEUrea)",
+            "description": "Percentage of filtered urea that is excreted in the urine."
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Cause of ARF",
+            "description": "Possible etiology of ARF based on FEUrea."
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Set prerenal etiology"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Set intrinsic renal etiology"
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/Fractional_urea_excretion_Assessment.v1.test.yml
+++ b/gdl2/Fractional_urea_excretion_Assessment.v1.test.yml
@@ -1,0 +1,24 @@
+guidelines:
+  1: Fractional_urea_excretion_Assessment.v1
+test_cases:
+- id: less than 35%
+  input:
+    1:
+      gt0003|Fractional excretion of urea (FEUrea): 34,%
+  expected_output:
+    1:
+      gt0005|Cause of ARF: local::at0004|Prerenal etiology|
+- id: greater than 50%
+  input:
+    1:
+      gt0003|Fractional excretion of urea (FEUrea): 51,%
+  expected_output:
+    1:
+      gt0005|Cause of ARF: local::at0005|Intrinsic renal etiology|
+- id: between
+  input:
+    1:
+      gt0003|Fractional excretion of urea (FEUrea): 45,%
+  expected_output:
+    1:
+      gt0005|Cause of ARF: local::at0005|Intrinsic renal etiology|

--- a/gdl2/Fractional_urea_excretion_Calculation.v1.gdl2.json
+++ b/gdl2/Fractional_urea_excretion_Calculation.v1.gdl2.json
@@ -1,0 +1,437 @@
+{
+  "id": "Fractional_urea_excretion_Calculation.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2017-01-18",
+      "name": "Eneimi Allwell-Brown",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "other_contributors": [
+      "Dennis Forslund",
+      "Jimmy Axelsson"
+    ],
+    "lifecycle_state": "Author draft",
+    "details": {
+      "sv": {
+        "id": "sv",
+        "purpose": "Att uppskatta den andel av totala mängden urea som i njurarna filtreras till urinen, och därigenom understödja differentiering mellan pre-renala och renala orsaker till akut njursvikt.",
+        "keywords": [
+          "akut njursvikt",
+          "FEUN",
+          "FENa",
+          "urea",
+          "urea-utsöndring",
+          "FEUrea",
+          "nefrologi"
+        ],
+        "use": "Använd för att beräkna Fractional Excretion of Urea (FEUrea) med hjälp av provsvar för urea (mmol/l eller mg/dl) och kreatinin (umol/l eller mg/dl) i serum och urin. FEUrea ≤ 35% indikerar prerenal etiologi till akut njursvikt medan >50% indikerar renal orsak.",
+        "misuse": "FEUrea bör endast användas tillsammans med utförlig klinisk bedömning, och är ej avsedd att i sig själv vara beslutsgrundande. \r\n\r\nEndast avsedd för användning vid akut njursvikt.",
+        "copyright": "© Cambio Healthcare Systems"
+      },
+      "en": {
+        "id": "en",
+        "purpose": "To determine the proportion of urea excreted in the urine compared with the total amount of urea filtered by the kidneys, and help differentiate between pre-renal and intrinsic renal causes of renal failure and acute kidney injury.",
+        "keywords": [
+          "acute kidney injury",
+          "FEUN",
+          "FENa",
+          "acute tubular necrosis",
+          "prerenal azotemia",
+          "nephrology"
+        ],
+        "use": "To calculate FEUrea (%) from given values of urea (mmol/L or mg/dl) and creatinine (umol/L or mg/dl) detected in serum and urine samples. To determine if acute renal failure/kidney injury is due to prerenal (FEUrea <= 35%) or intrinsic renal (FEUrea > 50%) etiology.\r\nEtiology of acute kidney injury (AKI) should be based upon the totality of the presentation (history, clinical examination, urine microscopy, and, when appropriate, response to volume resuscitation), not just on the FEUrea.",
+        "misuse": "FEUrea is a useful discriminator in acute renal failure, not chronic renal failure.",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Carvounis CP, Nisar S, Guro-Razuman S. Significance of the fractional excretion of urea in the differential diagnosis of acute renal failure. Kidney international. 2002 Dec 31;62(6):2223-9."
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0021": {
+        "id": "gt0021",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-fractional_urea_excretion.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-fractional_urea_excretion.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0022": {
+            "id": "gt0022",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0.0.14]"
+          },
+          "gt0023": {
+            "id": "gt0023",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0.0.15]"
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0.0.16]"
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0.0.17]"
+          },
+          "gt0034": {
+            "id": "gt0034",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0026": {
+        "id": "gt0026",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-fractional_urea_excretion.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-fractional_urea_excretion.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0027": {
+            "id": "gt0027",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0.0.14]"
+          },
+          "gt0028": {
+            "id": "gt0028",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0.0.15]"
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0.0.16]"
+          },
+          "gt0030": {
+            "id": "gt0030",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0.0.17]"
+          },
+          "gt0031": {
+            "id": "gt0031",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0.0.18]"
+          }
+        }
+      }
+    },
+    "rules": {
+      "gt0014": {
+        "id": "gt0014",
+        "priority": 9,
+        "when": [
+          "$gt0022|Blood urea nitrogen (BUN)|.unit=='mmol/l'",
+          "$gt0022|Blood urea nitrogen (BUN)|!=null"
+        ],
+        "then": [
+          "$gt0027|Blood urea nitrogen (BUN)|.unit='mmol/l'",
+          "$gt0027|Blood urea nitrogen (BUN)|.precision=2",
+          "$gt0027|Blood urea nitrogen (BUN)|=$gt0022|Blood urea nitrogen (BUN)|"
+        ]
+      },
+      "gt0032": {
+        "id": "gt0032",
+        "priority": 8,
+        "when": [
+          "$gt0022|Blood urea nitrogen (BUN)|.unit=='mg/dl'",
+          "$gt0022|Blood urea nitrogen (BUN)|!=null"
+        ],
+        "then": [
+          "$gt0027|Blood urea nitrogen (BUN)|.unit='mmol/l'",
+          "$gt0027|Blood urea nitrogen (BUN)|.precision=2",
+          "$gt0027|Blood urea nitrogen (BUN)|.magnitude=$gt0022.magnitude*0.3571"
+        ]
+      },
+      "gt0015": {
+        "id": "gt0015",
+        "priority": 7,
+        "when": [
+          "$gt0023|urine Urea (uUrea)|.unit=='mmol/l'",
+          "$gt0023|urine Urea (uUrea)|!=null"
+        ],
+        "then": [
+          "$gt0028|urine Urea (uUrea)|.unit='mmol/l'",
+          "$gt0028|urine Urea (uUrea)|.precision=2",
+          "$gt0028|urine Urea (uUrea)|=$gt0023|urine Urea (uUrea)|"
+        ]
+      },
+      "gt0033": {
+        "id": "gt0033",
+        "priority": 6,
+        "when": [
+          "$gt0023|urine Urea (uUrea)|.unit=='mg/dl'",
+          "$gt0023|urine Urea (uUrea)|!=null"
+        ],
+        "then": [
+          "$gt0028|urine Urea (uUrea)|.unit='mmol/l'",
+          "$gt0028|urine Urea (uUrea)|.precision=2",
+          "$gt0028|urine Urea (uUrea)|.magnitude=$gt0023.magnitude*0.3571"
+        ]
+      },
+      "gt0016": {
+        "id": "gt0016",
+        "priority": 5,
+        "when": [
+          "$gt0024|serum Creatinine (sCr)|.unit=='umol/l'",
+          "$gt0024|serum Creatinine (sCr)|!=null"
+        ],
+        "then": [
+          "$gt0029|serum Creatinine (sCr)|.unit='umol/l'",
+          "$gt0029|serum Creatinine (sCr)|.precision=2",
+          "$gt0029|serum Creatinine (sCr)|=$gt0024|serum Creatinine (sCr)|"
+        ]
+      },
+      "gt0017": {
+        "id": "gt0017",
+        "priority": 4,
+        "when": [
+          "$gt0024|serum Creatinine (sCr)|.unit=='mg/dl'",
+          "$gt0024|serum Creatinine (sCr)|!=null"
+        ],
+        "then": [
+          "$gt0029|serum Creatinine (sCr)|.unit='umol/l'",
+          "$gt0029|serum Creatinine (sCr)|.precision=2",
+          "$gt0029|serum Creatinine (sCr)|.magnitude=$gt0024.magnitude*88.42"
+        ]
+      },
+      "gt0018": {
+        "id": "gt0018",
+        "priority": 3,
+        "when": [
+          "$gt0025|urine Creatinine (uCr)|.unit=='umol/l'",
+          "$gt0025|urine Creatinine (uCr)|!=null"
+        ],
+        "then": [
+          "$gt0030|urine Creatinine (uCr)|.precision=2",
+          "$gt0030|urine Creatinine (uCr)|.unit='umol/l'",
+          "$gt0030|urine Creatinine (uCr)|=$gt0025|urine Creatinine (uCr)|"
+        ]
+      },
+      "gt0019": {
+        "id": "gt0019",
+        "priority": 2,
+        "when": [
+          "$gt0025|urine Creatinine (uCr)|.unit=='mg/dl'",
+          "$gt0025|urine Creatinine (uCr)|!=null"
+        ],
+        "then": [
+          "$gt0030|urine Creatinine (uCr)|.unit='umol/l'",
+          "$gt0030|urine Creatinine (uCr)|.precision=2",
+          "$gt0030|urine Creatinine (uCr)|.magnitude=$gt0025.magnitude*88.42"
+        ]
+      },
+      "gt0020": {
+        "id": "gt0020",
+        "priority": 1,
+        "when": [
+          "$gt0028|urine Urea (uUrea)|>0,mmol/l",
+          "$gt0027|Blood urea nitrogen (BUN)|>0,mmol/l",
+          "$gt0029|serum Creatinine (sCr)|>0,umol/l",
+          "$gt0030|urine Creatinine (uCr)|>0,umol/l"
+        ],
+        "then": [
+          "$gt0031|Fractional excretion of urea (FEUrea)|.unit='%'",
+          "$gt0031|Fractional excretion of urea (FEUrea)|.precision=2",
+          "$gt0031|Fractional excretion of urea (FEUrea)|.magnitude=(($gt0029.magnitude*$gt0028.magnitude)/($gt0027.magnitude*$gt0030.magnitude))*100"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "sv": {
+        "id": "sv",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Urea-utsöndring",
+            "description": "Fractional Excretion of Urea (FEUrea) är den andel urea i blodet som utsöndras i urinen efter filtrering i njurarna. Värdet kan användas för att differentiera mellan prerenal och renal orsak till akut njursvikt, med specifikt avseende på prerenal azotemi och akut tubulär nekros. Dess bruk är idag mindre omfattande än natriumutsöndring men har högre specificitet och sensitivitet, och har ett potentiellt högre värde i utredning då utsöndring av urea till skillnad från natrium inte påverkas av diuretika i signifikant utsträckning. För beräkningen krävs kända värden av koncentration urea och kreatinin i såväl blod som urin. FEUrea ≤ 35% indikerar prerenal orsak till njurskada medan >50% indikerar renal etiologi."
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "CDS s-urea utan att konvertera enhet"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "CDS u-urea utan att konvertera enhet"
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "CDS s-krea utan att konvertera enhet"
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "text": "CDS s-krea med konvertering av enhet"
+          },
+          "gt0018": {
+            "id": "gt0018",
+            "text": "CDS u-krea without unit conversion"
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "text": "CDS u-krea med konvertering av enhet"
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "Beräkna FEUrea"
+          },
+          "gt0022": {
+            "id": "gt0022",
+            "text": "S-urea",
+            "description": "*(en) Urea level in this specimen."
+          },
+          "gt0023": {
+            "id": "gt0023",
+            "text": "U-urea",
+            "description": "*(en) Urea level in this specimen."
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "text": "S-kreatinin",
+            "description": "*(en) Creatinine level in this specimen."
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "text": "U-kreatinin",
+            "description": "*(en) Creatinine level in this specimen."
+          },
+          "gt0027": {
+            "id": "gt0027",
+            "text": "S-urea",
+            "description": "*(en) Urea level in this specimen."
+          },
+          "gt0028": {
+            "id": "gt0028",
+            "text": "U-urea",
+            "description": "*(en) Urea level in this specimen."
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "text": "S-kreatinin",
+            "description": "*(en) Creatinine level in this specimen."
+          },
+          "gt0030": {
+            "id": "gt0030",
+            "text": "U-kreatinin",
+            "description": "*(en) Creatinine level in this specimen."
+          },
+          "gt0031": {
+            "id": "gt0031",
+            "text": "Fractional excretion of urea (FEUrea)",
+            "description": "*(en) Percentage of filtered urea that is excreted in the urine."
+          },
+          "gt0032": {
+            "id": "gt0032",
+            "text": "CDS s-urea med konvertering av enhet"
+          },
+          "gt0033": {
+            "id": "gt0033",
+            "text": "CDS u-urea med konvertering av enhet"
+          },
+          "gt0034": {
+            "id": "gt0034",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      },
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Fractional Excretion of Urea (FEUrea) Calculator",
+            "description": "Fractional excretion of urea (FEUrea) is the percentage of blood urea nitrogen filtered by the kidney which is excreted in the urine. FEUrea helps distinguish between prerenal and intrinsic renal causes of acute renal failure, specifically prerenal azotemia and acute tubular nerosis (ATN). Though less common than fractional excretion of sodium (FENa), it is more specific and sensitive and potentially more useful because urea excretion (unlike sodium) is not significantly affected by diuretics. The calculation requires blood urea nitrogen (BUN) and urine urea (uUrea) concentrations (mmol/L or mg/dl), and serum (sCr) and urine (uCr) creatinine concentrations (umol/L or mg/dl). FEUrea <= 35% suggests kidney injury of prerenal etiology while FEUrea > 50% suggests an intrinsic renal etiology."
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "Set BUN without unit conversion"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "Set uUrea without unit conversion"
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "Set sCr without unit conversion"
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "text": "Set sCr with unit conversion"
+          },
+          "gt0018": {
+            "id": "gt0018",
+            "text": "Set uCr without unit conversion"
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "text": "Set uCr with unit conversion"
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "Calculate FEUrea"
+          },
+          "gt0022": {
+            "id": "gt0022",
+            "text": "Blood urea nitrogen (BUN)",
+            "description": "Urea level in this specimen."
+          },
+          "gt0023": {
+            "id": "gt0023",
+            "text": "urine Urea (uUrea)",
+            "description": "Urea level in this specimen."
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "text": "serum Creatinine (sCr)",
+            "description": "Creatinine level in this specimen."
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "text": "urine Creatinine (uCr)",
+            "description": "Creatinine level in this specimen."
+          },
+          "gt0027": {
+            "id": "gt0027",
+            "text": "Blood urea nitrogen (BUN)",
+            "description": "Urea level in this specimen."
+          },
+          "gt0028": {
+            "id": "gt0028",
+            "text": "urine Urea (uUrea)",
+            "description": "Urea level in this specimen."
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "text": "serum Creatinine (sCr)",
+            "description": "Creatinine level in this specimen."
+          },
+          "gt0030": {
+            "id": "gt0030",
+            "text": "urine Creatinine (uCr)",
+            "description": "Creatinine level in this specimen."
+          },
+          "gt0031": {
+            "id": "gt0031",
+            "text": "Fractional excretion of urea (FEUrea)",
+            "description": "Percentage of filtered urea that is excreted in the urine."
+          },
+          "gt0032": {
+            "id": "gt0032",
+            "text": "Set BUN with unit conversion"
+          },
+          "gt0033": {
+            "id": "gt0033",
+            "text": "Set uUrea with unit conversion"
+          },
+          "gt0034": {
+            "id": "gt0034",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/Fractional_urea_excretion_Calculation.v1.test.yml
+++ b/gdl2/Fractional_urea_excretion_Calculation.v1.test.yml
@@ -1,0 +1,123 @@
+guidelines:
+  1: Fractional_urea_excretion_Calculation.v1
+test_cases:
+- id: Normal range
+  input:
+    1:
+      gt0022|Blood urea nitrogen (BUN): 7,mmol/l
+      gt0023|urine Urea (uUrea): 90,mmol/l
+      gt0024|serum Creatinine (sCr): 140,umol/l
+      gt0025|urine Creatinine (uCr): 2000,umol/l
+      gt0034|Event time: 2019-02-22T15:58Z
+  expected_output:
+    1:
+      gt0029|serum Creatinine (sCr): 140,umol/l
+      gt0027|Blood urea nitrogen (BUN): 7,mmol/l
+      gt0030|urine Creatinine (uCr): 2000,umol/l
+      gt0028|urine Urea (uUrea): 90,mmol/l
+      gt0031|Fractional excretion of urea (FEUrea): 90.00,%
+- id: High BUN
+  input:
+    1:
+      gt0022|Blood urea nitrogen (BUN): 10,mmol/l
+      gt0023|urine Urea (uUrea): 110,mmol/l
+      gt0024|serum Creatinine (sCr): 140,umol/l
+      gt0025|urine Creatinine (uCr): 2000,umol/l
+      gt0034|Event time: 2019-02-22T15:58Z
+  expected_output:
+    1:
+      gt0029|serum Creatinine (sCr): 140,umol/l
+      gt0027|Blood urea nitrogen (BUN): 10,mmol/l
+      gt0030|urine Creatinine (uCr): 2000,umol/l
+      gt0028|urine Urea (uUrea): 110,mmol/l
+      gt0031|Fractional excretion of urea (FEUrea): 77.00,%
+- id: Low BUN
+  input:
+    1:
+      gt0022|Blood urea nitrogen (BUN): 1,mmol/l
+      gt0023|urine Urea (uUrea): 110,mmol/l
+      gt0024|serum Creatinine (sCr): 140,umol/l
+      gt0025|urine Creatinine (uCr): 2000,umol/l
+      gt0034|Event time: 2019-02-22T15:58Z
+  expected_output:
+    1:
+      gt0029|serum Creatinine (sCr): 140,umol/l
+      gt0027|Blood urea nitrogen (BUN): 1,mmol/l
+      gt0030|urine Creatinine (uCr): 2000,umol/l
+      gt0028|urine Urea (uUrea): 110,mmol/l
+      gt0031|Fractional excretion of urea (FEUrea): 770.00,%
+- id: High urine creatinine
+  input:
+    1:
+      gt0022|Blood urea nitrogen (BUN): 1,mmol/l
+      gt0023|urine Urea (uUrea): 110,mmol/l
+      gt0024|serum Creatinine (sCr): 110,umol/l
+      gt0025|urine Creatinine (uCr): 30000,umol/l
+      gt0034|Event time: 2019-02-22T15:58Z
+  expected_output:
+    1:
+      gt0029|serum Creatinine (sCr): 110,umol/l
+      gt0027|Blood urea nitrogen (BUN): 1,mmol/l
+      gt0030|urine Creatinine (uCr): 30000,umol/l
+      gt0028|urine Urea (uUrea): 110,mmol/l
+      gt0031|Fractional excretion of urea (FEUrea): 40.33,%
+- id: High urine creatinine 2
+  input:
+    1:
+      gt0022|Blood urea nitrogen (BUN): 2,mmol/l
+      gt0023|urine Urea (uUrea): 110,mmol/l
+      gt0024|serum Creatinine (sCr): 110,umol/l
+      gt0025|urine Creatinine (uCr): 30000,umol/l
+      gt0034|Event time: 2019-02-22T15:58Z
+  expected_output:
+    1:
+      gt0029|serum Creatinine (sCr): 110,umol/l
+      gt0027|Blood urea nitrogen (BUN): 2,mmol/l
+      gt0030|urine Creatinine (uCr): 30000,umol/l
+      gt0028|urine Urea (uUrea): 110,mmol/l
+      gt0031|Fractional excretion of urea (FEUrea): 20.17,%
+- id: BUN in mg/dl
+  input:
+    1:
+      gt0022|Blood urea nitrogen (BUN): 20,mg/dl
+      gt0023|urine Urea (uUrea): 90,mmol/l
+      gt0024|serum Creatinine (sCr): 140,umol/l
+      gt0025|urine Creatinine (uCr): 2000,umol/l
+      gt0034|Event time: 2019-02-20T16:57Z
+  expected_output:
+    1:
+      gt0029|serum Creatinine (sCr): 140,umol/l
+      gt0027|Blood urea nitrogen (BUN): 7.14,mmol/l
+      gt0030|urine Creatinine (uCr): 2000,umol/l
+      gt0028|urine Urea (uUrea): 90,mmol/l
+      gt0031|Fractional excretion of urea (FEUrea): 88.21,%
+- id: two in mg/dl
+  input:
+    1:
+      gt0022|Blood urea nitrogen (BUN): 20,mg/dl
+      gt0023|urine Urea (uUrea): 250,mg/dl
+      gt0024|serum Creatinine (sCr): 140,umol/l
+      gt0025|urine Creatinine (uCr): 2000,umol/l
+      gt0034|Event time: 2019-02-20T16:57Z
+  expected_output:
+    1:
+      gt0029|serum Creatinine (sCr): 140,umol/l
+      gt0027|Blood urea nitrogen (BUN): 7.14,mmol/l
+      gt0030|urine Creatinine (uCr): 2000,umol/l
+      gt0028|urine Urea (uUrea): 89.27,mmol/l
+      gt0031|Fractional excretion of urea (FEUrea): 87.50,%
+- id: all in mg/dl
+  input:
+    1:
+      gt0022|Blood urea nitrogen (BUN): 20,mg/dl
+      gt0023|urine Urea (uUrea): 250,mg/dl
+      gt0024|serum Creatinine (sCr): 1,mg/dl
+      gt0025|urine Creatinine (uCr): 14,mg/dl
+      gt0034|Event time: 2019-02-20T16:57Z
+  expected_output:
+    1:
+      gt0029|serum Creatinine (sCr): 88.42,umol/l
+      gt0027|Blood urea nitrogen (BUN): 7.14,mmol/l
+      gt0030|urine Creatinine (uCr): 1237.88,umol/l
+      gt0028|urine Urea (uUrea): 89.27,mmol/l
+      gt0031|Fractional excretion of urea (FEUrea): 89.29,%


### PR DESCRIPTION
4 guidelines updated. Some remarks:
-FENa Assessment:
--From the description there should be 2 input parameters, but only one is implemented, therefore it is not completely compatible with the  reference.
--No rules for exact 1% or 4%.
-FEUrea Assessment:
--On mdcalc.com, they distinguish two categories whether FEUrea > 35% or  <35%, while this guideline hase "three": FEUrea > 50% ,  <35%, and between the two values there is no rule fired. I don't know whether this is intentional or a bug.