### PR TITLE
Framingham score calculation migrated

### DIFF
--- a/gdl2/Framingham_CHD.v1.gdl2.json
+++ b/gdl2/Framingham_CHD.v1.gdl2.json
@@ -1,0 +1,1818 @@
+{
+  "id": "Framingham_CHD.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2016-02-05",
+      "name": "Syeeda S Farruque",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "other_contributors": [
+      "Dennis Forslund",
+      "Jimmy Axelsson"
+    ],
+    "lifecycle_state": "Author draft",
+    "details": {
+      "en": {
+        "id": "en",
+        "purpose": "This Framingham Risk score is based on the 'Hard' Coronary Framingham outcomes model, which omits co-morbidities and is used to calculate an estimate of the risk of occurence of a heart attack within a 10 year period.\r\n",
+        "keywords": [
+          "framingham CHD risk score",
+          "coronary heart disease"
+        ],
+        "use": "The score is calculated differently between males and females and is based on the total sum of 5 of the 7 individual variables with continuous variables discretized. \r\nThe 2 variables that do not contribute to the score directly, are Sex and whether the patient is on BP medications. The 7 variables are:\r\nAge\r\nSex\r\nSmoker\r\nTotal Cholesterol (norm range: 150-200 mg/dL)\r\nHDL Cholesterol (norm range: 40-80 mg/dL)\r\nSys BP (norm range: 100-120)\r\nBP being treated with medication\r\n\r\nMoreover, the scoring for Total Cholesterol and smoker/non-smoker depends on the age bracket the value falls within and scores for sys BP depends on whether the patient is having their BP treated with medication or not.\r\n\r\nThe scoring system sheets can be seen in (1). Score interpretations can be found in more detail on (2) As example for men:\r\n\r\nScore of 5-6                               Relates to 2% 10 year CHD RIsk\r\nScore of 12                                 Relates to 10% 10 year CHD Risk\r\nScore of ≥17                              Relates to > 30% 10 year CHD Risk",
+        "misuse": "The tool should be used with caution when applied to varying populations (as figures are based on the US population over many years). The tool should also be accompanied by other supporting evidence and clinical judgement when utilising the results.\r\n",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Ref.1: Wilson PW, et. al. Prediction of Coronary Heart Disease Using Risk Factor Categories. Circulation 1998. 97(18): 1837-1847.\r\n\r\nRef. 2: D'Agostino RB, Sr. Vasan RS, Pencina M.J, Wolf PA, Cobain M, Massaro JM, Kannel WB. (2008) General cardiovascular risk profile for use in primary care: the Framingham Heart Study. Circulation 117(6): 743–753."
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0002": {
+        "id": "gt0002",
+        "model_id": "openEHR-EHR-OBSERVATION.basic_demographic.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.basic_demographic.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0003": {
+            "id": "gt0003",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0008]"
+          },
+          "gt0004": {
+            "id": "gt0004",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0004]"
+          },
+          "gt0127": {
+            "id": "gt0127",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0005": {
+        "id": "gt0005",
+        "model_id": "openEHR-EHR-OBSERVATION.basic_demographic.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.basic_demographic.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0006": {
+            "id": "gt0006",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0013]"
+          },
+          "gt0123": {
+            "id": "gt0123",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0004]"
+          }
+        }
+      },
+      "gt0009": {
+        "id": "gt0009",
+        "model_id": "openEHR-EHR-OBSERVATION.blood_pressure.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.blood_pressure.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0010": {
+            "id": "gt0010",
+            "path": "/data[at0001]/events[at0006]/data[at0003]/items[at0004]"
+          },
+          "gt0126": {
+            "id": "gt0126",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0011": {
+        "id": "gt0011",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-lipids.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-lipids.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0012": {
+            "id": "gt0012",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.5]"
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.3]"
+          },
+          "gt0125": {
+            "id": "gt0125",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0014": {
+        "id": "gt0014",
+        "model_id": "openEHR-EHR-OBSERVATION.framingham_chd_risk_score.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.framingham_chd_risk_score.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0015": {
+            "id": "gt0015",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0105]"
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0010]"
+          },
+          "gt0124": {
+            "id": "gt0124",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0017": {
+        "id": "gt0017",
+        "model_id": "openEHR-EHR-OBSERVATION.framingham_chd_risk_score.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.framingham_chd_risk_score.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0018": {
+            "id": "gt0018",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0004]"
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0056]"
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0006]"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0057]"
+          },
+          "gt0022": {
+            "id": "gt0022",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0007]"
+          },
+          "gt0023": {
+            "id": "gt0023",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0058]"
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0008]"
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0010]"
+          },
+          "gt0030": {
+            "id": "gt0030",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0011]"
+          },
+          "gt0031": {
+            "id": "gt0031",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0055]"
+          },
+          "gt0036": {
+            "id": "gt0036",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0105]"
+          },
+          "gt0075": {
+            "id": "gt0075",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0009]"
+          },
+          "gt0076": {
+            "id": "gt0076",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0094]"
+          }
+        }
+      }
+    },
+    "rules": {
+      "gt0032": {
+        "id": "gt0032",
+        "priority": 73,
+        "when": [
+          "$gt0075|Systolic BP: men|==null",
+          "$gt0076|Systolic BP: women|==null",
+          "$gt0036|Smoker|==null",
+          "$gt0029|Blood Pressure treated with medication|==null",
+          "$gt0018|Age variable: men|==null",
+          "$gt0019|Age variable: women|==null",
+          "$gt0020|Smoker: men|==null",
+          "$gt0021|Smoker: women|==null",
+          "$gt0022|Total Cholesterol: men|==null",
+          "$gt0023|Total Cholesterol: women|==null",
+          "$gt0024|HDL Cholesterol: men and women|==null"
+        ],
+        "then": [
+          "$gt0076|Systolic BP: women|=0|local::at0100|< 120|",
+          "$gt0075|Systolic BP: men|=0|local::at0046|< 120 or 120-129 if untreated|",
+          "$gt0036|Smoker|=0|local::at0106|No|",
+          "$gt0029|Blood Pressure treated with medication|=0|local::at0053|No|",
+          "$gt0018|Age variable: men|=0|local::at0017|40-44|",
+          "$gt0019|Age variable: women|=0|local::at0061|40-44|",
+          "$gt0020|Smoker: men|=0|local::at0034|Non-smoker |",
+          "$gt0021|Smoker: women|=0|local::at0069|Non smoker|",
+          "$gt0022|Total Cholesterol: men|=0|local::at0023|< 160 |",
+          "$gt0023|Total Cholesterol: women|=0|local::at0076|<160|",
+          "$gt0024|HDL Cholesterol: men and women|=0|local::at0020|50-59|"
+        ]
+      },
+      "gt0033": {
+        "id": "gt0033",
+        "priority": 72,
+        "when": [
+          "$gt0003|Birthdate|!=null"
+        ],
+        "then": [
+          "$gt0006|Age|.magnitude=$currentDateTime.year-$gt0003.year",
+          "$gt0006|Age|.unit='a'"
+        ]
+      },
+      "gt0034": {
+        "id": "gt0034",
+        "priority": 71,
+        "when": [
+          "$gt0015|Smoker|!=null",
+          "$gt0004|Gender|!=null",
+          "$gt0004|Gender|==local::at0005|Male|",
+          "$gt0015|Smoker|==0|local::at0106|No|"
+        ],
+        "then": [
+          "$gt0036|Smoker|=0|local::at0106|No|",
+          "$gt0020|Smoker: men|=0|local::at0034|Non-smoker |"
+        ]
+      },
+      "gt0035": {
+        "id": "gt0035",
+        "priority": 70,
+        "when": [
+          "$gt0015|Smoker|!=null",
+          "$gt0004|Gender|!=null",
+          "fired($gt0033)",
+          "$gt0006|Age|<=79,a",
+          "$gt0006|Age|>=60,a",
+          "$gt0015|Smoker|==1|local::at0107|Yes|",
+          "$gt0004|Gender|==local::at0005|Male|"
+        ],
+        "then": [
+          "$gt0036|Smoker|=1|local::at0107|Yes|",
+          "$gt0020|Smoker: men|=1|local::at0035|Smoker - 60-79|"
+        ]
+      },
+      "gt0037": {
+        "id": "gt0037",
+        "priority": 69,
+        "when": [
+          "$gt0015|Smoker|!=null",
+          "fired($gt0033)",
+          "$gt0004|Gender|!=null",
+          "$gt0004|Gender|==local::at0005|Male|",
+          "$gt0015|Smoker|==1|local::at0107|Yes|",
+          "$gt0006|Age|>=50,a",
+          "$gt0006|Age|<=59,a"
+        ],
+        "then": [
+          "$gt0020|Smoker: men|=3|local::at0036|Smoker - 50 -59|",
+          "$gt0036|Smoker|=1|local::at0107|Yes|"
+        ]
+      },
+      "gt0039": {
+        "id": "gt0039",
+        "priority": 68,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "fired($gt0033)",
+          "$gt0015|Smoker|!=null",
+          "$gt0015|Smoker|==1|local::at0107|Yes|",
+          "$gt0004|Gender|==local::at0005|Male|",
+          "$gt0006|Age|>=40,a",
+          "$gt0006|Age|<=49,a"
+        ],
+        "then": [
+          "$gt0020|Smoker: men|=5|local::at0037|Smoker - 40-49|",
+          "$gt0036|Smoker|=1|local::at0107|Yes|"
+        ]
+      },
+      "gt0040": {
+        "id": "gt0040",
+        "priority": 67,
+        "when": [
+          "fired($gt0033)",
+          "$gt0004|Gender|!=null",
+          "$gt0015|Smoker|!=null",
+          "$gt0015|Smoker|==1|local::at0107|Yes|",
+          "$gt0004|Gender|==local::at0005|Male|",
+          "$gt0006|Age|<=39,a",
+          "$gt0006|Age|>=20,a"
+        ],
+        "then": [
+          "$gt0020|Smoker: men|=8|local::at0038|Smoker - 20-39|",
+          "$gt0036|Smoker|=1|local::at0107|Yes|"
+        ]
+      },
+      "gt0041": {
+        "id": "gt0041",
+        "priority": 66,
+        "when": [
+          "$gt0015|Smoker|!=null",
+          "$gt0004|Gender|!=null",
+          "$gt0004|Gender|==local::at0006|Female|",
+          "$gt0015|Smoker|==0|local::at0106|No|"
+        ],
+        "then": [
+          "$gt0036|Smoker|=0|local::at0106|No|",
+          "$gt0021|Smoker: women|=0|local::at0069|Non smoker|"
+        ]
+      },
+      "gt0043": {
+        "id": "gt0043",
+        "priority": 65,
+        "when": [
+          "fired($gt0033)",
+          "$gt0015|Smoker|!=null",
+          "$gt0004|Gender|!=null",
+          "$gt0015|Smoker|==1|local::at0107|Yes|",
+          "$gt0004|Gender|==local::at0006|Female|",
+          "$gt0006|Age|<=79,a",
+          "$gt0006|Age|>=70,a"
+        ],
+        "then": [
+          "$gt0036|Smoker|=1|local::at0107|Yes|",
+          "$gt0021|Smoker: women|=1|local::at0070|Smoker - 70-79|"
+        ]
+      },
+      "gt0042": {
+        "id": "gt0042",
+        "priority": 64,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "fired($gt0033)",
+          "$gt0015|Smoker|!=null",
+          "$gt0015|Smoker|==1|local::at0107|Yes|",
+          "$gt0004|Gender|==local::at0006|Female|",
+          "$gt0006|Age|<=69,a",
+          "$gt0006|Age|>=60,a"
+        ],
+        "then": [
+          "$gt0021|Smoker: women|=2|local::at0071|Smoker - 60-69|",
+          "$gt0036|Smoker|=1|local::at0107|Yes|"
+        ]
+      },
+      "gt0044": {
+        "id": "gt0044",
+        "priority": 63,
+        "when": [
+          "fired($gt0033)",
+          "$gt0015|Smoker|!=null",
+          "$gt0004|Gender|!=null",
+          "$gt0015|Smoker|==1|local::at0107|Yes|",
+          "$gt0004|Gender|==local::at0006|Female|",
+          "$gt0006|Age|<=59,a",
+          "$gt0006|Age|>=50,a"
+        ],
+        "then": [
+          "$gt0036|Smoker|=1|local::at0107|Yes|",
+          "$gt0021|Smoker: women|=4|local::at0072|Smoker - 50-59|"
+        ]
+      },
+      "gt0045": {
+        "id": "gt0045",
+        "priority": 62,
+        "when": [
+          "fired($gt0033)",
+          "$gt0015|Smoker|!=null",
+          "$gt0004|Gender|!=null",
+          "$gt0015|Smoker|==1|local::at0107|Yes|",
+          "$gt0004|Gender|==local::at0006|Female|",
+          "$gt0006|Age|<=49,a",
+          "$gt0006|Age|>=40,a"
+        ],
+        "then": [
+          "$gt0036|Smoker|=1|local::at0107|Yes|",
+          "$gt0021|Smoker: women|=7|local::at0073|Smoker - 40-49|"
+        ]
+      },
+      "gt0046": {
+        "id": "gt0046",
+        "priority": 61,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "$gt0015|Smoker|!=null",
+          "fired($gt0033)",
+          "$gt0004|Gender|==local::at0006|Female|",
+          "$gt0015|Smoker|==1|local::at0107|Yes|",
+          "$gt0006|Age|<=39,a",
+          "$gt0006|Age|>=20,a"
+        ],
+        "then": [
+          "$gt0036|Smoker|=1|local::at0107|Yes|",
+          "$gt0021|Smoker: women|=9|local::at0074|Smoker - 20-39|"
+        ]
+      },
+      "gt0048": {
+        "id": "gt0048",
+        "priority": 60,
+        "when": [
+          "$gt0012|Total Cholesterol|<160,mg/dl",
+          "$gt0012|Total Cholesterol|!=null"
+        ],
+        "then": [
+          "$gt0023|Total Cholesterol: women|=0|local::at0076|<160|",
+          "$gt0022|Total Cholesterol: men|=0|local::at0023|< 160 |"
+        ]
+      },
+      "gt0049": {
+        "id": "gt0049",
+        "priority": 59,
+        "when": [
+          "$gt0012|Total Cholesterol|>=160,mg/dl",
+          "$gt0012|Total Cholesterol|<=239,mg/dl",
+          "$gt0004|Gender|!=null",
+          "fired($gt0033)",
+          "$gt0012|Total Cholesterol|!=null",
+          "$gt0004|Gender|==local::at0005|Male|",
+          "$gt0006|Age|<=79,a",
+          "$gt0006|Age|>=70,a"
+        ],
+        "then": [
+          "$gt0022|Total Cholesterol: men|=0|local::at0023|< 160 |"
+        ]
+      },
+      "gt0050": {
+        "id": "gt0050",
+        "priority": 58,
+        "when": [
+          "fired($gt0033)",
+          "$gt0004|Gender|!=null",
+          "$gt0012|Total Cholesterol|!=null",
+          "$gt0004|Gender|==local::at0005|Male|",
+          "(($gt0012|Total Cholesterol|<=239,mg/dl)&&(($gt0012|Total Cholesterol|>=160,mg/dl)&&(($gt0006|Age|>=60,a)&&($gt0006|Age|<=69,a))))||(($gt0012|Total Cholesterol|>=240,mg/dl)&&(($gt0006|Age|<=79,a)&&($gt0006|Age|>=70,a)))"
+        ],
+        "then": [
+          "$gt0022|Total Cholesterol: men|=1|local::at0024|160-239 (60-69 years)..|"
+        ]
+      },
+      "gt0052": {
+        "id": "gt0052",
+        "priority": 57,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "fired($gt0033)",
+          "$gt0012|Total Cholesterol|!=null",
+          "$gt0004|Gender|==local::at0005|Male|",
+          "(($gt0006|Age|<=59,a)&&(($gt0006|Age|>=50,a)&&(($gt0012|Total Cholesterol|>=160,mg/dl)&&($gt0012|Total Cholesterol|<=199,mg/dl))))||(($gt0006|Age|<=69,a)&&(($gt0006|Age|>=60,a)&&(($gt0012|Total Cholesterol|<=279,mg/dl)&&($gt0012|Total Cholesterol|>=240,mg/dl))))"
+        ],
+        "then": [
+          "$gt0022|Total Cholesterol: men|=2|local::at0025|160-199 (50-59 years)..|"
+        ]
+      },
+      "gt0053": {
+        "id": "gt0053",
+        "priority": 56,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "$gt0004|Gender|==local::at0005|Male|",
+          "fired($gt0033)",
+          "$gt0012|Total Cholesterol|!=null",
+          "((($gt0006|Age|<=49,a)&&(($gt0006|Age|>=40,a)&&(($gt0012|Total Cholesterol|<=199,mg/dl)&&($gt0012|Total Cholesterol|>=160,mg/dl))))||(($gt0006|Age|<=59,a)&&(($gt0006|Age|>=50,a)&&(($gt0012|Total Cholesterol|<=239,mg/dl)&&($gt0012|Total Cholesterol|>=200,mg/dl)))))||(($gt0006|Age|<=69,a)&&(($gt0006|Age|>=60,a)&&($gt0012|Total Cholesterol|>=280,mg/dl)))"
+        ],
+        "then": [
+          "$gt0022|Total Cholesterol: men|=3|local::at0026|160-199 (40-59 years) or 200-239 (50-59 years)|"
+        ]
+      },
+      "gt0054": {
+        "id": "gt0054",
+        "priority": 55,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "$gt0012|Total Cholesterol|!=null",
+          "fired($gt0033)",
+          "$gt0004|Gender|==local::at0005|Male|",
+          "(($gt0006|Age|<=39,a)&&(($gt0006|Age|>=20,a)&&(($gt0012|Total Cholesterol|<=199,mg/dl)&&($gt0012|Total Cholesterol|>=160,mg/dl))))||(($gt0006|Age|<=59,a)&&(($gt0006|Age|>=50,a)&&(($gt0012|Total Cholesterol|<=279,mg/dl)&&($gt0012|Total Cholesterol|>=240,mg/dl))))"
+        ],
+        "then": [
+          "$gt0022|Total Cholesterol: men|=4|local::at0027|160-199 (20-39 years)..|"
+        ]
+      },
+      "gt0055": {
+        "id": "gt0055",
+        "priority": 54,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "$gt0004|Gender|==local::at0005|Male|",
+          "fired($gt0033)",
+          "$gt0012|Total Cholesterol|!=null",
+          "(($gt0006|Age|<=49,a)&&(($gt0006|Age|>=40,a)&&(($gt0012|Total Cholesterol|<=239,mg/dl)&&($gt0012|Total Cholesterol|>=200,mg/dl))))||(($gt0006|Age|<=59,a)&&(($gt0006|Age|>=50,a)&&($gt0012|Total Cholesterol|>=280,mg/dl)))"
+        ],
+        "then": [
+          "$gt0022|Total Cholesterol: men|=5|local::at0028|200-239 (40-49 years)..|"
+        ]
+      },
+      "gt0056": {
+        "id": "gt0056",
+        "priority": 53,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "fired($gt0033)",
+          "$gt0012|Total Cholesterol|!=null",
+          "$gt0004|Gender|==local::at0005|Male|",
+          "$gt0006|Age|<=49,a",
+          "$gt0006|Age|>=40,a",
+          "$gt0012|Total Cholesterol|<=279,mg/dl",
+          "$gt0012|Total Cholesterol|>=240,mg/dl"
+        ],
+        "then": [
+          "$gt0022|Total Cholesterol: men|=6|local::at0029|240-279 (40-49 years)|"
+        ]
+      },
+      "gt0057": {
+        "id": "gt0057",
+        "priority": 52,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "$gt0004|Gender|==local::at0005|Male|",
+          "fired($gt0033)",
+          "$gt0012|Total Cholesterol|!=null",
+          "$gt0006|Age|<=39,a",
+          "$gt0006|Age|>=20,a",
+          "$gt0012|Total Cholesterol|<=239,mg/dl",
+          "$gt0012|Total Cholesterol|>=200,mg/dl"
+        ],
+        "then": [
+          "$gt0022|Total Cholesterol: men|=7|local::at0030|200-239 (20-39 years)|"
+        ]
+      },
+      "gt0058": {
+        "id": "gt0058",
+        "priority": 51,
+        "when": [
+          "$gt0004|Gender|==local::at0005|Male|",
+          "$gt0012|Total Cholesterol|!=null",
+          "fired($gt0033)",
+          "$gt0004|Gender|!=null",
+          "$gt0012|Total Cholesterol|>=280,mg/dl",
+          "$gt0006|Age|<=49,a",
+          "$gt0006|Age|>=40,a"
+        ],
+        "then": [
+          "$gt0022|Total Cholesterol: men|=8|local::at0031|≥280 (40-49 years)|"
+        ]
+      },
+      "gt0059": {
+        "id": "gt0059",
+        "priority": 50,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "$gt0004|Gender|==local::at0005|Male|",
+          "$gt0012|Total Cholesterol|!=null",
+          "fired($gt0033)",
+          "$gt0006|Age|<=39,a",
+          "$gt0006|Age|>=20,a",
+          "$gt0012|Total Cholesterol|<=279,mg/dl",
+          "$gt0012|Total Cholesterol|>=240,mg/dl"
+        ],
+        "then": [
+          "$gt0022|Total Cholesterol: men|=9|local::at0032|240-279 (20-39 years)|"
+        ]
+      },
+      "gt0060": {
+        "id": "gt0060",
+        "priority": 49,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "fired($gt0033)",
+          "$gt0012|Total Cholesterol|!=null",
+          "$gt0004|Gender|==local::at0005|Male|",
+          "$gt0012|Total Cholesterol|>=280,mg/dl",
+          "$gt0006|Age|<=39,a",
+          "$gt0006|Age|>=20,a"
+        ],
+        "then": [
+          "$gt0022|Total Cholesterol: men|=11|local::at0033|≥ 280 (20-39 years)|"
+        ]
+      },
+      "gt0062": {
+        "id": "gt0062",
+        "priority": 48,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "$gt0004|Gender|==local::at0006|Female|",
+          "fired($gt0033)",
+          "$gt0012|Total Cholesterol|!=null",
+          "(($gt0006|Age|<=79,a)&&(($gt0006|Age|>=60,a)&&(($gt0012|Total Cholesterol|<=199,mg/dl)&&($gt0012|Total Cholesterol|>=160,mg/dl))))||(($gt0006|Age|<=79,a)&&(($gt0006|Age|>=70,a)&&(($gt0012|Total Cholesterol|<=239,mg/dl)&&($gt0012|Total Cholesterol|>=200,mg/dl))))"
+        ],
+        "then": [
+          "$gt0023|Total Cholesterol: women|=1|local::at0077|160-199 or 200-239..|"
+        ]
+      },
+      "gt0063": {
+        "id": "gt0063",
+        "priority": 47,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "$gt0004|Gender|==local::at0006|Female|",
+          "fired($gt0033)",
+          "$gt0012|Total Cholesterol|!=null",
+          "((($gt0006|Age|<=59,a)&&(($gt0006|Age|>=50,a)&&(($gt0012|Total Cholesterol|<=199,mg/dl)&&($gt0012|Total Cholesterol|>=160,mg/dl))))||(($gt0006|Age|<=69,a)&&(($gt0006|Age|>=60,a)&&(($gt0012|Total Cholesterol|<=239,mg/dl)&&($gt0012|Total Cholesterol|>=200,mg/dl)))))||(($gt0006|Age|<=79,a)&&(($gt0006|Age|>=70,a)&&($gt0012|Total Cholesterol|>=240,mg/dl)))"
+        ],
+        "then": [
+          "$gt0023|Total Cholesterol: women|=2|local::at0078|160 to ≥ 280..|"
+        ]
+      },
+      "gt0064": {
+        "id": "gt0064",
+        "priority": 46,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "fired($gt0033)",
+          "$gt0012|Total Cholesterol|!=null",
+          "$gt0004|Gender|==local::at0006|Female|",
+          "(($gt0006|Age|<=49,a)&&(($gt0006|Age|>=40,a)&&(($gt0012|Total Cholesterol|<=199,mg/dl)&&($gt0012|Total Cholesterol|>=160,mg/dl))))||(($gt0006|Age|<=69,a)&&(($gt0006|Age|>=60,a)&&(($gt0012|Total Cholesterol|<=279,mg/dl)&&($gt0012|Total Cholesterol|>=200,mg/dl))))"
+        ],
+        "then": [
+          "$gt0023|Total Cholesterol: women|=3|local::at0079|160-199 or 240-279..|"
+        ]
+      },
+      "gt0065": {
+        "id": "gt0065",
+        "priority": 45,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "fired($gt0033)",
+          "$gt0012|Total Cholesterol|!=null",
+          "$gt0004|Gender|==local::at0006|Female|",
+          "((($gt0006|Age|<=39,a)&&(($gt0006|Age|>=20,a)&&(($gt0012|Total Cholesterol|<=199,mg/dl)&&($gt0012|Total Cholesterol|>=160,mg/dl))))||(($gt0006|Age|<=59,a)&&(($gt0006|Age|>=50,a)&&(($gt0012|Total Cholesterol|<=239,mg/dl)&&($gt0012|Total Cholesterol|>=200,mg/dl)))))||(($gt0006|Age|<=69,a)&&(($gt0006|Age|>=60,a)&&($gt0012|Total Cholesterol|>=280,mg/dl)))"
+        ],
+        "then": [
+          "$gt0023|Total Cholesterol: women|=4|local::at0080|160-199, 200-239 or ≥280..|"
+        ]
+      },
+      "gt0066": {
+        "id": "gt0066",
+        "priority": 44,
+        "when": [
+          "$gt0004|Gender|==local::at0006|Female|",
+          "$gt0012|Total Cholesterol|!=null",
+          "fired($gt0033)",
+          "$gt0004|Gender|!=null",
+          "$gt0012|Total Cholesterol|<=279,mg/dl",
+          "$gt0012|Total Cholesterol|>=240,mg/dl",
+          "$gt0006|Age|<=59,a",
+          "$gt0006|Age|>=50,a"
+        ],
+        "then": [
+          "$gt0023|Total Cholesterol: women|=5|local::at0081|240-279..|"
+        ]
+      },
+      "gt0067": {
+        "id": "gt0067",
+        "priority": 43,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "$gt0004|Gender|==local::at0006|Female|",
+          "$gt0012|Total Cholesterol|!=null",
+          "fired($gt0033)",
+          "$gt0012|Total Cholesterol|<=239,mg/dl",
+          "$gt0012|Total Cholesterol|>=200,mg/dl",
+          "$gt0006|Age|<=49,a",
+          "$gt0006|Age|>=40,a"
+        ],
+        "then": [
+          "$gt0023|Total Cholesterol: women|=6|local::at0082|200-239..|"
+        ]
+      },
+      "gt0068": {
+        "id": "gt0068",
+        "priority": 42,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "fired($gt0033)",
+          "$gt0012|Total Cholesterol|!=null",
+          "$gt0004|Gender|==local::at0006|Female|",
+          "$gt0006|Age|<=59,a",
+          "$gt0006|Age|>=50,a",
+          "$gt0012|Total Cholesterol|>=280,mg/dl"
+        ],
+        "then": [
+          "$gt0023|Total Cholesterol: women|=7|local::at0083|≥ 280..|"
+        ]
+      },
+      "gt0069": {
+        "id": "gt0069",
+        "priority": 41,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "fired($gt0033)",
+          "$gt0012|Total Cholesterol|!=null",
+          "$gt0004|Gender|==local::at0006|Female|",
+          "(($gt0006|Age|<=39,a)&&(($gt0006|Age|>=20,a)&&(($gt0012|Total Cholesterol|<=239,mg/dl)&&($gt0012|Total Cholesterol|>=200,mg/dl))))||(($gt0006|Age|<=49,a)&&(($gt0006|Age|>=40,a)&&(($gt0012|Total Cholesterol|<=279,mg/dl)&&($gt0012|Total Cholesterol|>=240,mg/dl))))"
+        ],
+        "then": [
+          "$gt0023|Total Cholesterol: women|=8|local::at0084|200-239..|"
+        ]
+      },
+      "gt0070": {
+        "id": "gt0070",
+        "priority": 40,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "fired($gt0033)",
+          "$gt0012|Total Cholesterol|!=null",
+          "$gt0004|Gender|==local::at0006|Female|",
+          "$gt0006|Age|<=49,a",
+          "$gt0006|Age|>=40,a",
+          "$gt0012|Total Cholesterol|>=280,mg/dl"
+        ],
+        "then": [
+          "$gt0023|Total Cholesterol: women|=10|local::at0086|≥280..|"
+        ]
+      },
+      "gt0071": {
+        "id": "gt0071",
+        "priority": 39,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "fired($gt0033)",
+          "$gt0012|Total Cholesterol|!=null",
+          "$gt0004|Gender|==local::at0006|Female|",
+          "$gt0006|Age|<=39,a",
+          "$gt0006|Age|>=20,a",
+          "$gt0012|Total Cholesterol|<=279,mg/dl",
+          "$gt0012|Total Cholesterol|>=240,mg/dl"
+        ],
+        "then": [
+          "$gt0023|Total Cholesterol: women|=11|local::at0087|240-279..|"
+        ]
+      },
+      "gt0072": {
+        "id": "gt0072",
+        "priority": 38,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "fired($gt0033)",
+          "$gt0012|Total Cholesterol|!=null",
+          "$gt0004|Gender|==local::at0006|Female|",
+          "$gt0006|Age|<=39,a",
+          "$gt0006|Age|>=20,a",
+          "$gt0012|Total Cholesterol|>=280,mg/dl"
+        ],
+        "then": [
+          "$gt0023|Total Cholesterol: women|=13|local::at0088|≥ 280..|"
+        ]
+      },
+      "gt0077": {
+        "id": "gt0077",
+        "priority": 37,
+        "when": [
+          "$gt0016|Blood Pressure treated with medication|!=null",
+          "$gt0004|Gender|!=null",
+          "$gt0010|Systolic|!=null",
+          "$gt0004|Gender|==local::at0005|Male|",
+          "($gt0010|Systolic|<120,mm[Hg])||(($gt0029|Blood Pressure treated with medication|==0|local::at0053|No|)&&(($gt0010|Systolic|<=129,mm[Hg])&&($gt0010|Systolic|>=120,mm[Hg])))"
+        ],
+        "then": [
+          "$gt0029|Blood Pressure treated with medication|=$gt0016|Blood Pressure treated with medication|",
+          "$gt0075|Systolic BP: men|=0|local::at0046|< 120 or 120-129 if untreated|"
+        ]
+      },
+      "gt0078": {
+        "id": "gt0078",
+        "priority": 36,
+        "when": [
+          "$gt0016|Blood Pressure treated with medication|!=null",
+          "$gt0010|Systolic|!=null",
+          "$gt0004|Gender|!=null",
+          "$gt0004|Gender|==local::at0005|Male|",
+          "(($gt0016|Blood Pressure treated with medication|==1|local::at0054|Yes|)&&(($gt0010|Systolic|<=129,mm[Hg])&&($gt0010|Systolic|>=120,mm[Hg])))||(($gt0016|Blood Pressure treated with medication|==0|local::at0053|No|)&&(($gt0010|Systolic|<=159,mm[Hg])&&($gt0010|Systolic|>=130,mm[Hg])))"
+        ],
+        "then": [
+          "$gt0029|Blood Pressure treated with medication|=$gt0016|Blood Pressure treated with medication|",
+          "$gt0075|Systolic BP: men|=1|local::at0047|120-129 if treated or 130-159 if untreated|"
+        ]
+      },
+      "gt0079": {
+        "id": "gt0079",
+        "priority": 35,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "$gt0004|Gender|==local::at0005|Male|",
+          "$gt0010|Systolic|!=null",
+          "$gt0016|Blood Pressure treated with medication|!=null",
+          "(($gt0016|Blood Pressure treated with medication|==1|local::at0054|Yes|)&&(($gt0010|Systolic|<=159,mm[Hg])&&($gt0010|Systolic|>=130,mm[Hg])))||(($gt0016|Blood Pressure treated with medication|==0|local::at0053|No|)&&($gt0010|Systolic|>=160,mm[Hg]))"
+        ],
+        "then": [
+          "$gt0029|Blood Pressure treated with medication|=$gt0016|Blood Pressure treated with medication|",
+          "$gt0075|Systolic BP: men|=2|local::at0048|130-159 if treated or ≥ 160 if untreated|"
+        ]
+      },
+      "gt0080": {
+        "id": "gt0080",
+        "priority": 34,
+        "when": [
+          "$gt0016|Blood Pressure treated with medication|!=null",
+          "$gt0010|Systolic|!=null",
+          "$gt0004|Gender|!=null",
+          "$gt0016|Blood Pressure treated with medication|==1|local::at0054|Yes|",
+          "$gt0004|Gender|==local::at0005|Male|",
+          "$gt0010|Systolic|>=160,mm[Hg]"
+        ],
+        "then": [
+          "$gt0029|Blood Pressure treated with medication|=1|local::at0054|Yes|",
+          "$gt0075|Systolic BP: men|=3|local::at0049|≥ 160 if treated|"
+        ]
+      },
+      "gt0081": {
+        "id": "gt0081",
+        "priority": 33,
+        "when": [
+          "$gt0016|Blood Pressure treated with medication|!=null",
+          "$gt0010|Systolic|!=null",
+          "$gt0004|Gender|!=null",
+          "$gt0010|Systolic|<120,mm[Hg]",
+          "$gt0004|Gender|==local::at0006|Female|"
+        ],
+        "then": [
+          "$gt0029|Blood Pressure treated with medication|=$gt0016|Blood Pressure treated with medication|",
+          "$gt0076|Systolic BP: women|=0|local::at0100|< 120|"
+        ]
+      },
+      "gt0082": {
+        "id": "gt0082",
+        "priority": 32,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "$gt0016|Blood Pressure treated with medication|!=null",
+          "$gt0010|Systolic|!=null",
+          "$gt0004|Gender|==local::at0006|Female|",
+          "$gt0010|Systolic|<=129,mm[Hg]",
+          "$gt0010|Systolic|>=120,mm[Hg]",
+          "$gt0016|Blood Pressure treated with medication|==0|local::at0053|No|"
+        ],
+        "then": [
+          "$gt0029|Blood Pressure treated with medication|=0|local::at0053|No|",
+          "$gt0076|Systolic BP: women|=1|local::at0101|120-129 if untreated|"
+        ]
+      },
+      "gt0083": {
+        "id": "gt0083",
+        "priority": 31,
+        "when": [
+          "$gt0016|Blood Pressure treated with medication|!=null",
+          "$gt0010|Systolic|!=null",
+          "$gt0004|Gender|!=null",
+          "$gt0016|Blood Pressure treated with medication|==0|local::at0053|No|",
+          "$gt0004|Gender|==local::at0006|Female|",
+          "$gt0010|Systolic|<=139,mm[Hg]",
+          "$gt0010|Systolic|>=130,mm[Hg]"
+        ],
+        "then": [
+          "$gt0029|Blood Pressure treated with medication|=0|local::at0053|No|",
+          "$gt0076|Systolic BP: women|=2|local::at0102|130-139 if untreated|"
+        ]
+      },
+      "gt0084": {
+        "id": "gt0084",
+        "priority": 30,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "$gt0010|Systolic|!=null",
+          "$gt0016|Blood Pressure treated with medication|!=null",
+          "$gt0004|Gender|==local::at0006|Female|",
+          "(($gt0016|Blood Pressure treated with medication|==0|local::at0053|No|)&&(($gt0010|Systolic|<=159,mm[Hg])&&($gt0010|Systolic|>=140,mm[Hg])))||(($gt0016|Blood Pressure treated with medication|==1|local::at0054|Yes|)&&(($gt0010|Systolic|<=129,mm[Hg])&&($gt0010|Systolic|>=120,mm[Hg])))"
+        ],
+        "then": [
+          "$gt0029|Blood Pressure treated with medication|=$gt0016|Blood Pressure treated with medication|",
+          "$gt0076|Systolic BP: women|=3|local::at0103|140-159 if untreated or 120-129 if treated|"
+        ]
+      },
+      "gt0085": {
+        "id": "gt0085",
+        "priority": 29,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "$gt0010|Systolic|!=null",
+          "$gt0016|Blood Pressure treated with medication|!=null",
+          "$gt0004|Gender|==local::at0006|Female|",
+          "(($gt0016|Blood Pressure treated with medication|==0|local::at0053|No|)&&($gt0010|Systolic|>=160,mm[Hg]))||(($gt0016|Blood Pressure treated with medication|==1|local::at0054|Yes|)&&(($gt0010|Systolic|<=139,mm[Hg])&&($gt0010|Systolic|>=130,mm[Hg])))"
+        ],
+        "then": [
+          "$gt0029|Blood Pressure treated with medication|=$gt0016|Blood Pressure treated with medication|",
+          "$gt0076|Systolic BP: women|=4|local::at0104|≥ 160 if untreated or 130-139 if treated|"
+        ]
+      },
+      "gt0086": {
+        "id": "gt0086",
+        "priority": 28,
+        "when": [
+          "$gt0016|Blood Pressure treated with medication|!=null",
+          "$gt0010|Systolic|!=null",
+          "$gt0004|Gender|!=null",
+          "$gt0016|Blood Pressure treated with medication|==1|local::at0054|Yes|",
+          "$gt0004|Gender|==local::at0006|Female|",
+          "$gt0010|Systolic|<=159,mm[Hg]",
+          "$gt0010|Systolic|>=140,mm[Hg]"
+        ],
+        "then": [
+          "$gt0029|Blood Pressure treated with medication|=$gt0016|Blood Pressure treated with medication|",
+          "$gt0076|Systolic BP: women|=5|local::at0108|140-159 if treated|"
+        ]
+      },
+      "gt0087": {
+        "id": "gt0087",
+        "priority": 27,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "$gt0010|Systolic|!=null",
+          "$gt0016|Blood Pressure treated with medication|!=null",
+          "$gt0004|Gender|==local::at0006|Female|",
+          "$gt0016|Blood Pressure treated with medication|==1|local::at0054|Yes|",
+          "$gt0010|Systolic|>=160,mm[Hg]"
+        ],
+        "then": [
+          "$gt0029|Blood Pressure treated with medication|=$gt0016|Blood Pressure treated with medication|",
+          "$gt0076|Systolic BP: women|=6|local::at0109|≥ 160 if treated|"
+        ]
+      },
+      "gt0088": {
+        "id": "gt0088",
+        "priority": 26,
+        "when": [
+          "$gt0013|HDL Cholesterol|!=null",
+          "$gt0013|HDL Cholesterol|>=50,mg/dl",
+          "$gt0013|HDL Cholesterol|<=59,mg/dl"
+        ],
+        "then": [
+          "$gt0024|HDL Cholesterol: men and women|=0|local::at0020|50-59|"
+        ]
+      },
+      "gt0089": {
+        "id": "gt0089",
+        "priority": 25,
+        "when": [
+          "$gt0013|HDL Cholesterol|!=null",
+          "$gt0013|HDL Cholesterol|<=49,mg/dl",
+          "$gt0013|HDL Cholesterol|>=40,mg/dl"
+        ],
+        "then": [
+          "$gt0024|HDL Cholesterol: men and women|=1|local::at0021|40-49|"
+        ]
+      },
+      "gt0090": {
+        "id": "gt0090",
+        "priority": 24,
+        "when": [
+          "$gt0013|HDL Cholesterol|!=null",
+          "$gt0013|HDL Cholesterol|<40,mg/dl"
+        ],
+        "then": [
+          "$gt0024|HDL Cholesterol: men and women|=2|local::at0022|< 40|"
+        ]
+      },
+      "gt0095": {
+        "id": "gt0095",
+        "priority": 23,
+        "when": [
+          "$gt0013|HDL Cholesterol|!=null",
+          "$gt0013|HDL Cholesterol|>=60,mg/dl"
+        ],
+        "then": [
+          "$gt0024|HDL Cholesterol: men and women|=-1|local::at0019|≥60|"
+        ]
+      },
+      "gt0097": {
+        "id": "gt0097",
+        "priority": 22,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "$gt0004|Gender|==local::at0005|Male|",
+          "fired($gt0033)",
+          "$gt0006|Age|<=44,a",
+          "$gt0006|Age|>=40,a"
+        ],
+        "then": [
+          "$gt0018|Age variable: men|=0|local::at0017|40-44|"
+        ]
+      },
+      "gt0098": {
+        "id": "gt0098",
+        "priority": 21,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "$gt0004|Gender|==local::at0005|Male|",
+          "fired($gt0033)",
+          "$gt0006|Age|>=45,a",
+          "$gt0006|Age|<=49,a"
+        ],
+        "then": [
+          "$gt0018|Age variable: men|=3|local::at0018|45-49|"
+        ]
+      },
+      "gt0099": {
+        "id": "gt0099",
+        "priority": 20,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "$gt0004|Gender|==local::at0005|Male|",
+          "fired($gt0033)",
+          "$gt0006|Age|<=54,a",
+          "$gt0006|Age|>=50,a"
+        ],
+        "then": [
+          "$gt0018|Age variable: men|=6|local::at0039|50-54|"
+        ]
+      },
+      "gt0100": {
+        "id": "gt0100",
+        "priority": 19,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "$gt0004|Gender|==local::at0005|Male|",
+          "fired($gt0033)",
+          "$gt0006|Age|<=59,a",
+          "$gt0006|Age|>=55,a"
+        ],
+        "then": [
+          "$gt0018|Age variable: men|=8|local::at0040|55-59|"
+        ]
+      },
+      "gt0101": {
+        "id": "gt0101",
+        "priority": 18,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "$gt0004|Gender|==local::at0005|Male|",
+          "fired($gt0033)",
+          "$gt0006|Age|<=64,a",
+          "$gt0006|Age|>=60,a"
+        ],
+        "then": [
+          "$gt0018|Age variable: men|=10|local::at0041|60-64|"
+        ]
+      },
+      "gt0102": {
+        "id": "gt0102",
+        "priority": 17,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "$gt0004|Gender|==local::at0005|Male|",
+          "fired($gt0033)",
+          "$gt0006|Age|<=69,a",
+          "$gt0006|Age|>=65,a"
+        ],
+        "then": [
+          "$gt0018|Age variable: men|=11|local::at0042|65-69|"
+        ]
+      },
+      "gt0103": {
+        "id": "gt0103",
+        "priority": 16,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "$gt0004|Gender|==local::at0005|Male|",
+          "fired($gt0033)",
+          "$gt0006|Age|<=74,a",
+          "$gt0006|Age|>=70,a"
+        ],
+        "then": [
+          "$gt0018|Age variable: men|=12|local::at0043|70-74|"
+        ]
+      },
+      "gt0104": {
+        "id": "gt0104",
+        "priority": 15,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "$gt0004|Gender|==local::at0005|Male|",
+          "fired($gt0033)",
+          "$gt0006|Age|<=79,a",
+          "$gt0006|Age|>=75,a"
+        ],
+        "then": [
+          "$gt0018|Age variable: men|=13|local::at0044|75-79|"
+        ]
+      },
+      "gt0105": {
+        "id": "gt0105",
+        "priority": 14,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "$gt0004|Gender|==local::at0005|Male|",
+          "fired($gt0033)",
+          "$gt0006|Age|<=34,a",
+          "$gt0006|Age|>=20,a"
+        ],
+        "then": [
+          "$gt0018|Age variable: men|=-9|local::at0015|20-34|"
+        ]
+      },
+      "gt0106": {
+        "id": "gt0106",
+        "priority": 13,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "$gt0004|Gender|==local::at0005|Male|",
+          "fired($gt0033)",
+          "$gt0006|Age|<=39,a",
+          "$gt0006|Age|>=35,a"
+        ],
+        "then": [
+          "$gt0018|Age variable: men|=-4|local::at0016|35-39|"
+        ]
+      },
+      "gt0108": {
+        "id": "gt0108",
+        "priority": 12,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "$gt0004|Gender|==local::at0006|Female|",
+          "fired($gt0033)",
+          "$gt0006|Age|<=44,a",
+          "$gt0006|Age|>=40,a"
+        ],
+        "then": [
+          "$gt0019|Age variable: women|=0|local::at0061|40-44|"
+        ]
+      },
+      "gt0109": {
+        "id": "gt0109",
+        "priority": 11,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "$gt0004|Gender|==local::at0006|Female|",
+          "fired($gt0033)",
+          "$gt0006|Age|<=49,a",
+          "$gt0006|Age|>=45,a"
+        ],
+        "then": [
+          "$gt0019|Age variable: women|=3|local::at0062|45-49|"
+        ]
+      },
+      "gt0110": {
+        "id": "gt0110",
+        "priority": 10,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "$gt0004|Gender|==local::at0006|Female|",
+          "fired($gt0033)",
+          "$gt0006|Age|<=54,a",
+          "$gt0006|Age|>=50,a"
+        ],
+        "then": [
+          "$gt0019|Age variable: women|=6|local::at0063|50-54|"
+        ]
+      },
+      "gt0111": {
+        "id": "gt0111",
+        "priority": 9,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "$gt0004|Gender|==local::at0006|Female|",
+          "fired($gt0033)",
+          "$gt0006|Age|<=59,a",
+          "$gt0006|Age|>=55,a"
+        ],
+        "then": [
+          "$gt0019|Age variable: women|=8|local::at0064|55-59|"
+        ]
+      },
+      "gt0112": {
+        "id": "gt0112",
+        "priority": 8,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "$gt0004|Gender|==local::at0006|Female|",
+          "fired($gt0033)",
+          "$gt0006|Age|<=64,a",
+          "$gt0006|Age|>=60,a"
+        ],
+        "then": [
+          "$gt0019|Age variable: women|=10|local::at0065|60-64|"
+        ]
+      },
+      "gt0113": {
+        "id": "gt0113",
+        "priority": 7,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "$gt0004|Gender|==local::at0006|Female|",
+          "fired($gt0033)",
+          "$gt0006|Age|<=69,a",
+          "$gt0006|Age|>=65,a"
+        ],
+        "then": [
+          "$gt0019|Age variable: women|=12|local::at0066|65-69|"
+        ]
+      },
+      "gt0114": {
+        "id": "gt0114",
+        "priority": 6,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "$gt0004|Gender|==local::at0006|Female|",
+          "fired($gt0033)",
+          "$gt0006|Age|<=74,a",
+          "$gt0006|Age|>=70,a"
+        ],
+        "then": [
+          "$gt0019|Age variable: women|=14|local::at0067|70-74|"
+        ]
+      },
+      "gt0115": {
+        "id": "gt0115",
+        "priority": 5,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "$gt0004|Gender|==local::at0006|Female|",
+          "fired($gt0033)",
+          "$gt0006|Age|<=79,a",
+          "$gt0006|Age|>=75,a"
+        ],
+        "then": [
+          "$gt0019|Age variable: women|=16|local::at0068|75-79|"
+        ]
+      },
+      "gt0116": {
+        "id": "gt0116",
+        "priority": 4,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "fired($gt0033)",
+          "$gt0004|Gender|==local::at0006|Female|",
+          "$gt0006|Age|<=34,a",
+          "$gt0006|Age|>=20,a"
+        ],
+        "then": [
+          "$gt0019|Age variable: women|=-7|local::at0059|20-34|"
+        ]
+      },
+      "gt0117": {
+        "id": "gt0117",
+        "priority": 3,
+        "when": [
+          "$gt0004|Gender|!=null",
+          "fired($gt0033)",
+          "$gt0004|Gender|==local::at0006|Female|",
+          "$gt0006|Age|<=39,a",
+          "$gt0006|Age|>=35,a"
+        ],
+        "then": [
+          "$gt0019|Age variable: women|=-3|local::at0060|35-39|"
+        ]
+      },
+      "gt0120": {
+        "id": "gt0120",
+        "priority": 2,
+        "when": [
+          "$gt0004|Gender|==local::at0005|Male|"
+        ],
+        "then": [
+          "$gt0030|Total score: men|.magnitude=((($gt0018.value+$gt0022.value)+$gt0024.value)+$gt0020.value)+$gt0075.value"
+        ]
+      },
+      "gt0121": {
+        "id": "gt0121",
+        "priority": 1,
+        "when": [
+          "$gt0004|Gender|==local::at0006|Female|"
+        ],
+        "then": [
+          "$gt0031|Total score: women|.magnitude=((($gt0019.value+$gt0021.value)+$gt0076.value)+$gt0023.value)+$gt0024.value"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Framingham CHD risk",
+            "description": "The Framingham CHD (Coronary Artery Disease)  Risk Score estimates the risk of heart attack in 10 years."
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "Birthdate",
+            "description": "*"
+          },
+          "gt0004": {
+            "id": "gt0004",
+            "text": "Gender",
+            "description": "*"
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Age",
+            "description": "Age in years, and for babies: months, weeks or days"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Systolic",
+            "description": "Peak systemic arterial blood pressure  - measured in systolic or contraction phase of the heart cycle."
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Systolic",
+            "description": "Peak systemic arterial blood pressure  - measured in systolic or contraction phase of the heart cycle."
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "Total Cholesterol",
+            "description": "The total cholesterol concentration in the sample."
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "HDL Cholesterol",
+            "description": "HDL-Cholesterol level in the sample."
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "Smoker",
+            "description": "Whether smoker or not"
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "Blood Pressure treated with medication",
+            "description": "Whether treated by BP medication or not"
+          },
+          "gt0018": {
+            "id": "gt0018",
+            "text": "Age variable: men",
+            "description": "Age scores for men dependant on several discretized age brackets, which range from -9 to 13"
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "text": "Age variable: women",
+            "description": "Age scores for women dependant on several discretized age brackets, which range from -7 to 16"
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "Smoker: men",
+            "description": "Scores for men in this smoking variable vary depending on age or whether smoker or non smoker"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "text": "Smoker: women",
+            "description": "Scores for women in this smoking variable vary depending on age or whether smoker or non smoker"
+          },
+          "gt0022": {
+            "id": "gt0022",
+            "text": "Total Cholesterol: men",
+            "description": "Total Cholesterol (mg/dL) scores for men, dependant on age values as indicated"
+          },
+          "gt0023": {
+            "id": "gt0023",
+            "text": "Total Cholesterol: women",
+            "description": "Total Cholesterol (mg/dL) scores for women dependant on age values as indicated"
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "text": "HDL Cholesterol: men and women",
+            "description": "HDL (mg/dL) discrete values for both men and women - the score ranges from -1 to 2"
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "text": "Sys BP - treated: men",
+            "description": "Sys BP scores for men dependant upon patient being on BP medication"
+          },
+          "gt0026": {
+            "id": "gt0026",
+            "text": "Sys BP - treated: women",
+            "description": "Sys BP scores for woman dependant upon patient being on BP medication"
+          },
+          "gt0027": {
+            "id": "gt0027",
+            "text": "Sys BP - untreated: men",
+            "description": "Sys BP scores for men dependant upon patient not being on BP medication"
+          },
+          "gt0028": {
+            "id": "gt0028",
+            "text": "Sys BP - untreated: women",
+            "description": "Sys BP scores for women dependant upon patient not being on BP medication"
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "text": "Blood Pressure treated with medication",
+            "description": "Whether treated by BP medication or not"
+          },
+          "gt0030": {
+            "id": "gt0030",
+            "text": "Total score: men",
+            "description": "Sum of individual scores for men"
+          },
+          "gt0031": {
+            "id": "gt0031",
+            "text": "Total score: women",
+            "description": "Sum of individual scores for women"
+          },
+          "gt0032": {
+            "id": "gt0032",
+            "text": "Default"
+          },
+          "gt0033": {
+            "id": "gt0033",
+            "text": "Calculate age "
+          },
+          "gt0034": {
+            "id": "gt0034",
+            "text": "Set smoker men: non"
+          },
+          "gt0035": {
+            "id": "gt0035",
+            "text": "Set smoker men: 60-79 yrs"
+          },
+          "gt0036": {
+            "id": "gt0036",
+            "text": "Smoker",
+            "description": "Whether smoker or not"
+          },
+          "gt0037": {
+            "id": "gt0037",
+            "text": "Set smoker men: 50-59 yrs"
+          },
+          "gt0038": {
+            "id": "gt0038",
+            "text": "Set smoking default status for ages > 79 or < 20 yrs "
+          },
+          "gt0039": {
+            "id": "gt0039",
+            "text": "Set smoker men: 40-49 yrs"
+          },
+          "gt0040": {
+            "id": "gt0040",
+            "text": "Set smoker men: 20-39 yrs"
+          },
+          "gt0041": {
+            "id": "gt0041",
+            "text": "Set smoker women: non"
+          },
+          "gt0042": {
+            "id": "gt0042",
+            "text": "Set smoker women: 60-69 yrs"
+          },
+          "gt0043": {
+            "id": "gt0043",
+            "text": "Set smoker women: 70-79 yrs"
+          },
+          "gt0044": {
+            "id": "gt0044",
+            "text": "Set smoker women: 50-59 yrs"
+          },
+          "gt0045": {
+            "id": "gt0045",
+            "text": "Set smoker women: 40-49 yrs"
+          },
+          "gt0046": {
+            "id": "gt0046",
+            "text": "Set smoker women: 20-39 yrs"
+          },
+          "gt0047": {
+            "id": "gt0047",
+            "text": "Set age men: 20-34 yrs"
+          },
+          "gt0048": {
+            "id": "gt0048",
+            "text": "Score 0 - Total cholesterol <160mg/dL: all ages"
+          },
+          "gt0049": {
+            "id": "gt0049",
+            "text": "Score 0 - Men: Total cholesterol 160-239 mg/dL 70-79 yrs"
+          },
+          "gt0050": {
+            "id": "gt0050",
+            "text": "Score 1 - Men: Tot cholesterol 160-239mg/dL (60-69yrs)"
+          },
+          "gt0051": {
+            "id": "gt0051",
+            "text": "Score 1 - Men: Tot cholesterol >= 240 mg/dL (70-79 yrs)"
+          },
+          "gt0052": {
+            "id": "gt0052",
+            "text": "Score 2 - Men: Tot cholesterol 160-199 (50-59) or 240-279 (60-69)"
+          },
+          "gt0053": {
+            "id": "gt0053",
+            "text": "Score 3 - Men: Tot cholesterol 160-199 (40-49yrs); 200-239 (50-59 yrs); >= 280 (60-69yrs)"
+          },
+          "gt0054": {
+            "id": "gt0054",
+            "text": "Score 4 - Men: Tot chol 160-199 (20-39yrs); 240-279 (50-59yrs)"
+          },
+          "gt0055": {
+            "id": "gt0055",
+            "text": "Score 5 - Men: Tot chol 200-239 (40-49yrs); >=280 (50-59yrs)"
+          },
+          "gt0056": {
+            "id": "gt0056",
+            "text": "Score 6 - Men: Tot chol 240-279 (40-49 yrs)"
+          },
+          "gt0057": {
+            "id": "gt0057",
+            "text": "Score 7 - Men: Tot chol 200-239 (20-39yrs)"
+          },
+          "gt0058": {
+            "id": "gt0058",
+            "text": "Score 8 - Men: Tot chol >= 280 (40-49yrs)"
+          },
+          "gt0059": {
+            "id": "gt0059",
+            "text": "Score 9 - Men: Tot chol 240-279 (20-39yrs)"
+          },
+          "gt0060": {
+            "id": "gt0060",
+            "text": "Score 11 - Men: Tot chol >= 280 (20-39yrs)"
+          },
+          "gt0061": {
+            "id": "gt0061",
+            "text": "Default for values out of range: Tot chol and age"
+          },
+          "gt0062": {
+            "id": "gt0062",
+            "text": "Score 1 - Women: Tot chol 160-199 (60-79yrs) or 200-239 (70-79 yrs)"
+          },
+          "gt0063": {
+            "id": "gt0063",
+            "text": "Score 2 - Women: Tot chol 160-199 (50-59 yrs) or 200-239 (60-69 yrs) or >= 240 (70-79 yrs)"
+          },
+          "gt0064": {
+            "id": "gt0064",
+            "text": "Score 3 - Women: Tot chol 160-199 (40-49 yrs) 240-279 (60-69 yrs)"
+          },
+          "gt0065": {
+            "id": "gt0065",
+            "text": "Score 4 - Women: Tot chol 160-199 (20-39 yrs) or 200-239 (50-59 yrs) or >= 280 (60-69 yrs)"
+          },
+          "gt0066": {
+            "id": "gt0066",
+            "text": "Score 5 - Women: Tot chol 240-279 (50-59 yrs)"
+          },
+          "gt0067": {
+            "id": "gt0067",
+            "text": "Score 6 - Women: Tot chol 200-239 (40-49 yrs)"
+          },
+          "gt0068": {
+            "id": "gt0068",
+            "text": "Score 7 - Women: Tot chol >= 280 (50-59 yrs)"
+          },
+          "gt0069": {
+            "id": "gt0069",
+            "text": "Score 8 - Women: Tot chol 200-239 (20-39 yrs) or 240-279 (40-49 yrs)"
+          },
+          "gt0070": {
+            "id": "gt0070",
+            "text": "Score 10 - Women: Tot chol >= 280 (40-49 yrs)"
+          },
+          "gt0071": {
+            "id": "gt0071",
+            "text": "Score 11 - Women: Tot chol 240-279 (20-39 yrs)"
+          },
+          "gt0072": {
+            "id": "gt0072",
+            "text": "Score 13 - Women: Tot chol >= 280 (20-39 yrs)"
+          },
+          "gt0073": {
+            "id": "gt0073",
+            "text": "Set Sys BP Score 0 men"
+          },
+          "gt0074": {
+            "id": "gt0074"
+          },
+          "gt0075": {
+            "id": "gt0075",
+            "text": "Systolic BP: men",
+            "description": "Sys BP scores for men dependant upon patient being on BP medication or not"
+          },
+          "gt0076": {
+            "id": "gt0076",
+            "text": "Systolic BP: women",
+            "description": "Sys BP scores for women dependant upon patient not being on BP medication or not"
+          },
+          "gt0077": {
+            "id": "gt0077",
+            "text": "Score 0 Systolic BP men"
+          },
+          "gt0078": {
+            "id": "gt0078",
+            "text": "Score 1 Systolic BP men"
+          },
+          "gt0079": {
+            "id": "gt0079",
+            "text": "Score 2 Systolic BP men"
+          },
+          "gt0080": {
+            "id": "gt0080",
+            "text": "Score 3 Systolic BP men"
+          },
+          "gt0081": {
+            "id": "gt0081",
+            "text": "Score 0 Systolic BP women"
+          },
+          "gt0082": {
+            "id": "gt0082",
+            "text": "Score 1 Systolic BP women"
+          },
+          "gt0083": {
+            "id": "gt0083",
+            "text": "Score 2 Systolic BP women"
+          },
+          "gt0084": {
+            "id": "gt0084",
+            "text": "Score 3 Systolic BP women"
+          },
+          "gt0085": {
+            "id": "gt0085",
+            "text": "Score 4 Systolic BP women"
+          },
+          "gt0086": {
+            "id": "gt0086",
+            "text": "Score 5 Systolic BP women"
+          },
+          "gt0087": {
+            "id": "gt0087",
+            "text": "Score 6 Systolic BP women"
+          },
+          "gt0088": {
+            "id": "gt0088",
+            "text": "Set HDL cholesterol score 0"
+          },
+          "gt0089": {
+            "id": "gt0089",
+            "text": "Set HDL cholesterol score 1"
+          },
+          "gt0090": {
+            "id": "gt0090",
+            "text": "Set HDL cholesterol score 2"
+          },
+          "gt0091": {
+            "id": "gt0091",
+            "text": "Set HDL score -1"
+          },
+          "gt0092": {
+            "id": "gt0092",
+            "text": "Set HDL score -1"
+          },
+          "gt0094": {
+            "id": "gt0094",
+            "text": "HDL Cholesterol",
+            "description": "HDL-Cholesterol level in the sample."
+          },
+          "gt0095": {
+            "id": "gt0095",
+            "text": "Set HDL cholesterol score -1"
+          },
+          "gt0096": {
+            "id": "gt0096",
+            "text": "test scoring"
+          },
+          "gt0097": {
+            "id": "gt0097",
+            "text": "Set age score 0 for men 40-44 years"
+          },
+          "gt0098": {
+            "id": "gt0098",
+            "text": "Set age score 3 for men 45-49 years"
+          },
+          "gt0099": {
+            "id": "gt0099",
+            "text": "Set age score 6 for men 50-54 years"
+          },
+          "gt0100": {
+            "id": "gt0100",
+            "text": "Set age score 8 for men 55-59 years"
+          },
+          "gt0101": {
+            "id": "gt0101",
+            "text": "Set age score 10 for men 60-64 years"
+          },
+          "gt0102": {
+            "id": "gt0102",
+            "text": "Set age score 11 for men 65-69 years"
+          },
+          "gt0103": {
+            "id": "gt0103",
+            "text": "Set age score 12 for men 70-74 years"
+          },
+          "gt0104": {
+            "id": "gt0104",
+            "text": "Set age score 13 for men 75-79 years"
+          },
+          "gt0105": {
+            "id": "gt0105",
+            "text": "Set age score -9 for men 20-34 years"
+          },
+          "gt0106": {
+            "id": "gt0106",
+            "text": "Set age score -4 for men 35-39 years"
+          },
+          "gt0107": {
+            "id": "gt0107",
+            "text": "HDL value holder",
+            "description": "Slot to hold a negative value for HDL score when HDL is >= 65 mg/dL"
+          },
+          "gt0108": {
+            "id": "gt0108",
+            "text": "Set age score 0 for women 40-44 years "
+          },
+          "gt0109": {
+            "id": "gt0109",
+            "text": "Set age score 3  for women 45-49 years"
+          },
+          "gt0110": {
+            "id": "gt0110",
+            "text": "Set age score 6  for women 50-54 years"
+          },
+          "gt0111": {
+            "id": "gt0111",
+            "text": "Set age score 8  for women 55-59 years"
+          },
+          "gt0112": {
+            "id": "gt0112",
+            "text": "Set age score 10  for women 60-64 years"
+          },
+          "gt0113": {
+            "id": "gt0113",
+            "text": "Set age score 12  for women 65-69 years"
+          },
+          "gt0114": {
+            "id": "gt0114",
+            "text": "Set age score 14  for women 70-74 years"
+          },
+          "gt0115": {
+            "id": "gt0115",
+            "text": "Set age score 16  for women 75-79 years"
+          },
+          "gt0116": {
+            "id": "gt0116",
+            "text": "Set age score -7  for women 20-34 years"
+          },
+          "gt0117": {
+            "id": "gt0117",
+            "text": "Set age score -3  for women 35-39 years"
+          },
+          "gt0118": {
+            "id": "gt0118",
+            "text": "Negative age score holder: men",
+            "description": "To hold negative age score values of -9 and -4 for men"
+          },
+          "gt0119": {
+            "id": "gt0119",
+            "text": "Negative age score holder: women",
+            "description": "To hold negative age score values of -7 and -3 for women"
+          },
+          "gt0120": {
+            "id": "gt0120",
+            "text": "Total score: men"
+          },
+          "gt0121": {
+            "id": "gt0121",
+            "text": "Total score: women"
+          },
+          "gt0122": {
+            "id": "gt0122"
+          },
+          "gt0123": {
+            "id": "gt0123",
+            "text": "Gender",
+            "description": "*"
+          },
+          "gt0124": {
+            "id": "gt0124",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0125": {
+            "id": "gt0125",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0126": {
+            "id": "gt0126",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0127": {
+            "id": "gt0127",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/Framingham_CHD.v1.test.yml
+++ b/gdl2/Framingham_CHD.v1.test.yml
@@ -1,0 +1,224 @@
+guidelines:
+  1: Framingham_CHD.v1
+test_cases:
+- id: Male, default rule
+  input:
+    1:
+      gt0004|Gender: local::at0005|Male|
+      gt0124|Event time: 2019-03-20T09:03Z
+  expected_output:
+    1:
+      'gt0030|Total score: men': 0
+      'gt0021|Smoker: women': 0|local::at0069|Non smoker|
+      'gt0076|Systolic BP: women': 0|local::at0100|< 120|
+      gt0029|Blood Pressure treated with medication: 0|local::at0053|No|
+      'gt0018|Age variable: men': 0|local::at0017|40-44|
+      gt0036|Smoker: 0|local::at0106|No|
+      'gt0024|HDL Cholesterol: men and women': 0|local::at0020|50-59|
+      'gt0020|Smoker: men': 0|local::at0034|Non-smoker |
+      'gt0075|Systolic BP: men': 0|local::at0046|< 120 or 120-129 if untreated|
+      'gt0019|Age variable: women': 0|local::at0061|40-44|
+      'gt0023|Total Cholesterol: women': 0|local::at0076|<160|
+      'gt0022|Total Cholesterol: men': 0|local::at0023|< 160 |
+- id: Female, age calculation 1, default rule
+  input:
+    1:
+      gt0003|Birthdate: 1997-03-04T10:11Z
+      gt0004|Gender: local::at0006|Female|
+      gt0124|Event time: 2019-03-05T10:11Z
+  expected_output:
+    1:
+      gt0006|Age: 22,a
+      'gt0021|Smoker: women': 0|local::at0069|Non smoker|
+      'gt0076|Systolic BP: women': 0|local::at0100|< 120|
+      gt0029|Blood Pressure treated with medication: 0|local::at0053|No|
+      'gt0018|Age variable: men': 0|local::at0017|40-44|
+      gt0036|Smoker: 0|local::at0106|No|
+      'gt0024|HDL Cholesterol: men and women': 0|local::at0020|50-59|
+      'gt0020|Smoker: men': 0|local::at0034|Non-smoker |
+      'gt0075|Systolic BP: men': 0|local::at0046|< 120 or 120-129 if untreated|
+      'gt0019|Age variable: women': -7|local::at0059|20-34|
+      'gt0023|Total Cholesterol: women': 0|local::at0076|<160|
+      'gt0022|Total Cholesterol: men': 0|local::at0023|< 160 |
+      'gt0031|Total score: women': -7
+- id: Female, age calculation 2, default rule
+  input:
+    1:
+      gt0003|Birthdate: 1944-02-26T12:11Z
+      gt0004|Gender: local::at0006|Female|
+      gt0127|Event time: 2019-03-20T12:11Z
+      gt0010|Systolic: 130,mm[Hg]
+      gt0126|Event time: 2019-03-19T12:20Z
+      gt0012|Total Cholesterol: 11,mg/dl
+      gt0013|HDL Cholesterol: 3,mg/dl
+      gt0125|Event time: 2019-03-26T12:33Z
+      gt0015|Smoker: 0|local::at0106|No|
+      gt0016|Blood Pressure treated with medication: 0|local::at0053|No|
+      gt0124|Event time: 2019-03-26T12:26Z
+  expected_output:
+    1:
+      gt0006|Age: 75,a
+      'gt0021|Smoker: women': 0|local::at0069|Non smoker|
+      'gt0076|Systolic BP: women': 2|local::at0102|130-139 if untreated|
+      gt0029|Blood Pressure treated with medication: 0|local::at0053|No|
+      gt0036|Smoker: 0|local::at0106|No|
+      'gt0024|HDL Cholesterol: men and women': 2|local::at0022|< 40|
+      'gt0019|Age variable: women': 16|local::at0068|75-79|
+      'gt0023|Total Cholesterol: women': 0|local::at0076|<160|
+      'gt0022|Total Cholesterol: men': 0|local::at0023|< 160 |
+      'gt0031|Total score: women': 20
+- id: Male >75, Prehypertension
+  input:
+    1:
+      gt0003|Birthdate: 1944-02-26T12:11Z
+      gt0004|Gender: local::at0005|Male|
+      gt0127|Event time: 2019-03-20T12:11Z
+      gt0010|Systolic: 130,mm[Hg]
+      gt0126|Event time: 2019-03-19T12:20Z
+      gt0012|Total Cholesterol: 11,mg/dl
+      gt0013|HDL Cholesterol: 3,mg/dl
+      gt0125|Event time: 2019-03-26T12:33Z
+      gt0015|Smoker: 0|local::at0106|No|
+      gt0016|Blood Pressure treated with medication: 0|local::at0053|No|
+      gt0124|Event time: 2019-03-26T12:26Z
+  expected_output:
+    1:
+      gt0006|Age: 75,a
+      'gt0030|Total score: men': 16
+      gt0029|Blood Pressure treated with medication: 0|local::at0053|No|
+      'gt0018|Age variable: men': 13|local::at0044|75-79|
+      gt0036|Smoker: 0|local::at0106|No|
+      'gt0024|HDL Cholesterol: men and women': 2|local::at0022|< 40|
+      'gt0020|Smoker: men': 0|local::at0034|Non-smoker |
+      'gt0075|Systolic BP: men': 1|local::at0047|120-129 if treated or 130-159 if untreated|
+      'gt0023|Total Cholesterol: women': 0|local::at0076|<160|
+      'gt0022|Total Cholesterol: men': 0|local::at0023|< 160 |
+- id: Male >75, Hypertension, no medication
+  input:
+    1:
+      gt0003|Birthdate: 1944-02-26T12:11Z
+      gt0004|Gender: local::at0005|Male|
+      gt0127|Event time: 2019-03-20T12:11Z
+      gt0010|Systolic: 150,mm[Hg]
+      gt0126|Event time: 2019-03-19T12:20Z
+      gt0012|Total Cholesterol: 11,mg/dl
+      gt0013|HDL Cholesterol: 3,mg/dl
+      gt0125|Event time: 2019-03-26T12:33Z
+      gt0015|Smoker: 0|local::at0106|No|
+      gt0016|Blood Pressure treated with medication: 0|local::at0053|No|
+      gt0124|Event time: 2019-03-26T12:26Z
+  expected_output:
+    1:
+      gt0006|Age: 75,a
+      'gt0030|Total score: men': 16
+      gt0029|Blood Pressure treated with medication: 0|local::at0053|No|
+      'gt0018|Age variable: men': 13|local::at0044|75-79|
+      gt0036|Smoker: 0|local::at0106|No|
+      'gt0024|HDL Cholesterol: men and women': 2|local::at0022|< 40|
+      'gt0020|Smoker: men': 0|local::at0034|Non-smoker |
+      'gt0075|Systolic BP: men': 1|local::at0047|120-129 if treated or 130-159 if untreated|
+      'gt0023|Total Cholesterol: women': 0|local::at0076|<160|
+      'gt0022|Total Cholesterol: men': 0|local::at0023|< 160 |
+- id: Male >75, Hypertension, with medication
+  input:
+    1:
+      gt0003|Birthdate: 1944-02-26T12:11Z
+      gt0004|Gender: local::at0005|Male|
+      gt0127|Event time: 2019-03-20T12:11Z
+      gt0010|Systolic: 140,mm[Hg]
+      gt0126|Event time: 2019-03-19T12:20Z
+      gt0012|Total Cholesterol: 11,mg/dl
+      gt0013|HDL Cholesterol: 3,mg/dl
+      gt0125|Event time: 2019-03-26T12:33Z
+      gt0015|Smoker: 0|local::at0106|No|
+      gt0016|Blood Pressure treated with medication: 1|local::at0054|Yes|
+      gt0124|Event time: 2019-03-26T12:26Z
+  expected_output:
+    1:
+      gt0006|Age: 75,a
+      'gt0030|Total score: men': 17
+      gt0029|Blood Pressure treated with medication: 1|local::at0054|Yes|
+      'gt0018|Age variable: men': 13|local::at0044|75-79|
+      gt0036|Smoker: 0|local::at0106|No|
+      'gt0024|HDL Cholesterol: men and women': 2|local::at0022|< 40|
+      'gt0020|Smoker: men': 0|local::at0034|Non-smoker |
+      'gt0075|Systolic BP: men': 2|local::at0048|130-159 if treated or ≥ 160 if untreated|
+      'gt0023|Total Cholesterol: women': 0|local::at0076|<160|
+      'gt0022|Total Cholesterol: men': 0|local::at0023|< 160 |
+- id: Middle-age smoker man, unhealthy cholesterol
+  input:
+    1:
+      gt0003|Birthdate: 1964-02-26T12:11Z
+      gt0004|Gender: local::at0005|Male|
+      gt0127|Event time: 2019-03-20T12:11Z
+      gt0010|Systolic: 201,mm[Hg]
+      gt0126|Event time: 2019-03-19T12:20Z
+      gt0012|Total Cholesterol: 11,mg/dl
+      gt0013|HDL Cholesterol: 51,mg/dl
+      gt0125|Event time: 2019-03-26T12:33Z
+      gt0015|Smoker: 1|local::at0107|Yes|
+      gt0016|Blood Pressure treated with medication: 1|local::at0054|Yes|
+      gt0124|Event time: 2019-03-26T12:26Z
+  expected_output:
+    1:
+      gt0006|Age: 55,a
+      'gt0030|Total score: men': 14
+      gt0029|Blood Pressure treated with medication: 1|local::at0054|Yes|
+      'gt0018|Age variable: men': 8|local::at0040|55-59|
+      gt0036|Smoker: 1|local::at0107|Yes|
+      'gt0024|HDL Cholesterol: men and women': 0|local::at0020|50-59|
+      'gt0020|Smoker: men': 3|local::at0036|Smoker - 50 -59|
+      'gt0075|Systolic BP: men': 3|local::at0049|≥ 160 if treated|
+      'gt0023|Total Cholesterol: women': 0|local::at0076|<160|
+      'gt0022|Total Cholesterol: men': 0|local::at0023|< 160 |
+- id: Healthy old lady
+  input:
+    1:
+      gt0003|Birthdate: 1948-02-26T12:11Z
+      gt0004|Gender: local::at0006|Female|
+      gt0127|Event time: 2019-03-20T12:11Z
+      gt0010|Systolic: 110,mm[Hg]
+      gt0126|Event time: 2019-03-19T12:20Z
+      gt0012|Total Cholesterol: 110,mg/dl
+      gt0013|HDL Cholesterol: 60,mg/dl
+      gt0125|Event time: 2019-03-26T12:33Z
+      gt0015|Smoker: 0|local::at0106|No|
+      gt0016|Blood Pressure treated with medication: 0|local::at0053|No|
+      gt0124|Event time: 2019-03-26T12:26Z
+  expected_output:
+    1:
+      gt0006|Age: 71,a
+      'gt0021|Smoker: women': 0|local::at0069|Non smoker|
+      'gt0076|Systolic BP: women': 0|local::at0100|< 120|
+      gt0029|Blood Pressure treated with medication: 0|local::at0053|No|
+      gt0036|Smoker: 0|local::at0106|No|
+      'gt0024|HDL Cholesterol: men and women': -1|local::at0019|≥60|
+      'gt0019|Age variable: women': 14|local::at0067|70-74|
+      'gt0023|Total Cholesterol: women': 0|local::at0076|<160|
+      'gt0022|Total Cholesterol: men': 0|local::at0023|< 160 |
+      'gt0031|Total score: women': 13
+- id: Unhealthy young man
+  input:
+    1:
+      gt0003|Birthdate: 1988-02-26T12:11Z
+      gt0004|Gender: local::at0005|Male|
+      gt0127|Event time: 2019-03-20T12:11Z
+      gt0010|Systolic: 160,mm[Hg]
+      gt0126|Event time: 2019-03-19T12:20Z
+      gt0012|Total Cholesterol: 260,mg/dl
+      gt0013|HDL Cholesterol: 40,mg/dl
+      gt0125|Event time: 2019-03-26T12:33Z
+      gt0015|Smoker: 1|local::at0107|Yes|
+      gt0016|Blood Pressure treated with medication: 0|local::at0053|No|
+      gt0124|Event time: 2019-03-26T12:26Z
+  expected_output:
+    1:
+      gt0006|Age: 31,a
+      'gt0030|Total score: men': 11
+      gt0029|Blood Pressure treated with medication: 0|local::at0053|No|
+      'gt0018|Age variable: men': -9|local::at0015|20-34|
+      gt0036|Smoker: 1|local::at0107|Yes|
+      'gt0024|HDL Cholesterol: men and women': 1|local::at0021|40-49|
+      'gt0020|Smoker: men': 8|local::at0038|Smoker - 20-39|
+      'gt0075|Systolic BP: men': 2|local::at0048|130-159 if treated or ≥ 160 if untreated|
+      'gt0022|Total Cholesterol: men': 9|local::at0032|240-279 (20-39 years)|

--- a/gdl2/Framingham_CHD_Assessment.v1.gdl2.json
+++ b/gdl2/Framingham_CHD_Assessment.v1.gdl2.json
@@ -1,0 +1,552 @@
+{
+  "id": "Framingham_CHD_Assessment.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2017-03-09",
+      "name": "Syeeda S Farruque",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "other_contributors": [
+      "Dennis Forslund",
+      "Jimmy Axelsson"
+    ],
+    "lifecycle_state": "Not set",
+    "details": {
+      "en": {
+        "id": "en",
+        "purpose": "This Framingham Risk score is based on the 'Hard' Coronary Framingham outcomes model, which omits co-morbidities and is used to calculate an estimate of the risk of occurence of a heart attack within a 10 year period.",
+        "keywords": [
+          "Framingham Risk score",
+          "coronary artery disease"
+        ],
+        "use": "The score is calculated differently between males and females and is based on the total sum of 5 of the 7 individual variables with continuous variables discretized.\r\n\r\nThe scoring system sheets can be seen in (1). \r\nScore interpretations can be found in more detail on (2) As example for men:\r\n\r\nScore of 5-6                               Relates to 2% 10 year CHD RIsk\r\nScore of 12                                 Relates to 10% 10 year CHD Risk\r\nScore of ≥17                              Relates to > 30% 10 year CHD Risk",
+        "misuse": "The tool should be used with caution when applied to varying populations (as figures are based on the US population over many years). The tool should also be accompanied by other supporting evidence and clinical judgement when utilising the results.",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Ref.1: Wilson PW, et. al. Prediction of Coronary Heart Disease Using Risk Factor Categories. Circulation 1998. 97(18): 1837-1847.\r\n\r\nRef. 2: D'Agostino RB, Sr. Vasan RS, Pencina M.J, Wolf PA, Cobain M, Massaro JM, Kannel WB. (2008) General cardiovascular risk profile for use in primary care: the Framingham Heart Study. Circulation 117(6): 743–753."
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0002": {
+        "id": "gt0002",
+        "model_id": "openEHR-EHR-EVALUATION.framingham_chd_risk_score_assessment.v1",
+        "template_id": "openEHR-EHR-EVALUATION.framingham_chd_risk_score_assessment.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0009": {
+            "id": "gt0009",
+            "path": "/data[at0001]/items[at0002]"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "path": "/data[at0001]/items[at0003]"
+          }
+        }
+      },
+      "gt0003": {
+        "id": "gt0003",
+        "model_id": "openEHR-EHR-OBSERVATION.framingham_chd_risk_score.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.framingham_chd_risk_score.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0007": {
+            "id": "gt0007",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0011]"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0055]"
+          }
+        }
+      }
+    },
+    "rules": {
+      "gt0013": {
+        "id": "gt0013",
+        "priority": 30,
+        "when": [
+          "$gt0007|Total score: men|<0"
+        ],
+        "then": [
+          "$gt0009|Risk percentage in men|=0|local::at0004|0% Risk|"
+        ]
+      },
+      "gt0014": {
+        "id": "gt0014",
+        "priority": 29,
+        "when": [
+          "$gt0007|Total score: men|==0"
+        ],
+        "then": [
+          "$gt0009|Risk percentage in men|=1|local::at0005|< 1% Risk|"
+        ]
+      },
+      "gt0015": {
+        "id": "gt0015",
+        "priority": 28,
+        "when": [
+          "$gt0007|Total score: men|<=4",
+          "$gt0007|Total score: men|>=1"
+        ],
+        "then": [
+          "$gt0009|Risk percentage in men|=2|local::at0006|1% Risk|"
+        ]
+      },
+      "gt0016": {
+        "id": "gt0016",
+        "priority": 27,
+        "when": [
+          "$gt0007|Total score: men|<=6",
+          "$gt0007|Total score: men|>=5"
+        ],
+        "then": [
+          "$gt0009|Risk percentage in men|=3|local::at0007|2% Risk|"
+        ]
+      },
+      "gt0017": {
+        "id": "gt0017",
+        "priority": 26,
+        "when": [
+          "$gt0007|Total score: men|==7"
+        ],
+        "then": [
+          "$gt0009|Risk percentage in men|=4|local::at0008|3% Risk|"
+        ]
+      },
+      "gt0018": {
+        "id": "gt0018",
+        "priority": 25,
+        "when": [
+          "$gt0007|Total score: men|==8"
+        ],
+        "then": [
+          "$gt0009|Risk percentage in men|=5|local::at0009|4% Risk|"
+        ]
+      },
+      "gt0019": {
+        "id": "gt0019",
+        "priority": 24,
+        "when": [
+          "$gt0007|Total score: men|==9"
+        ],
+        "then": [
+          "$gt0009|Risk percentage in men|=6|local::at0010|5% Risk|"
+        ]
+      },
+      "gt0020": {
+        "id": "gt0020",
+        "priority": 23,
+        "when": [
+          "$gt0007|Total score: men|==10"
+        ],
+        "then": [
+          "$gt0009|Risk percentage in men|=7|local::at0011|6% Risk|"
+        ]
+      },
+      "gt0021": {
+        "id": "gt0021",
+        "priority": 22,
+        "when": [
+          "$gt0007|Total score: men|==11"
+        ],
+        "then": [
+          "$gt0009|Risk percentage in men|=8|local::at0012|8% Risk|"
+        ]
+      },
+      "gt0022": {
+        "id": "gt0022",
+        "priority": 21,
+        "when": [
+          "$gt0007|Total score: men|==12"
+        ],
+        "then": [
+          "$gt0009|Risk percentage in men|=9|local::at0013|10% Risk|"
+        ]
+      },
+      "gt0023": {
+        "id": "gt0023",
+        "priority": 20,
+        "when": [
+          "$gt0007|Total score: men|==13"
+        ],
+        "then": [
+          "$gt0009|Risk percentage in men|=10|local::at0014|12% RIsk|"
+        ]
+      },
+      "gt0024": {
+        "id": "gt0024",
+        "priority": 19,
+        "when": [
+          "$gt0007|Total score: men|==14"
+        ],
+        "then": [
+          "$gt0009|Risk percentage in men|=11|local::at0015|16% Risk|"
+        ]
+      },
+      "gt0025": {
+        "id": "gt0025",
+        "priority": 18,
+        "when": [
+          "$gt0007|Total score: men|==15"
+        ],
+        "then": [
+          "$gt0009|Risk percentage in men|=12|local::at0016|20% Risk|"
+        ]
+      },
+      "gt0026": {
+        "id": "gt0026",
+        "priority": 17,
+        "when": [
+          "$gt0007|Total score: men|==16"
+        ],
+        "then": [
+          "$gt0009|Risk percentage in men|=13|local::at0017|25% Risk|"
+        ]
+      },
+      "gt0027": {
+        "id": "gt0027",
+        "priority": 16,
+        "when": [
+          "$gt0007|Total score: men|>=17"
+        ],
+        "then": [
+          "$gt0009|Risk percentage in men|=14|local::at0018|>30% Risk|"
+        ]
+      },
+      "gt0028": {
+        "id": "gt0028",
+        "priority": 15,
+        "when": [
+          "$gt0008|Total score: women|<0"
+        ],
+        "then": [
+          "$gt0010|Risk percentage in women|=0|local::at0019|0% Risk|"
+        ]
+      },
+      "gt0029": {
+        "id": "gt0029",
+        "priority": 14,
+        "when": [
+          "$gt0008|Total score: women|<=8",
+          "$gt0008|Total score: women|>=0"
+        ],
+        "then": [
+          "$gt0010|Risk percentage in women|=1|local::at0020|< 1% Risk|"
+        ]
+      },
+      "gt0030": {
+        "id": "gt0030",
+        "priority": 13,
+        "when": [
+          "$gt0008|Total score: women|<=12",
+          "$gt0008|Total score: women|>=9"
+        ],
+        "then": [
+          "$gt0010|Risk percentage in women|=2|local::at0021|1% Risk|"
+        ]
+      },
+      "gt0031": {
+        "id": "gt0031",
+        "priority": 12,
+        "when": [
+          "$gt0008|Total score: women|<=14",
+          "$gt0008|Total score: women|>=13"
+        ],
+        "then": [
+          "$gt0010|Risk percentage in women|=3|local::at0022|2% Risk|"
+        ]
+      },
+      "gt0032": {
+        "id": "gt0032",
+        "priority": 11,
+        "when": [
+          "$gt0008|Total score: women|==15"
+        ],
+        "then": [
+          "$gt0010|Risk percentage in women|=4|local::at0023|3% Risk|"
+        ]
+      },
+      "gt0033": {
+        "id": "gt0033",
+        "priority": 10,
+        "when": [
+          "$gt0008|Total score: women|==16"
+        ],
+        "then": [
+          "$gt0010|Risk percentage in women|=5|local::at0024|4% Risk|"
+        ]
+      },
+      "gt0034": {
+        "id": "gt0034",
+        "priority": 9,
+        "when": [
+          "$gt0008|Total score: women|==17"
+        ],
+        "then": [
+          "$gt0010|Risk percentage in women|=6|local::at0025|5% Risk|"
+        ]
+      },
+      "gt0035": {
+        "id": "gt0035",
+        "priority": 8,
+        "when": [
+          "$gt0008|Total score: women|==18"
+        ],
+        "then": [
+          "$gt0010|Risk percentage in women|=7|local::at0026|6% Risk|"
+        ]
+      },
+      "gt0036": {
+        "id": "gt0036",
+        "priority": 7,
+        "when": [
+          "$gt0008|Total score: women|==19"
+        ],
+        "then": [
+          "$gt0010|Risk percentage in women|=8|local::at0027|8% Risk|"
+        ]
+      },
+      "gt0037": {
+        "id": "gt0037",
+        "priority": 6,
+        "when": [
+          "$gt0008|Total score: women|==20"
+        ],
+        "then": [
+          "$gt0010|Risk percentage in women|=9|local::at0028|11% Risk|"
+        ]
+      },
+      "gt0038": {
+        "id": "gt0038",
+        "priority": 5,
+        "when": [
+          "$gt0008|Total score: women|==21"
+        ],
+        "then": [
+          "$gt0010|Risk percentage in women|=10|local::at0029|14% Risk|"
+        ]
+      },
+      "gt0039": {
+        "id": "gt0039",
+        "priority": 4,
+        "when": [
+          "$gt0008|Total score: women|==22"
+        ],
+        "then": [
+          "$gt0010|Risk percentage in women|=11|local::at0030|17% Risk|"
+        ]
+      },
+      "gt0040": {
+        "id": "gt0040",
+        "priority": 3,
+        "when": [
+          "$gt0008|Total score: women|==23"
+        ],
+        "then": [
+          "$gt0010|Risk percentage in women|=12|local::at0031|22% Risk|"
+        ]
+      },
+      "gt0041": {
+        "id": "gt0041",
+        "priority": 2,
+        "when": [
+          "$gt0008|Total score: women|==24"
+        ],
+        "then": [
+          "$gt0010|Risk percentage in women|=13|local::at0032|27% Risk|"
+        ]
+      },
+      "gt0042": {
+        "id": "gt0042",
+        "priority": 1,
+        "when": [
+          "$gt0008|Total score: women|>=25"
+        ],
+        "then": [
+          "$gt0010|Risk percentage in women|=14|local::at0033|>30% Risk|"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Framingham CHD Assessment",
+            "description": "The Framingham CHD (Coronary Artery Disease)  Risk Score estimates the risk of heart attack in 10 years."
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Total score: men",
+            "description": "Sum of individual scores for men"
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Total score: women",
+            "description": "Sum of individual scores for women"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Total score: men",
+            "description": "Sum of individual scores for men"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Total score: women",
+            "description": "Sum of individual scores for women"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Risk percentage in men",
+            "description": "Framingham risk score result interpretation for men"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Risk percentage in women",
+            "description": "Framingham risk score result interpretation for women"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Set score men"
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "Set score women"
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "Set 0% Risk: men"
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "Set <1% Risk: men"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "Set 1% Risk: men"
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "Set 2% Risk: men"
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "text": "Set 3% Risk: men"
+          },
+          "gt0018": {
+            "id": "gt0018",
+            "text": "Set 4% Risk: men"
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "text": "Set 5% Risk: men"
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "Set 6% Risk: men"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "text": "Set 8% Risk: men"
+          },
+          "gt0022": {
+            "id": "gt0022",
+            "text": "Set 10% Risk: men"
+          },
+          "gt0023": {
+            "id": "gt0023",
+            "text": "Set 12% Risk: men"
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "text": "Set 16% Risk: men"
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "text": "Set 20% Risk: men"
+          },
+          "gt0026": {
+            "id": "gt0026",
+            "text": "Set 25% Risk: men"
+          },
+          "gt0027": {
+            "id": "gt0027",
+            "text": "Set >30% Risk: men"
+          },
+          "gt0028": {
+            "id": "gt0028",
+            "text": "Set 0% Risk: women"
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "text": "Set <1% Risk: women"
+          },
+          "gt0030": {
+            "id": "gt0030",
+            "text": "Set 1% Risk: women"
+          },
+          "gt0031": {
+            "id": "gt0031",
+            "text": "Set 2% Risk: women"
+          },
+          "gt0032": {
+            "id": "gt0032",
+            "text": "Set 3% Risk: women"
+          },
+          "gt0033": {
+            "id": "gt0033",
+            "text": "Set 4% Risk: women"
+          },
+          "gt0034": {
+            "id": "gt0034",
+            "text": "Set 5% Risk: women"
+          },
+          "gt0035": {
+            "id": "gt0035",
+            "text": "Set 6% Risk: women"
+          },
+          "gt0036": {
+            "id": "gt0036",
+            "text": "Set 8% Risk: women"
+          },
+          "gt0037": {
+            "id": "gt0037",
+            "text": "Set 11% Risk: women"
+          },
+          "gt0038": {
+            "id": "gt0038",
+            "text": "Set 14% Risk: women"
+          },
+          "gt0039": {
+            "id": "gt0039",
+            "text": "Set 17% Risk: women"
+          },
+          "gt0040": {
+            "id": "gt0040",
+            "text": "Set 22% Risk: women"
+          },
+          "gt0041": {
+            "id": "gt0041",
+            "text": "Set 27% Risk: women"
+          },
+          "gt0042": {
+            "id": "gt0042",
+            "text": "Set >30% Risk: women"
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/Framingham_CHD_Assessment.v1.test.yml
+++ b/gdl2/Framingham_CHD_Assessment.v1.test.yml
@@ -1,0 +1,59 @@
+guidelines:
+  1: Framingham_CHD_Assessment.v1
+test_cases:
+- id: Male 1
+  input:
+    1:
+      'gt0007|Total score: men': 1
+  expected_output:
+    1:
+      gt0009|Risk percentage in men: 2|local::at0006|1% Risk|
+- id: Male 6
+  input:
+    1:
+      'gt0007|Total score: men': 6
+  expected_output:
+    1:
+      gt0009|Risk percentage in men: 3|local::at0007|2% Risk|
+- id: Male 7
+  input:
+    1:
+      'gt0007|Total score: men': 7
+  expected_output:
+    1:
+      gt0009|Risk percentage in men: 4|local::at0008|3% Risk|
+- id: Male 17
+  input:
+    1:
+      'gt0007|Total score: men': 17
+  expected_output:
+    1:
+      gt0009|Risk percentage in men: 14|local::at0018|>30% Risk|
+- id: Female 3
+  input:
+    1:
+      'gt0008|Total score: women': 3
+  expected_output:
+    1:
+      gt0010|Risk percentage in women: 1|local::at0020|< 1% Risk|
+- id: Female 17
+  input:
+    1:
+      'gt0008|Total score: women': 17
+  expected_output:
+    1:
+      gt0010|Risk percentage in women: 6|local::at0025|5% Risk|
+- id: Female 19
+  input:
+    1:
+      'gt0008|Total score: women': 19
+  expected_output:
+    1:
+      gt0010|Risk percentage in women: 8|local::at0027|8% Risk|
+- id: Female 25
+  input:
+    1:
+      'gt0008|Total score: women': 25
+  expected_output:
+    1:
+      gt0010|Risk percentage in women: 14|local::at0033|>30% Risk|


### PR DESCRIPTION
Dear Isabelle,

Hear is the Framingham score calculation guidelines, I hope it is good as it is.
The guidelines work as good as in GDL1 but in the future they might need improvment as I encountered some unexpected behavior during migration/testing.
Framingham CHD: Instead of looking for Age in the output, I used the rule fired("calculate age") precondition for some of the rules.
Remarks: The implementation (the original as well) might need some revision and simplification in the future, now there are 50+ rules. And in addition, it does not handle mmol/l values and default rule is meant only if most of the variables are left out, if for example smoking habit is given, it won't fire anymore.
The CHD assessment did not need to much modification.