### PR TITLE
Migrated calculated_age.v1

### DIFF
--- a/gdl2/Calculated_age.v1.0.0.gdl2.json
+++ b/gdl2/Calculated_age.v1.0.0.gdl2.json
@@ -1,0 +1,107 @@
+{
+  "id": "Calculated_age.v1.0.0",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2019-03-26",
+      "name": "Rong Chen"
+    },
+    "lifecycle_state": "Not set",
+    "details": {
+      "en": {
+        "id": "en",
+        "keywords": [
+          "age"
+        ]
+      }
+    },
+    "other_details": {}
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0002": {
+        "id": "gt0002",
+        "model_id": "openEHR-EHR-OBSERVATION.basic_demographic.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.basic_demographic.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0003": {
+            "id": "gt0003",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0008]"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0004": {
+        "id": "gt0004",
+        "model_id": "openEHR-EHR-OBSERVATION.basic_demographic.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.basic_demographic.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0005": {
+            "id": "gt0005",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0013]"
+          }
+        }
+      }
+    },
+    "rules": {
+      "gt0006": {
+        "id": "gt0006",
+        "priority": 1,
+        "when": [
+          "$gt0005|Age|==null",
+          "$gt0003|Birthdate|!=null"
+        ],
+        "then": [
+          "$gt0005|Age|.magnitude=($currentDateTime-$gt0003)/1,a",
+          "$gt0005|Age|.precision=0",
+          "$gt0005|Age|.unit='a'"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Calculated age",
+            "description": "Calculate age based on given birth date"
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "Birthdate",
+            "description": "The patient's date of birth."
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Age",
+            "description": "Age in years, and for babies: months, weeks or days"
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Calculate age"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/Calculated_age.v1.0.0.test.yml
+++ b/gdl2/Calculated_age.v1.0.0.test.yml
@@ -13,7 +13,7 @@ test_cases:
 - id: case_2:Age 8
   input:
     1:
-      gt0003|Birthdate: 2010-09-19T11:29Z
+      gt0003|Birthdate: 2010-12-19T11:29Z
       gt0007|Event time: 2019-03-26T11:29Z
   expected_output:
     1:

--- a/gdl2/Calculated_age.v1.0.0.test.yml
+++ b/gdl2/Calculated_age.v1.0.0.test.yml
@@ -1,0 +1,47 @@
+guidelines:
+  1: Calculated_age.v1.0.0
+test_cases:
+- id: case_1:Age 3
+  input:
+    1:
+      gt0003|Birthdate: 2016-03-02T11:29Z
+      gt0007|Event time: 2019-03-26T11:29Z
+  expected_output:
+    1:
+      gt0005|Age: 3,a
+
+- id: case_2:Age 8
+  input:
+    1:
+      gt0003|Birthdate: 2010-09-19T11:29Z
+      gt0007|Event time: 2019-03-26T11:29Z
+  expected_output:
+    1:
+      gt0005|Age: 8,a
+
+- id: case_3:Age 12
+  input:
+    1:
+      gt0003|Birthdate: 2006-12-17T11:29Z
+      gt0007|Event time: 2019-03-26T11:29Z
+  expected_output:
+    1:
+      gt0005|Age: 12,a
+
+- id: case_4:Age 44
+  input:
+    1:
+      gt0003|Birthdate: 1975-04-29T11:29Z
+      gt0007|Event time: 2019-03-26T11:29Z
+  expected_output:
+    1:
+      gt0005|Age: 44,a
+
+- id: case_5:Age103
+  input:
+    1:
+      gt0003|Birthdate: 1916-04-05T11:29Z
+      gt0007|Event time: 2019-03-26T11:29Z
+  expected_output:
+    1:
+      gt0005|Age: 103,a


### PR DESCRIPTION
I have migrated the calculated_age.v1 guideline and text fixture.
Removed the attribute value from the currentDateTime variable, as well as adding event time and function predicate in the input definition entry. 

/Linda