### PR TITLE
Migrated Lansky play performance assessment.v1 and test fixture

### DIFF
--- a/gdl2/Lansky play performance assessment.v1.gdl2.json
+++ b/gdl2/Lansky play performance assessment.v1.gdl2.json
@@ -1,0 +1,262 @@
+{
+  "id": "Lansky play performance assessment.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2017-08-13",
+      "name": "Syeeda S Farruque",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "other_contributors": [
+      "Dennis Forslund, Cambio Healthcare Systems"
+    ],
+    "lifecycle_state": "Author draft",
+    "details": {
+      "sv": {
+        "id": "sv",
+        "purpose": "Lansky Play-Performance Scale for Pediatric Functional Status används för att dokumentera bedömning av ett barns funktionsförmåga och svar på behandling, baserat på utvärdering av förälder.",
+        "keywords": [
+          "sjukdomsprogression",
+          "funktionsstatus",
+          "Lansky Play-Performance Scale",
+          "barnmedicin",
+          "pediatrik"
+        ],
+        "use": "Instrumentet utgörs av en skala 0-100 med steg om 10.\r\nFunktionsbegränsning är uppdelad i tre grupper - ingen, mild och måttlig till svår begränsning. ",
+        "misuse": "Endast tillämpbar på individer under 16 års ålder.",
+        "copyright": "© Cambio Healthcare Systems"
+      },
+      "en": {
+        "id": "en",
+        "purpose": "This tool captures a parental assessment of their chronically ill child's ability and response to treatment and provides a method to track disease progression over time.",
+        "keywords": [
+          "disease progress",
+          "pediatric functional status"
+        ],
+        "use": "Restrictions are separated into 3 groups, such as none (70-100), mild (50-60) and moderate (0-40) restriction.",
+        "misuse": "Do not use for patients >= 16 yrs of age",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Ref. 1: Lansky DA, List MA, Lansky LL, Ritter-Sterr C, Miller DR (1987). The measurement of performance in childhood cancer patients. Cancer 60 (7): 1651–6.doi:10.1002/1097-0142(19871001)60:73.0.CO;2-J. PMID 3621134."
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0004": {
+        "id": "gt0004",
+        "model_id": "openEHR-EHR-OBSERVATION.pediatric_functional_status_lansky_play_performance.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.pediatric_functional_status_lansky_play_performance.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0012": {
+            "id": "gt0012",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0027]"
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0006": {
+        "id": "gt0006",
+        "model_id": "openEHR-EHR-EVALUATION.lansky_play_performance_scale_assessment.v1",
+        "template_id": "openEHR-EHR-EVALUATION.lansky_play_performance_scale_assessment.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0007": {
+            "id": "gt0007",
+            "path": "/data[at0001]/items[at0002]"
+          }
+        }
+      }
+    },
+    "rules": {
+      "gt0013": {
+        "id": "gt0013",
+        "priority": 3,
+        "when": [
+          "$gt0012|Final score|<=100",
+          "$gt0012|Final score|>=70"
+        ],
+        "then": [
+          "$gt0007|Play Performance Scale|=0|local::at0003|No restriction|"
+        ]
+      },
+      "gt0014": {
+        "id": "gt0014",
+        "priority": 2,
+        "when": [
+          "$gt0012|Final score|<=60",
+          "$gt0012|Final score|>=50"
+        ],
+        "then": [
+          "$gt0007|Play Performance Scale|=1|local::at0004|Mild restriction|"
+        ]
+      },
+      "gt0015": {
+        "id": "gt0015",
+        "priority": 1,
+        "when": [
+          "$gt0012|Final score|<=40",
+          "$gt0012|Final score|>=0"
+        ],
+        "then": [
+          "$gt0007|Play Performance Scale|=2|local::at0005|Moderate restriction|"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "sv": {
+        "id": "sv",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Lansky Play-Performance Scale - utvärdering",
+            "description": "Lansky Play-Performance Scale for Pediatric Functional Status används för att dokumentera bedömning av ett barns funktionsförmåga och svar på behandling, baserat på utvärdering av förälder."
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "Utvärdering",
+            "description": "Beskrivning av individen."
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Utvärdering",
+            "description": "Beskrivning av individen."
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Play Performance Scale",
+            "description": "Funktionsbegränsning är uppdelad i tre grupper - ingen, mild och måttlig begränsning. "
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "CDS Utvärdering"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "CDS Performance scale"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Utvärdering",
+            "description": "Beskrivning av individen."
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Resultat",
+            "description": "Resultat baserad på förälders utvärdering."
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "Resultat",
+            "description": "Resultat baserad på förälders utvärdering."
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "Ingen begränsning"
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "Mild begränsning"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "Måttlig till svår begränsning"
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "*(en) set score"
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      },
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Lansky play performance scale assessment",
+            "description": "The Lansky Play-Performance Scale for Pediatric Functional Status captures a parental assessment of their child's ability and response to treatment"
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "Patient Description",
+            "description": "Patient Description"
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Patient Description",
+            "description": "Patient Description"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Play Performance Scale",
+            "description": "Restrictions are separated into 3 groups, such as none, mild and moderate restriction"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Set Patient description"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Set Performance scale"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Patient Description",
+            "description": "Patient Description"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Final score",
+            "description": "Final score"
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "Final score",
+            "description": "Final score"
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "No restriction"
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "Mild restriction"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "Moderate restriction"
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "set score"
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/Lansky play performance assessment.v1.test.yml
+++ b/gdl2/Lansky play performance assessment.v1.test.yml
@@ -1,0 +1,45 @@
+guidelines:
+  1: Lansky play performance assessment.v1
+test_cases:
+- id: case_1:Score 100 = Non restriction 
+  input:
+    1:
+      gt0012|Final score: 100
+      gt0017|Event time: 2019-03-07T14:30Z
+  expected_output:
+    1:
+      gt0007|Play Performance Scale: 0|local::at0003|No restriction|
+
+- id: case_2:Score 60=Mild restriction
+  input:
+    1:
+      gt0012|Final score: 60
+      gt0017|Event time: 2019-03-07T14:30Z
+  expected_output:
+    1:
+      gt0007|Play Performance Scale: 1|local::at0004|Mild restriction|
+
+- id: case_3:Score 40= Moderate restriction
+  input:
+    1:
+      gt0012|Final score: 40
+      gt0017|Event time: 2019-03-07T14:30Z
+  expected_output:
+    1:
+      gt0007|Play Performance Scale: 2|local::at0005|Moderate restriction|
+
+- id: case_4:Score 0 = Moderate restriction
+  input:
+    1:
+      gt0012|Final score: 0
+      gt0017|Event time: 2019-03-07T14:30Z
+  expected_output:
+    1:
+      gt0007|Play Performance Scale: 2|local::at0005|Moderate restriction|
+
+
+
+
+
+
+


### PR DESCRIPTION
Hi again.
I have now migrated the Lansky play performance assessment guideline and test fixture. Please review.
I am wondering if we should change the naming of two of the three groups to:  Mild to moderate and moderate to severe?
/Linda