### PR TITLE
Migrated Alvarado

### DIFF
--- a/gdl2/Alvarado.v1.gdl2.json
+++ b/gdl2/Alvarado.v1.gdl2.json
@@ -1,0 +1,782 @@
+{
+  "id": "Alvarado.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2016-12-28",
+      "name": "Syeeda S Farruque",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "other_contributors": [
+      "Dennis Forslund",
+      "Jimmy Axelsson"
+    ],
+    "lifecycle_state": "Not set",
+    "details": {
+      "sv": {
+        "id": "sv",
+        "purpose": "Alvarado score utvecklades för att understödja diagnostik vid misstänkt akut appendicit.",
+        "keywords": [
+          "alvarado",
+          "appendicit"
+        ],
+        "use": "Använd för att understödja diagnostik vid misstänkt akut appendicit. Totala poängen uppgår till maximalt 10p och utgörs av summan av följande faktorer:\n\n+2 poäng - Ömhet höger fossa\n+1 poäng - Förhöjd temperatur (>37.3°C eller 99.1°F)\n+1 poäng - Släppömhet\n+1 poäng - Smärtvandring till höger fossa\n+1 poäng - Anorexi/aptitlöshet\n+1 poäng - Illamående eller kräkning\n+2 poäng - LPK > 10,000\n+1 poäng - Vänsterförskjuten diff\n\n- Poäng om ≤3p anses vara låg risk utan behov av vidare utredning med DT\n- DT rekommenderas om 4-6p\n- Poäng om ≥7p bör föranleda kontakt med kirurg. \n",
+        "misuse": "Ej att anse som diagnostisk utan är endast till för att understödja klinisk bedömning.",
+        "copyright": "© Cambio Healthcare Systems"
+      },
+      "en": {
+        "id": "en",
+        "purpose": "The Alvarado score was developed to assist in diagnosing appendicitis in the early stages.",
+        "keywords": [
+          "Alvarado score",
+          "acute appendicitis"
+        ],
+        "use": "The total score, derived by adding up the individual scores for each of the 8 items ranges from 0 to 10 with score weights allocated thus:\n\n+2 points - Right lower quadrant tenderness\n+1 point - Elevated temperature (>37.3°C or 99.1°F)\n+1 point - Rebound tenderness\n+1 point - Migration of pain to the right lower quadrant\n+1 point - Anorexia\n+1 point - Nausea or vomiting\n+2 point - Leukocytosis > 10,000\n+1 point - Leukocyte left shift \n\n- A CT scan is recommended for scores 4-6 \n- A surgical consultation for scores  ≥ 7. \n- For scores  ≤ 3: a CT scan is not needed due to the low probability of appendicitis.",
+        "misuse": "This tool depends on a thorough clinical assessment made by the physician and care team and should only be used to assist diagnosis.",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Ref. 1: Alvarado A. A practical score for the early diagnosis of acute appendicitis. Ann Emerg Med. 1986; 15(5): 557-64. \n\nRef. 2: McKay R, Shepherd J. The use of the clinical scoring system by Alvarado in the decision to perform computed tomography for acute appendicitis in the ED. Am J Emerg Med. 2007; 25(5): 489-93. "
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0031": {
+        "id": "gt0031",
+        "model_id": "openEHR-EHR-OBSERVATION.alvarado_score.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.alvarado_score.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0033": {
+            "id": "gt0033",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0004]"
+          },
+          "gt0034": {
+            "id": "gt0034",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0005]"
+          },
+          "gt0035": {
+            "id": "gt0035",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0006]"
+          },
+          "gt0036": {
+            "id": "gt0036",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0007]"
+          },
+          "gt0037": {
+            "id": "gt0037",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0008]"
+          },
+          "gt0038": {
+            "id": "gt0038",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0009]"
+          },
+          "gt0044": {
+            "id": "gt0044",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0010]"
+          },
+          "gt0045": {
+            "id": "gt0045",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0011]"
+          },
+          "gt0059": {
+            "id": "gt0059",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0032": {
+        "id": "gt0032",
+        "model_id": "openEHR-EHR-OBSERVATION.alvarado_score.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.alvarado_score.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0039": {
+            "id": "gt0039",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0004]"
+          },
+          "gt0040": {
+            "id": "gt0040",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0005]"
+          },
+          "gt0041": {
+            "id": "gt0041",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0006]"
+          },
+          "gt0042": {
+            "id": "gt0042",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0007]"
+          },
+          "gt0043": {
+            "id": "gt0043",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0008]"
+          },
+          "gt0046": {
+            "id": "gt0046",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0009]"
+          },
+          "gt0047": {
+            "id": "gt0047",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0010]"
+          },
+          "gt0048": {
+            "id": "gt0048",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0011]"
+          },
+          "gt0049": {
+            "id": "gt0049",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0012]"
+          }
+        }
+      }
+    },
+    "rules": {
+      "gt0030": {
+        "id": "gt0030",
+        "priority": 10,
+        "when": [
+          "$gt0047|Leukocytosis > 10,000?|==null",
+          "$gt0048|Leukocyte Left Shift|==null",
+          "$gt0041|Rebound Tenderness?|==null",
+          "$gt0039|Right Lower Quadrant Tenderness?|==null",
+          "$gt0040|Elevated Temperature (>37.3°C or 99.1°F)?|==null",
+          "$gt0042|Migration of Pain to the Right Lower Quadrant?|==null",
+          "$gt0043|Anorexia?|==null",
+          "$gt0046|Nausea or Vomiting?|==null"
+        ],
+        "then": [
+          "$gt0048|Leukocyte Left Shift|=0|local::at0028|No|",
+          "$gt0047|Leukocytosis > 10,000?|=0|local::at0026|No|",
+          "$gt0046|Nausea or Vomiting?|=0|local::at0024|No|",
+          "$gt0043|Anorexia?|=0|local::at0022|No|",
+          "$gt0042|Migration of Pain to the Right Lower Quadrant?|=0|local::at0020|No|",
+          "$gt0041|Rebound Tenderness?|=0|local::at0018|No|",
+          "$gt0040|Elevated Temperature (>37.3°C or 99.1°F)?|=0|local::at0016|No|",
+          "$gt0039|Right Lower Quadrant Tenderness?|=0|local::at0014|No|"
+        ]
+      },
+      "gt0050": {
+        "id": "gt0050",
+        "priority": 9,
+        "when": [
+          "$gt0033|Right Lower Quadrant Tenderness?|!=null"
+        ],
+        "then": [
+          "$gt0039|Right Lower Quadrant Tenderness?|=$gt0033|Right Lower Quadrant Tenderness?|"
+        ]
+      },
+      "gt0051": {
+        "id": "gt0051",
+        "priority": 8,
+        "when": [
+          "$gt0034|Elevated Temperature (>37.3°C or 99.1°F)?|!=null"
+        ],
+        "then": [
+          "$gt0040|Elevated Temperature (>37.3°C or 99.1°F)?|=$gt0034|Elevated Temperature (>37.3°C or 99.1°F)?|"
+        ]
+      },
+      "gt0052": {
+        "id": "gt0052",
+        "priority": 7,
+        "when": [
+          "$gt0035|Rebound Tenderness?|!=null"
+        ],
+        "then": [
+          "$gt0041|Rebound Tenderness?|=$gt0035|Rebound Tenderness?|"
+        ]
+      },
+      "gt0053": {
+        "id": "gt0053",
+        "priority": 6,
+        "when": [
+          "$gt0036|Migration of Pain to the Right Lower Quadrant?|!=null"
+        ],
+        "then": [
+          "$gt0042|Migration of Pain to the Right Lower Quadrant?|=$gt0036|Migration of Pain to the Right Lower Quadrant?|"
+        ]
+      },
+      "gt0054": {
+        "id": "gt0054",
+        "priority": 5,
+        "when": [
+          "$gt0037|Anorexia?|!=null"
+        ],
+        "then": [
+          "$gt0043|Anorexia?|=$gt0037|Anorexia?|"
+        ]
+      },
+      "gt0055": {
+        "id": "gt0055",
+        "priority": 4,
+        "when": [
+          "$gt0038|Nausea or Vomiting?|!=null"
+        ],
+        "then": [
+          "$gt0046|Nausea or Vomiting?|=$gt0038|Nausea or Vomiting?|"
+        ]
+      },
+      "gt0056": {
+        "id": "gt0056",
+        "priority": 3,
+        "when": [
+          "$gt0044|Leukocytosis > 10,000?|!=null"
+        ],
+        "then": [
+          "$gt0047|Leukocytosis > 10,000?|=$gt0044|Leukocytosis > 10,000?|"
+        ]
+      },
+      "gt0057": {
+        "id": "gt0057",
+        "priority": 2,
+        "when": [
+          "$gt0045|Leukocyte Left Shift|!=null"
+        ],
+        "then": [
+          "$gt0048|Leukocyte Left Shift|=$gt0045|Leukocyte Left Shift|"
+        ]
+      },
+      "gt0058": {
+        "id": "gt0058",
+        "priority": 1,
+        "then": [
+          "$gt0049|Total score|.magnitude=(((((($gt0039.value+$gt0040.value)+$gt0041.value)+$gt0042.value)+$gt0043.value)+$gt0046.value)+$gt0047.value)+$gt0048.value"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "sv": {
+        "id": "sv",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Alvarado Score",
+            "description": "Alvarado score utvecklades för att understödja diagnostik vid misstänkt akut appendicit. Poäng om ≤3p anses vara låg risk utan behov av vidare utredning medan DT rekommenderas om 4-6p. ≥7p bör föranleda kontakt med kirurg. "
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "Ömhet höger fossa?",
+            "description": ""
+          },
+          "gt0004": {
+            "id": "gt0004",
+            "text": "Förhöjd temperatur (>37.3°C eller 99.1°F)?",
+            "description": ""
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Släppömhet?",
+            "description": ""
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Smärtvandring till höger fossa?",
+            "description": ""
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Anorexi eller aptitlöshet?",
+            "description": ""
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Illamående eller kräkning?",
+            "description": ""
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "LPK > 10,000?",
+            "description": ""
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Vänsterförskjuten diff?",
+            "description": ""
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "Ömhet höger fossa?",
+            "description": ""
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "Förhöjd temperatur (>37.3°C eller 99.1°F)?",
+            "description": ""
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "Släppömhet?",
+            "description": ""
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "Smärtvandring till höger fossa?",
+            "description": ""
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "Anorexi eller aptitlöshet?",
+            "description": ""
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "text": "Illamående eller kräkning?",
+            "description": ""
+          },
+          "gt0018": {
+            "id": "gt0018",
+            "text": "LPK > 10,000?",
+            "description": ""
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "text": "Vänsterförskjuten diff?",
+            "description": ""
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "Resultat",
+            "description": ""
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "text": "CDS Q1"
+          },
+          "gt0022": {
+            "id": "gt0022",
+            "text": "CDS Q2"
+          },
+          "gt0023": {
+            "id": "gt0023",
+            "text": "CDS Q3"
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "text": "Beräkna resultat"
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "text": "CDS Q4"
+          },
+          "gt0026": {
+            "id": "gt0026",
+            "text": "CDS Q5"
+          },
+          "gt0027": {
+            "id": "gt0027",
+            "text": "CDS Q6"
+          },
+          "gt0028": {
+            "id": "gt0028",
+            "text": "CDS Q7"
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "text": "CDS Q8"
+          },
+          "gt0030": {
+            "id": "gt0030",
+            "text": "CDS standard"
+          },
+          "gt0033": {
+            "id": "gt0033",
+            "text": "Ömhet höger fossa?",
+            "description": ""
+          },
+          "gt0034": {
+            "id": "gt0034",
+            "text": "Förhöjd temperatur (>37.3°C eller 99.1°F)?",
+            "description": ""
+          },
+          "gt0035": {
+            "id": "gt0035",
+            "text": "Släppömhet?",
+            "description": ""
+          },
+          "gt0036": {
+            "id": "gt0036",
+            "text": "Smärtvandring till höger fossa?",
+            "description": ""
+          },
+          "gt0037": {
+            "id": "gt0037",
+            "text": "Anorexi eller aptitlöshet?",
+            "description": ""
+          },
+          "gt0038": {
+            "id": "gt0038",
+            "text": "Illamående eller kräkning?",
+            "description": ""
+          },
+          "gt0039": {
+            "id": "gt0039",
+            "text": "Ömhet höger fossa?",
+            "description": ""
+          },
+          "gt0040": {
+            "id": "gt0040",
+            "text": "Förhöjd temperatur (>37.3°C eller 99.1°F)?",
+            "description": ""
+          },
+          "gt0041": {
+            "id": "gt0041",
+            "text": "Släppömhet?",
+            "description": ""
+          },
+          "gt0042": {
+            "id": "gt0042",
+            "text": "Smärtvandring till höger fossa?",
+            "description": ""
+          },
+          "gt0043": {
+            "id": "gt0043",
+            "text": "Anorexi eller aptitlöshet?",
+            "description": ""
+          },
+          "gt0044": {
+            "id": "gt0044",
+            "text": "LPK > 10,000?",
+            "description": ""
+          },
+          "gt0045": {
+            "id": "gt0045",
+            "text": "Vänsterförskjuten diff?",
+            "description": ""
+          },
+          "gt0046": {
+            "id": "gt0046",
+            "text": "Illamående eller kräkning?",
+            "description": ""
+          },
+          "gt0047": {
+            "id": "gt0047",
+            "text": "LPK > 10,000?",
+            "description": ""
+          },
+          "gt0048": {
+            "id": "gt0048",
+            "text": "Vänsterförskjuten diff?",
+            "description": ""
+          },
+          "gt0049": {
+            "id": "gt0049",
+            "text": "Resultat",
+            "description": "Summan av samtliga faktorer"
+          },
+          "gt0050": {
+            "id": "gt0050",
+            "text": "CDS Q1"
+          },
+          "gt0051": {
+            "id": "gt0051",
+            "text": "CDS Q2"
+          },
+          "gt0052": {
+            "id": "gt0052",
+            "text": "CDS Q3"
+          },
+          "gt0053": {
+            "id": "gt0053",
+            "text": "CDS Q4"
+          },
+          "gt0054": {
+            "id": "gt0054",
+            "text": "CDS Q5"
+          },
+          "gt0055": {
+            "id": "gt0055",
+            "text": "CDS Q6"
+          },
+          "gt0056": {
+            "id": "gt0056",
+            "text": "CDS Q7"
+          },
+          "gt0057": {
+            "id": "gt0057",
+            "text": "CDS Q8"
+          },
+          "gt0058": {
+            "id": "gt0058",
+            "text": "Resultat"
+          },
+          "gt0059": {
+            "id": "gt0059",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      },
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Alvarado Score",
+            "description": "The Alvarado score was developed to assist in diagnosing appendicitis. A score ≤3p indicates low probability of appendicitis, whereas a CT scan is recommended for scores 4-6p. ≥7 warrants surgical consultation.\n"
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "Right Lower Quadrant Tenderness?",
+            "description": "Score 2 if positive"
+          },
+          "gt0004": {
+            "id": "gt0004",
+            "text": "Elevated Temperature (>37.3°C or 99.1°F)?",
+            "description": "Score 1 if positive"
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Rebound Tenderness?",
+            "description": "Score 1 if positive"
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Migration of Pain to the Right Lower Quadrant?",
+            "description": "Score 1 if positive"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Anorexia?",
+            "description": "Score 1 if positive"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Nausea or Vomiting?",
+            "description": "Score 1 if positive"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Leukocytosis > 10,000?",
+            "description": "Score 2 if positive"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Leukocyte Left Shift",
+            "description": "Score 1 if positive"
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "Right Lower Quadrant Tenderness?",
+            "description": "Score 2 if positive"
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "Elevated Temperature (>37.3°C or 99.1°F)?",
+            "description": "Score 1 if positive"
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "Rebound Tenderness?",
+            "description": "Score 1 if positive"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "Migration of Pain to the Right Lower Quadrant?",
+            "description": "Score 1 if positive"
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "Anorexia?",
+            "description": "Score 1 if positive"
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "text": "Nausea or Vomiting?",
+            "description": "Score 1 if positive"
+          },
+          "gt0018": {
+            "id": "gt0018",
+            "text": "Leukocytosis > 10,000?",
+            "description": "Score 2 if positive"
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "text": "Leukocyte Left Shift",
+            "description": "Score 1 if positive"
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "Total score",
+            "description": "*"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "text": "Set Q1"
+          },
+          "gt0022": {
+            "id": "gt0022",
+            "text": "Set Q2"
+          },
+          "gt0023": {
+            "id": "gt0023",
+            "text": "Set Q3"
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "text": "Calculate total score"
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "text": "Set Q4"
+          },
+          "gt0026": {
+            "id": "gt0026",
+            "text": "Set Q5"
+          },
+          "gt0027": {
+            "id": "gt0027",
+            "text": "Set Q6"
+          },
+          "gt0028": {
+            "id": "gt0028",
+            "text": "Set Q7"
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "text": "Set Q8"
+          },
+          "gt0030": {
+            "id": "gt0030",
+            "text": "Default"
+          },
+          "gt0033": {
+            "id": "gt0033",
+            "text": "Right Lower Quadrant Tenderness?",
+            "description": "Score 2 if positive"
+          },
+          "gt0034": {
+            "id": "gt0034",
+            "text": "Elevated Temperature (>37.3°C or 99.1°F)?",
+            "description": "Score 1 if positive"
+          },
+          "gt0035": {
+            "id": "gt0035",
+            "text": "Rebound Tenderness?",
+            "description": "Score 1 if positive"
+          },
+          "gt0036": {
+            "id": "gt0036",
+            "text": "Migration of Pain to the Right Lower Quadrant?",
+            "description": "Score 1 if positive"
+          },
+          "gt0037": {
+            "id": "gt0037",
+            "text": "Anorexia?",
+            "description": "Score 1 if positive"
+          },
+          "gt0038": {
+            "id": "gt0038",
+            "text": "Nausea or Vomiting?",
+            "description": "Score 1 if positive"
+          },
+          "gt0039": {
+            "id": "gt0039",
+            "text": "Right Lower Quadrant Tenderness?",
+            "description": "Score 2 if positive"
+          },
+          "gt0040": {
+            "id": "gt0040",
+            "text": "Elevated Temperature (>37.3°C or 99.1°F)?",
+            "description": "Score 1 if positive"
+          },
+          "gt0041": {
+            "id": "gt0041",
+            "text": "Rebound Tenderness?",
+            "description": "Score 1 if positive"
+          },
+          "gt0042": {
+            "id": "gt0042",
+            "text": "Migration of Pain to the Right Lower Quadrant?",
+            "description": "Score 1 if positive"
+          },
+          "gt0043": {
+            "id": "gt0043",
+            "text": "Anorexia?",
+            "description": "Score 1 if positive"
+          },
+          "gt0044": {
+            "id": "gt0044",
+            "text": "Leukocytosis > 10,000?",
+            "description": "Score 2 if positive"
+          },
+          "gt0045": {
+            "id": "gt0045",
+            "text": "Leukocyte Left Shift",
+            "description": "Score 1 if positive"
+          },
+          "gt0046": {
+            "id": "gt0046",
+            "text": "Nausea or Vomiting?",
+            "description": "Score 1 if positive"
+          },
+          "gt0047": {
+            "id": "gt0047",
+            "text": "Leukocytosis > 10,000?",
+            "description": "Score 2 if positive"
+          },
+          "gt0048": {
+            "id": "gt0048",
+            "text": "Leukocyte Left Shift",
+            "description": "Score 1 if positive"
+          },
+          "gt0049": {
+            "id": "gt0049",
+            "text": "Total score",
+            "description": "All components are summed together for a total score"
+          },
+          "gt0050": {
+            "id": "gt0050",
+            "text": "Set Q1"
+          },
+          "gt0051": {
+            "id": "gt0051",
+            "text": "Set Q2"
+          },
+          "gt0052": {
+            "id": "gt0052",
+            "text": "Set Q3"
+          },
+          "gt0053": {
+            "id": "gt0053",
+            "text": "Set Q4"
+          },
+          "gt0054": {
+            "id": "gt0054",
+            "text": "Set Q5"
+          },
+          "gt0055": {
+            "id": "gt0055",
+            "text": "Set Q6"
+          },
+          "gt0056": {
+            "id": "gt0056",
+            "text": "Set Q7"
+          },
+          "gt0057": {
+            "id": "gt0057",
+            "text": "Set Q8"
+          },
+          "gt0058": {
+            "id": "gt0058",
+            "text": "Total score"
+          },
+          "gt0059": {
+            "id": "gt0059",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/Alvarado.v1.test.yml
+++ b/gdl2/Alvarado.v1.test.yml
@@ -1,0 +1,268 @@
+guidelines:
+  1: Alvarado.v1
+test_cases:
+- id: default
+  input:
+    1: {}
+  expected_output:
+    1:
+      gt0046|Nausea or Vomiting?: 0|local::at0024|No|
+      gt0043|Anorexia?: 0|local::at0022|No|
+      gt0040|Elevated Temperature (>37.3°C or 99.1°F)?: 0|local::at0016|No|
+      gt0047|Leukocytosis > 10,000?: 0|local::at0026|No|
+      gt0042|Migration of Pain to the Right Lower Quadrant?: 0|local::at0020|No|
+      gt0041|Rebound Tenderness?: 0|local::at0018|No|
+      gt0048|Leukocyte Left Shift: 0|local::at0028|No|
+      gt0039|Right Lower Quadrant Tenderness?: 0|local::at0014|No|
+      gt0049|Total score: 0
+
+
+- id: RLQ(0)-temp(0)-tenderness(0)-pain(0)-anorexia(0)-nausea(0)-leukocytosis(0)-LLS(0)
+  input:
+    1:
+      gt0033|Right Lower Quadrant Tenderness?: 0|local::at0014|No|
+      gt0034|Elevated Temperature (>37.3°C or 99.1°F)?: 0|local::at0016|No|
+      gt0035|Rebound Tenderness?: 0|local::at0018|No|
+      gt0036|Migration of Pain to the Right Lower Quadrant?: 0|local::at0020|No|
+      gt0037|Anorexia?: 0|local::at0022|No|
+      gt0038|Nausea or Vomiting?: 0|local::at0024|No|
+      gt0044|Leukocytosis > 10,000?: 0|local::at0026|No|
+      gt0045|Leukocyte Left Shift: 0|local::at0028|No|
+      gt0059|Event time: 2019-03-23T15:24Z
+  expected_output:
+    1:
+      gt0046|Nausea or Vomiting?: 0|local::at0024|No|
+      gt0043|Anorexia?: 0|local::at0022|No|
+      gt0040|Elevated Temperature (>37.3°C or 99.1°F)?: 0|local::at0016|No|
+      gt0047|Leukocytosis > 10,000?: 0|local::at0026|No|
+      gt0042|Migration of Pain to the Right Lower Quadrant?: 0|local::at0020|No|
+      gt0041|Rebound Tenderness?: 0|local::at0018|No|
+      gt0048|Leukocyte Left Shift: 0|local::at0028|No|
+      gt0039|Right Lower Quadrant Tenderness?: 0|local::at0014|No|
+      gt0049|Total score: 0
+
+
+- id: RLQ(2)-temp(0)-tenderness(0)-pain(0)-anorexia(0)-nausea(0)-leukocytosis(0)-LLS(0)
+  input:
+    1:
+      gt0033|Right Lower Quadrant Tenderness?: 2|local::at0015|Yes|
+      gt0034|Elevated Temperature (>37.3°C or 99.1°F)?: 0|local::at0016|No|
+      gt0035|Rebound Tenderness?: 0|local::at0018|No|
+      gt0036|Migration of Pain to the Right Lower Quadrant?: 0|local::at0020|No|
+      gt0037|Anorexia?: 0|local::at0022|No|
+      gt0038|Nausea or Vomiting?: 0|local::at0024|No|
+      gt0044|Leukocytosis > 10,000?: 0|local::at0026|No|
+      gt0045|Leukocyte Left Shift: 0|local::at0028|No|
+      gt0059|Event time: 2019-03-23T15:27Z
+  expected_output:
+    1:
+      gt0046|Nausea or Vomiting?: 0|local::at0024|No|
+      gt0043|Anorexia?: 0|local::at0022|No|
+      gt0040|Elevated Temperature (>37.3°C or 99.1°F)?: 0|local::at0016|No|
+      gt0047|Leukocytosis > 10,000?: 0|local::at0026|No|
+      gt0042|Migration of Pain to the Right Lower Quadrant?: 0|local::at0020|No|
+      gt0041|Rebound Tenderness?: 0|local::at0018|No|
+      gt0048|Leukocyte Left Shift: 0|local::at0028|No|
+      gt0039|Right Lower Quadrant Tenderness?: 2|local::at0015|Yes|
+      gt0049|Total score: 2
+
+
+- id: RLQ(2)-temp(1)-tenderness(0)-pain(0)-anorexia(0)-nausea(0)-leukocytosis(0)-LLS(0)
+  input:
+    1:
+      gt0033|Right Lower Quadrant Tenderness?: 2|local::at0015|Yes|
+      gt0034|Elevated Temperature (>37.3°C or 99.1°F)?: 1|local::at0017|Yes|
+      gt0035|Rebound Tenderness?: 0|local::at0018|No|
+      gt0036|Migration of Pain to the Right Lower Quadrant?: 0|local::at0020|No|
+      gt0037|Anorexia?: 0|local::at0022|No|
+      gt0038|Nausea or Vomiting?: 0|local::at0024|No|
+      gt0044|Leukocytosis > 10,000?: 0|local::at0026|No|
+      gt0045|Leukocyte Left Shift: 0|local::at0028|No|
+      gt0059|Event time: 2019-03-23T15:27Z
+  expected_output:
+    1:
+      gt0046|Nausea or Vomiting?: 0|local::at0024|No|
+      gt0043|Anorexia?: 0|local::at0022|No|
+      gt0040|Elevated Temperature (>37.3°C or 99.1°F)?: 1|local::at0017|Yes|
+      gt0047|Leukocytosis > 10,000?: 0|local::at0026|No|
+      gt0042|Migration of Pain to the Right Lower Quadrant?: 0|local::at0020|No|
+      gt0041|Rebound Tenderness?: 0|local::at0018|No|
+      gt0048|Leukocyte Left Shift: 0|local::at0028|No|
+      gt0039|Right Lower Quadrant Tenderness?: 2|local::at0015|Yes|
+      gt0049|Total score: 3
+
+
+- id: RLQ(2)-temp(1)-tenderness(1)-pain(0)-anorexia(0)-nausea(0)-leukocytosis(0)-LLS(0)
+  input:
+    1:
+      gt0033|Right Lower Quadrant Tenderness?: 2|local::at0015|Yes|
+      gt0034|Elevated Temperature (>37.3°C or 99.1°F)?: 1|local::at0017|Yes|
+      gt0035|Rebound Tenderness?: 1|local::at0019|Yes|
+      gt0036|Migration of Pain to the Right Lower Quadrant?: 0|local::at0020|No|
+      gt0037|Anorexia?: 0|local::at0022|No|
+      gt0038|Nausea or Vomiting?: 0|local::at0024|No|
+      gt0044|Leukocytosis > 10,000?: 0|local::at0026|No|
+      gt0045|Leukocyte Left Shift: 0|local::at0028|No|
+      gt0059|Event time: 2019-03-23T15:27Z
+  expected_output:
+    1:
+      gt0046|Nausea or Vomiting?: 0|local::at0024|No|
+      gt0043|Anorexia?: 0|local::at0022|No|
+      gt0040|Elevated Temperature (>37.3°C or 99.1°F)?: 1|local::at0017|Yes|
+      gt0047|Leukocytosis > 10,000?: 0|local::at0026|No|
+      gt0042|Migration of Pain to the Right Lower Quadrant?: 0|local::at0020|No|
+      gt0041|Rebound Tenderness?: 1|local::at0019|Yes|
+      gt0048|Leukocyte Left Shift: 0|local::at0028|No|
+      gt0039|Right Lower Quadrant Tenderness?: 2|local::at0015|Yes|
+      gt0049|Total score: 4
+
+
+- id: RLQ(2)-temp(1)-tenderness(1)-pain(1)-anorexia(0)-nausea(0)-leukocytosis(0)-LLS(0)
+  input:
+    1:
+      gt0033|Right Lower Quadrant Tenderness?: 2|local::at0015|Yes|
+      gt0034|Elevated Temperature (>37.3°C or 99.1°F)?: 1|local::at0017|Yes|
+      gt0035|Rebound Tenderness?: 1|local::at0019|Yes|
+      gt0036|Migration of Pain to the Right Lower Quadrant?: 1|local::at0021|Yes|
+      gt0037|Anorexia?: 0|local::at0022|No|
+      gt0038|Nausea or Vomiting?: 0|local::at0024|No|
+      gt0044|Leukocytosis > 10,000?: 0|local::at0026|No|
+      gt0045|Leukocyte Left Shift: 0|local::at0028|No|
+      gt0059|Event time: 2019-03-23T15:27Z
+  expected_output:
+    1:
+      gt0046|Nausea or Vomiting?: 0|local::at0024|No|
+      gt0043|Anorexia?: 0|local::at0022|No|
+      gt0040|Elevated Temperature (>37.3°C or 99.1°F)?: 1|local::at0017|Yes|
+      gt0047|Leukocytosis > 10,000?: 0|local::at0026|No|
+      gt0042|Migration of Pain to the Right Lower Quadrant?: 1|local::at0021|Yes|
+      gt0041|Rebound Tenderness?: 1|local::at0019|Yes|
+      gt0048|Leukocyte Left Shift: 0|local::at0028|No|
+      gt0039|Right Lower Quadrant Tenderness?: 2|local::at0015|Yes|
+      gt0049|Total score: 5
+
+
+- id: RLQ(2)-temp(1)-tenderness(1)-pain(1)-anorexia(1)-nausea(0)-leukocytosis(0)-LLS(0)
+  input:
+    1:
+      gt0033|Right Lower Quadrant Tenderness?: 2|local::at0015|Yes|
+      gt0034|Elevated Temperature (>37.3°C or 99.1°F)?: 1|local::at0017|Yes|
+      gt0035|Rebound Tenderness?: 1|local::at0019|Yes|
+      gt0036|Migration of Pain to the Right Lower Quadrant?: 1|local::at0021|Yes|
+      gt0037|Anorexia?: 1|local::at0023|Yes|
+      gt0038|Nausea or Vomiting?: 0|local::at0024|No|
+      gt0044|Leukocytosis > 10,000?: 0|local::at0026|No|
+      gt0045|Leukocyte Left Shift: 0|local::at0028|No|
+      gt0059|Event time: 2019-03-23T15:27Z
+  expected_output:
+    1:
+      gt0046|Nausea or Vomiting?: 0|local::at0024|No|
+      gt0043|Anorexia?: 1|local::at0023|Yes|
+      gt0040|Elevated Temperature (>37.3°C or 99.1°F)?: 1|local::at0017|Yes|
+      gt0047|Leukocytosis > 10,000?: 0|local::at0026|No|
+      gt0042|Migration of Pain to the Right Lower Quadrant?: 1|local::at0021|Yes|
+      gt0041|Rebound Tenderness?: 1|local::at0019|Yes|
+      gt0048|Leukocyte Left Shift: 0|local::at0028|No|
+      gt0039|Right Lower Quadrant Tenderness?: 2|local::at0015|Yes|
+      gt0049|Total score: 6
+
+
+- id: RLQ(2)-temp(1)-tenderness(1)-pain(1)-anorexia(1)-nausea(1)-leukocytosis(0)-LLS(0)
+  input:
+    1:
+      gt0033|Right Lower Quadrant Tenderness?: 2|local::at0015|Yes|
+      gt0034|Elevated Temperature (>37.3°C or 99.1°F)?: 1|local::at0017|Yes|
+      gt0035|Rebound Tenderness?: 1|local::at0019|Yes|
+      gt0036|Migration of Pain to the Right Lower Quadrant?: 1|local::at0021|Yes|
+      gt0037|Anorexia?: 1|local::at0023|Yes|
+      gt0038|Nausea or Vomiting?: 1|local::at0025|Yes|
+      gt0044|Leukocytosis > 10,000?: 0|local::at0026|No|
+      gt0045|Leukocyte Left Shift: 0|local::at0028|No|
+      gt0059|Event time: 2019-03-23T15:27Z
+  expected_output:
+    1:
+      gt0046|Nausea or Vomiting?: 1|local::at0025|Yes|
+      gt0043|Anorexia?: 1|local::at0023|Yes|
+      gt0040|Elevated Temperature (>37.3°C or 99.1°F)?: 1|local::at0017|Yes|
+      gt0047|Leukocytosis > 10,000?: 0|local::at0026|No|
+      gt0042|Migration of Pain to the Right Lower Quadrant?: 1|local::at0021|Yes|
+      gt0041|Rebound Tenderness?: 1|local::at0019|Yes|
+      gt0048|Leukocyte Left Shift: 0|local::at0028|No|
+      gt0039|Right Lower Quadrant Tenderness?: 2|local::at0015|Yes|
+      gt0049|Total score: 7
+
+
+- id: RLQ(2)-temp(1)-tenderness(1)-pain(1)-anorexia(1)-nausea(1)-leukocytosis(0)-LLS(1)
+  input:
+    1:
+      gt0033|Right Lower Quadrant Tenderness?: 2|local::at0015|Yes|
+      gt0034|Elevated Temperature (>37.3°C or 99.1°F)?: 1|local::at0017|Yes|
+      gt0035|Rebound Tenderness?: 1|local::at0019|Yes|
+      gt0036|Migration of Pain to the Right Lower Quadrant?: 1|local::at0021|Yes|
+      gt0037|Anorexia?: 1|local::at0023|Yes|
+      gt0038|Nausea or Vomiting?: 1|local::at0025|Yes|
+      gt0044|Leukocytosis > 10,000?: 0|local::at0026|No|
+      gt0045|Leukocyte Left Shift: 1|local::at0029|Yes|
+      gt0059|Event time: 2019-03-23T15:27Z
+  expected_output:
+    1:
+      gt0046|Nausea or Vomiting?: 1|local::at0025|Yes|
+      gt0043|Anorexia?: 1|local::at0023|Yes|
+      gt0040|Elevated Temperature (>37.3°C or 99.1°F)?: 1|local::at0017|Yes|
+      gt0047|Leukocytosis > 10,000?: 0|local::at0026|No|
+      gt0042|Migration of Pain to the Right Lower Quadrant?: 1|local::at0021|Yes|
+      gt0041|Rebound Tenderness?: 1|local::at0019|Yes|
+      gt0048|Leukocyte Left Shift: 1|local::at0029|Yes|
+      gt0039|Right Lower Quadrant Tenderness?: 2|local::at0015|Yes|
+      gt0049|Total score: 8
+
+
+- id: RLQ(2)-temp(1)-tenderness(1)-pain(1)-anorexia(1)-nausea(1)-leukocytosis(2)-LLS(0)
+  input:
+    1:
+      gt0033|Right Lower Quadrant Tenderness?: 2|local::at0015|Yes|
+      gt0034|Elevated Temperature (>37.3°C or 99.1°F)?: 1|local::at0017|Yes|
+      gt0035|Rebound Tenderness?: 1|local::at0019|Yes|
+      gt0036|Migration of Pain to the Right Lower Quadrant?: 1|local::at0021|Yes|
+      gt0037|Anorexia?: 1|local::at0023|Yes|
+      gt0038|Nausea or Vomiting?: 1|local::at0025|Yes|
+      gt0044|Leukocytosis > 10,000?: 2|local::at0027|Yes|
+      gt0045|Leukocyte Left Shift: 0|local::at0028|No|
+      gt0059|Event time: 2019-03-23T15:27Z
+  expected_output:
+    1:
+      gt0046|Nausea or Vomiting?: 1|local::at0025|Yes|
+      gt0043|Anorexia?: 1|local::at0023|Yes|
+      gt0040|Elevated Temperature (>37.3°C or 99.1°F)?: 1|local::at0017|Yes|
+      gt0047|Leukocytosis > 10,000?: 2|local::at0027|Yes|
+      gt0042|Migration of Pain to the Right Lower Quadrant?: 1|local::at0021|Yes|
+      gt0041|Rebound Tenderness?: 1|local::at0019|Yes|
+      gt0048|Leukocyte Left Shift: 0|local::at0028|No|
+      gt0039|Right Lower Quadrant Tenderness?: 2|local::at0015|Yes|
+      gt0049|Total score: 9
+
+
+- id: RLQ(2)-temp(1)-tenderness(1)-pain(1)-anorexia(1)-nausea(1)-leukocytosis(2)-LLS(1)
+  input:
+    1:
+      gt0033|Right Lower Quadrant Tenderness?: 2|local::at0015|Yes|
+      gt0034|Elevated Temperature (>37.3°C or 99.1°F)?: 1|local::at0017|Yes|
+      gt0035|Rebound Tenderness?: 1|local::at0019|Yes|
+      gt0036|Migration of Pain to the Right Lower Quadrant?: 1|local::at0021|Yes|
+      gt0037|Anorexia?: 1|local::at0023|Yes|
+      gt0038|Nausea or Vomiting?: 1|local::at0025|Yes|
+      gt0044|Leukocytosis > 10,000?: 2|local::at0027|Yes|
+      gt0045|Leukocyte Left Shift: 1|local::at0029|Yes|
+      gt0059|Event time: 2019-03-23T15:27Z
+  expected_output:
+    1:
+      gt0046|Nausea or Vomiting?: 1|local::at0025|Yes|
+      gt0043|Anorexia?: 1|local::at0023|Yes|
+      gt0040|Elevated Temperature (>37.3°C or 99.1°F)?: 1|local::at0017|Yes|
+      gt0047|Leukocytosis > 10,000?: 2|local::at0027|Yes|
+      gt0042|Migration of Pain to the Right Lower Quadrant?: 1|local::at0021|Yes|
+      gt0041|Rebound Tenderness?: 1|local::at0019|Yes|
+      gt0048|Leukocyte Left Shift: 1|local::at0029|Yes|
+      gt0039|Right Lower Quadrant Tenderness?: 2|local::at0015|Yes|
+      gt0049|Total score: 10
+

--- a/gdl2/Alvarado_Assessment.v1.gdl2.json
+++ b/gdl2/Alvarado_Assessment.v1.gdl2.json
@@ -1,0 +1,138 @@
+{
+  "id": "Alvarado_Assessment.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2017-02-28",
+      "name": "Syeeda S Farruque",
+      "organisation": "Cambio Healthcare Systems"
+    },
+    "lifecycle_state": "Not set",
+    "details": {
+      "en": {
+        "id": "en",
+        "purpose": "The Alvarado score was developed to assist in diagnosing appendicitis.",
+        "keywords": [
+          "Alvarado appendicitis",
+          "acute appendicitis"
+        ],
+        "use": "Score interpretation and recommended action:\n\n- A CT scan is recommended for scores 4-6 \n- A surgical consultation for scores  ≥ 7. \n- For scores  ≤ 3: a CT scan is not needed due to the low probability of appendicitis.",
+        "misuse": "This tool depends on a thorough clinical assessment made by the physician and care team and should only be used to assist diagnosis.",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Ref. 1: Alvarado A. A practical score for the early diagnosis of acute appendicitis. Ann Emerg Med. 1986; 15(5): 557-64. \n\nRef. 2: McKay R, Shepherd J. The use of the clinical scoring system by Alvarado in the decision to perform computed tomography for acute appendicitis in the ED. Am J Emerg Med. 2007; 25(5): 489-93."
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0004": {
+        "id": "gt0004",
+        "model_id": "openEHR-EHR-OBSERVATION.alvarado_score.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.alvarado_score.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0005": {
+            "id": "gt0005",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0012]"
+          }
+        }
+      },
+      "gt0006": {
+        "id": "gt0006",
+        "model_id": "openEHR-EHR-EVALUATION.alvarado_appendicitis_assessment.v1",
+        "template_id": "openEHR-EHR-EVALUATION.alvarado_appendicitis_assessment.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0007": {
+            "id": "gt0007",
+            "path": "/data[at0001]/items[at0002]"
+          }
+        }
+      }
+    },
+    "rules": {
+      "gt0009": {
+        "id": "gt0009",
+        "priority": 3,
+        "when": [
+          "$gt0005|Total score|<=3"
+        ],
+        "then": [
+          "$gt0007|Score recommendation|=0|local::at0003|A CT scan is not needed due to the low probability of appendicitis.\n\n|"
+        ]
+      },
+      "gt0010": {
+        "id": "gt0010",
+        "priority": 2,
+        "when": [
+          "$gt0005|Total score|<=6",
+          "$gt0005|Total score|>=4"
+        ],
+        "then": [
+          "$gt0007|Score recommendation|=1|local::at0004|A CT scan is recommended |"
+        ]
+      },
+      "gt0011": {
+        "id": "gt0011",
+        "priority": 1,
+        "when": [
+          "$gt0005|Total score|>=7"
+        ],
+        "then": [
+          "$gt0007|Score recommendation|=2|local::at0005|A surgical consultation is needed|"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Alvarado Assessment",
+            "description": "The Alvarado score was developed to assist in diagnosing appendicitis."
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "Total score",
+            "description": "All components are summed together for a total score"
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Total score",
+            "description": "All components are summed together for a total score"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Score recommendation",
+            "description": "Score interpretation and recommended action:"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "total score"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Recommendation: No CT scan needed"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Recommendation: CT scan needed"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Recommendation: Surgical consultation needed"
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/Alvarado_Assessment.v1.test.yml
+++ b/gdl2/Alvarado_Assessment.v1.test.yml
@@ -1,0 +1,94 @@
+guidelines:
+  1: Alvarado_Assessment.v1
+test_cases:
+- id: total_score(0)
+  input:
+    1:
+      gt0005|Total score: 0
+  expected_output:
+    1:
+      gt0007|Score recommendation: 0|local::at0003|A CT scan is not needed due to the low probability of appendicitis. |
+
+- id: total_score(1)
+  input:
+    1:
+      gt0005|Total score: 0
+  expected_output:
+    1:
+      gt0007|Score recommendation: 0|local::at0003|A CT scan is not needed due to the low probability of appendicitis. |
+
+- id: total_score(2)
+  input:
+    1:
+      gt0005|Total score: 2
+  expected_output:
+    1:
+      gt0007|Score recommendation: 0|local::at0003|A CT scan is not needed due to the low probability of appendicitis. |
+
+- id: total_score(3)
+  input:
+    1:
+      gt0005|Total score: 3
+  expected_output:
+    1:
+      gt0007|Score recommendation: 0|local::at0003|A CT scan is not needed due to the low probability of appendicitis. |
+
+- id: total_score(4)
+  input:
+    1:
+      gt0005|Total score: 4
+  expected_output:
+    1:
+      gt0007|Score recommendation: 1|local::at0004|A CT scan is recommended |
+
+- id: total_score(5)
+  input:
+    1:
+      gt0005|Total score: 5
+  expected_output:
+    1:
+      gt0007|Score recommendation: 1|local::at0004|A CT scan is recommended |
+
+- id: total_score(6)
+  input:
+    1:
+      gt0005|Total score: 6
+  expected_output:
+    1:
+      gt0007|Score recommendation: 1|local::at0004|A CT scan is recommended |
+
+- id: total_score(7)
+  input:
+    1:
+      gt0005|Total score: 7
+  expected_output:
+    1:
+      gt0007|Score recommendation: 2|local::at0005|A surgical consultation is needed|
+
+
+- id: total_score(8)
+  input:
+    1:
+      gt0005|Total score: 8
+  expected_output:
+    1:
+      gt0007|Score recommendation: 2|local::at0005|A surgical consultation is needed|
+
+
+- id: total_score(9)
+  input:
+    1:
+      gt0005|Total score: 9
+  expected_output:
+    1:
+      gt0007|Score recommendation: 2|local::at0005|A surgical consultation is needed|
+
+
+- id: total_score(10)
+  input:
+    1:
+      gt0005|Total score: 10
+  expected_output:
+    1:
+      gt0007|Score recommendation: 2|local::at0005|A surgical consultation is needed|
+

--- a/gdl2/Alvarado_Assessment.v1.test.yml
+++ b/gdl2/Alvarado_Assessment.v1.test.yml
@@ -7,7 +7,7 @@ test_cases:
       gt0005|Total score: 0
   expected_output:
     1:
-      gt0007|Score recommendation: 0|local::at0003|A CT scan is not needed due to the low probability of appendicitis. |
+      gt0007|Score recommendation: 0|local::at0003|A CT scan is not needed due to the low probability of appendicitis.|
 
 - id: total_score(1)
   input:
@@ -15,7 +15,7 @@ test_cases:
       gt0005|Total score: 0
   expected_output:
     1:
-      gt0007|Score recommendation: 0|local::at0003|A CT scan is not needed due to the low probability of appendicitis. |
+      gt0007|Score recommendation: 0|local::at0003|A CT scan is not needed due to the low probability of appendicitis.|
 
 - id: total_score(2)
   input:
@@ -23,7 +23,7 @@ test_cases:
       gt0005|Total score: 2
   expected_output:
     1:
-      gt0007|Score recommendation: 0|local::at0003|A CT scan is not needed due to the low probability of appendicitis. |
+      gt0007|Score recommendation: 0|local::at0003|A CT scan is not needed due to the low probability of appendicitis.|
 
 - id: total_score(3)
   input:
@@ -31,7 +31,7 @@ test_cases:
       gt0005|Total score: 3
   expected_output:
     1:
-      gt0007|Score recommendation: 0|local::at0003|A CT scan is not needed due to the low probability of appendicitis. |
+      gt0007|Score recommendation: 0|local::at0003|A CT scan is not needed due to the low probability of appendicitis.|
 
 - id: total_score(4)
   input:


### PR DESCRIPTION
Dear Isabelle, this branch contains the migrated Alvarado and Alvarado assessment files along with their test fixtures. Both app runs fine, however, for "Alvarado_Assessment" test fixtures, I found an error: 

For case total_score(0) until total_score(3), I've matched the result: "0|local::at0003|A CT scan is not needed due to the low probability of appendicitis. |" according to the test fixtures "Actual value", but it is still failed. 

I think it's something to do with the result from the execution tab, which shows "0|local::at0003|A CT scan is not needed due to the low probability of appendicitis.\n\n|", where "\n" means a new line. The test fixture is probably confused because there shouldn't be a new line there. 

For other cases, it runs just fine. Kindly please check and review it. Thank you. 