### PR TITLE
GAD Assessment

### DIFF
--- a/gdl2/GAD-7.v1.gdl2.json
+++ b/gdl2/GAD-7.v1.gdl2.json
@@ -1,0 +1,665 @@
+{
+  "id": "GAD-7.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2016-10-08",
+      "name": "Eneimi Allwell-Brown",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "other_contributors": [
+      "Jimmy Axelsson",
+      "Dennis Forslund"
+    ],
+    "lifecycle_state": "Author draft",
+    "details": {
+      "en": {
+        "id": "en",
+        "purpose": "It is intended to identify individuals with generalized anxiety disorder (GAD) and assess the severity of anxiety symptoms using a 7-item self-reported questionnaire (GAD-7).",
+        "keywords": [
+          "generalized anxiety disorder",
+          "GAD-7",
+          "panic disorder",
+          "social anxiety disorder",
+          "post-traumatic stress disorder",
+          "PTSD"
+        ],
+        "use": "Used to screen individuals for Generalized Anxiety Disorder (GAD) based on the individual's health status in the past 2 weeks. Also used to assess the severity of anxiety symptoms and their change over time. May be used to screen individuals for panic disorder, social anxiety disorder and post-traumatic stress disorder (PTSD). \r\n\r\nThe GAD-7 scale consists of 7 questions with answers scored on a 4-point Likert scale:\r\n(0 = Not at all, 1 = Several days, 2 = More than half the days, 3 = Nearly every day). \r\n\r\nThe total score is the sum of the scores on all 7 items and gives a minimum score of 0 and maximum score of 21. \r\nScores of 5, 10 and 15 are cut-off points for mild, moderate and severe anxiety respectively. Further evaluation of the individual is recommended with a total score of 10 or greater.",
+        "misuse": "Should not to be used for making confirmatory diagnoses.\r\nGAD-7 provides only a probable diagnosis which requires confirmation by further evaluation.",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Spitzer RL, Kroenke K, Williams JB, Löwe B. A brief measure for assessing generalized anxiety disorder: the GAD-7. Archives of internal medicine. 2006 May 22;166(10):1092-7.\r\n\r\nKroenke K, Spitzer RL, Williams JB, Monahan PO, Lo?we B. Anxiety disorders in primary care: prevalence, impairment, comorbidity, and detection. Annals of internal medicine. 2007 Mar 6;146(5):317-25."
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0003": {
+        "id": "gt0003",
+        "model_id": "openEHR-EHR-OBSERVATION.generalized_anxiety_disorder_7.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.generalized_anxiety_disorder_7.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0008": {
+            "id": "gt0008",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0005]"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0010]"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0015]"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0021]"
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0026]"
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0031]"
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0036]"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0006": {
+        "id": "gt0006",
+        "model_id": "openEHR-EHR-OBSERVATION.generalized_anxiety_disorder_7.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.generalized_anxiety_disorder_7.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0019": {
+            "id": "gt0019",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0005]"
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0010]"
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0015]"
+          },
+          "gt0034": {
+            "id": "gt0034",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0021]"
+          },
+          "gt0039": {
+            "id": "gt0039",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0026]"
+          },
+          "gt0044": {
+            "id": "gt0044",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0031]"
+          },
+          "gt0049": {
+            "id": "gt0049",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0036]"
+          },
+          "gt0055": {
+            "id": "gt0055",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0042]"
+          }
+        }
+      }
+    },
+    "rules": {
+      "gt0053": {
+        "id": "gt0053",
+        "priority": 30,
+        "when": [
+          "$gt0049|Feeling afraid as if something awful might happen|==null",
+          "$gt0044|Becoming easily annoyed or irritable|==null",
+          "$gt0039|Being so restless that it is hard to sit still|==null",
+          "$gt0034|Trouble relaxing|==null",
+          "$gt0029|Worrying too much about different things|==null",
+          "$gt0024|Not being able to stop or control worrying|==null",
+          "$gt0019|Feeling nervous, anxious or on edge|==null"
+        ],
+        "then": [
+          "$gt0049|Feeling afraid as if something awful might happen|=0|local::at0037|Not at all|",
+          "$gt0044|Becoming easily annoyed or irritable|=0|local::at0032|Not at all|",
+          "$gt0039|Being so restless that it is hard to sit still|=0|local::at0027|Not at all|",
+          "$gt0034|Trouble relaxing|=0|local::at0022|Not at all|",
+          "$gt0029|Worrying too much about different things|=0|local::at0016|Not at all|",
+          "$gt0024|Not being able to stop or control worrying|=0|local::at0011|Not at all|",
+          "$gt0019|Feeling nervous, anxious or on edge|=0|local::at0006|Not at all|"
+        ]
+      },
+      "gt0018": {
+        "id": "gt0018",
+        "priority": 29,
+        "when": [
+          "$gt0008|Feeling nervous, anxious or on edge|==0|local::at0006|Not at all|"
+        ],
+        "then": [
+          "$gt0019|Feeling nervous, anxious or on edge|=0|local::at0006|Not at all|"
+        ]
+      },
+      "gt0020": {
+        "id": "gt0020",
+        "priority": 28,
+        "when": [
+          "$gt0008|Feeling nervous, anxious or on edge|==1|local::at0007|Several days|"
+        ],
+        "then": [
+          "$gt0019|Feeling nervous, anxious or on edge|=1|local::at0007|Several days|"
+        ]
+      },
+      "gt0021": {
+        "id": "gt0021",
+        "priority": 27,
+        "when": [
+          "$gt0008|Feeling nervous, anxious or on edge|==2|local::at0008|More than half the days|"
+        ],
+        "then": [
+          "$gt0019|Feeling nervous, anxious or on edge|=2|local::at0008|More than half the days|"
+        ]
+      },
+      "gt0022": {
+        "id": "gt0022",
+        "priority": 26,
+        "when": [
+          "$gt0008|Feeling nervous, anxious or on edge|==3|local::at0009|Nearly every day|"
+        ],
+        "then": [
+          "$gt0019|Feeling nervous, anxious or on edge|=3|local::at0009|Nearly every day|"
+        ]
+      },
+      "gt0023": {
+        "id": "gt0023",
+        "priority": 25,
+        "when": [
+          "$gt0009|Not being able to stop or control worrying|==0|local::at0011|Not at all|"
+        ],
+        "then": [
+          "$gt0024|Not being able to stop or control worrying|=0|local::at0011|Not at all|"
+        ]
+      },
+      "gt0025": {
+        "id": "gt0025",
+        "priority": 24,
+        "when": [
+          "$gt0009|Not being able to stop or control worrying|==1|local::at0012|Several days|"
+        ],
+        "then": [
+          "$gt0024|Not being able to stop or control worrying|=1|local::at0012|Several days|"
+        ]
+      },
+      "gt0026": {
+        "id": "gt0026",
+        "priority": 23,
+        "when": [
+          "$gt0009|Not being able to stop or control worrying|==2|local::at0013|More than half the days|"
+        ],
+        "then": [
+          "$gt0024|Not being able to stop or control worrying|=2|local::at0013|More than half the days|"
+        ]
+      },
+      "gt0027": {
+        "id": "gt0027",
+        "priority": 22,
+        "when": [
+          "$gt0009|Not being able to stop or control worrying|==3|local::at0014|Nearly every day|"
+        ],
+        "then": [
+          "$gt0024|Not being able to stop or control worrying|=3|local::at0014|Nearly every day|"
+        ]
+      },
+      "gt0028": {
+        "id": "gt0028",
+        "priority": 21,
+        "when": [
+          "$gt0010|Worrying too much about different things|==0|local::at0016|Not at all|"
+        ],
+        "then": [
+          "$gt0029|Worrying too much about different things|=0|local::at0016|Not at all|"
+        ]
+      },
+      "gt0030": {
+        "id": "gt0030",
+        "priority": 20,
+        "when": [
+          "$gt0010|Worrying too much about different things|==1|local::at0017|Several days|"
+        ],
+        "then": [
+          "$gt0029|Worrying too much about different things|=1|local::at0017|Several days|"
+        ]
+      },
+      "gt0031": {
+        "id": "gt0031",
+        "priority": 19,
+        "when": [
+          "$gt0010|Worrying too much about different things|==2|local::at0018|More than half the days|"
+        ],
+        "then": [
+          "$gt0029|Worrying too much about different things|=2|local::at0018|More than half the days|"
+        ]
+      },
+      "gt0032": {
+        "id": "gt0032",
+        "priority": 18,
+        "when": [
+          "$gt0010|Worrying too much about different things|==3|local::at0019|Nearly every day|"
+        ],
+        "then": [
+          "$gt0029|Worrying too much about different things|=3|local::at0019|Nearly every day|"
+        ]
+      },
+      "gt0033": {
+        "id": "gt0033",
+        "priority": 17,
+        "when": [
+          "$gt0011|Trouble relaxing|==0|local::at0022|Not at all|"
+        ],
+        "then": [
+          "$gt0034|Trouble relaxing|=0|local::at0022|Not at all|"
+        ]
+      },
+      "gt0035": {
+        "id": "gt0035",
+        "priority": 16,
+        "when": [
+          "$gt0011|Trouble relaxing|==1|local::at0023|Several days|"
+        ],
+        "then": [
+          "$gt0034|Trouble relaxing|=1|local::at0023|Several days|"
+        ]
+      },
+      "gt0036": {
+        "id": "gt0036",
+        "priority": 15,
+        "when": [
+          "$gt0011|Trouble relaxing|==2|local::at0024|More than half the days|"
+        ],
+        "then": [
+          "$gt0034|Trouble relaxing|=2|local::at0024|More than half the days|"
+        ]
+      },
+      "gt0037": {
+        "id": "gt0037",
+        "priority": 14,
+        "when": [
+          "$gt0011|Trouble relaxing|==3|local::at0025|Nearly every day|"
+        ],
+        "then": [
+          "$gt0034|Trouble relaxing|=3|local::at0025|Nearly every day|"
+        ]
+      },
+      "gt0038": {
+        "id": "gt0038",
+        "priority": 13,
+        "when": [
+          "$gt0012|Being so restless that it is hard to sit still|==0|local::at0027|Not at all|"
+        ],
+        "then": [
+          "$gt0039|Being so restless that it is hard to sit still|=0|local::at0027|Not at all|"
+        ]
+      },
+      "gt0040": {
+        "id": "gt0040",
+        "priority": 12,
+        "when": [
+          "$gt0012|Being so restless that it is hard to sit still|==1|local::at0028|Several days|"
+        ],
+        "then": [
+          "$gt0039|Being so restless that it is hard to sit still|=1|local::at0028|Several days|"
+        ]
+      },
+      "gt0041": {
+        "id": "gt0041",
+        "priority": 11,
+        "when": [
+          "$gt0012|Being so restless that it is hard to sit still|==2|local::at0029|More than half the days|"
+        ],
+        "then": [
+          "$gt0039|Being so restless that it is hard to sit still|=2|local::at0029|More than half the days|"
+        ]
+      },
+      "gt0042": {
+        "id": "gt0042",
+        "priority": 10,
+        "when": [
+          "$gt0012|Being so restless that it is hard to sit still|==3|local::at0030|Nearly every day|"
+        ],
+        "then": [
+          "$gt0039|Being so restless that it is hard to sit still|=3|local::at0030|Nearly every day|"
+        ]
+      },
+      "gt0043": {
+        "id": "gt0043",
+        "priority": 9,
+        "when": [
+          "$gt0013|Becoming easily annoyed or irritable|==0|local::at0032|Not at all|"
+        ],
+        "then": [
+          "$gt0044|Becoming easily annoyed or irritable|=0|local::at0032|Not at all|"
+        ]
+      },
+      "gt0045": {
+        "id": "gt0045",
+        "priority": 8,
+        "when": [
+          "$gt0013|Becoming easily annoyed or irritable|==1|local::at0033|Several days|"
+        ],
+        "then": [
+          "$gt0044|Becoming easily annoyed or irritable|=1|local::at0033|Several days|"
+        ]
+      },
+      "gt0046": {
+        "id": "gt0046",
+        "priority": 7,
+        "when": [
+          "$gt0013|Becoming easily annoyed or irritable|==2|local::at0034|More than half the days|"
+        ],
+        "then": [
+          "$gt0044|Becoming easily annoyed or irritable|=2|local::at0034|More than half the days|"
+        ]
+      },
+      "gt0047": {
+        "id": "gt0047",
+        "priority": 6,
+        "when": [
+          "$gt0013|Becoming easily annoyed or irritable|==3|local::at0035|Nearly every day|"
+        ],
+        "then": [
+          "$gt0044|Becoming easily annoyed or irritable|=3|local::at0035|Nearly every day|"
+        ]
+      },
+      "gt0048": {
+        "id": "gt0048",
+        "priority": 5,
+        "when": [
+          "$gt0014|Feeling afraid as if something awful might happen|==0|local::at0037|Not at all|"
+        ],
+        "then": [
+          "$gt0049|Feeling afraid as if something awful might happen|=0|local::at0037|Not at all|"
+        ]
+      },
+      "gt0050": {
+        "id": "gt0050",
+        "priority": 4,
+        "when": [
+          "$gt0014|Feeling afraid as if something awful might happen|==1|local::at0038|Several days|"
+        ],
+        "then": [
+          "$gt0049|Feeling afraid as if something awful might happen|=1|local::at0038|Several days|"
+        ]
+      },
+      "gt0051": {
+        "id": "gt0051",
+        "priority": 3,
+        "when": [
+          "$gt0014|Feeling afraid as if something awful might happen|==2|local::at0039|More than half the days|"
+        ],
+        "then": [
+          "$gt0049|Feeling afraid as if something awful might happen|=2|local::at0039|More than half the days|"
+        ]
+      },
+      "gt0052": {
+        "id": "gt0052",
+        "priority": 2,
+        "when": [
+          "$gt0014|Feeling afraid as if something awful might happen|==3|local::at0040|Nearly every day|"
+        ],
+        "then": [
+          "$gt0049|Feeling afraid as if something awful might happen|=3|local::at0040|Nearly every day|"
+        ]
+      },
+      "gt0002": {
+        "id": "gt0002",
+        "priority": 1,
+        "when": [
+          "$gt0055|GAD-7 Total score|==null"
+        ],
+        "then": [
+          "$gt0055|GAD-7 Total score|.magnitude=((((($gt0044.value+$gt0034.value)+$gt0024.value)+$gt0029.value)+$gt0019.value)+$gt0049.value)+$gt0039.value"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Generalized Anxiety Disorder Score",
+            "description": "Generalized anxiety disorder score (GAD-7) is a seven-item self-report screening tool for identifying individuals with probable generalized anxiety disorder and assessing the severity of symptoms. Answers to the 7 questions are scored on a 4-point Likert scale: (0 = Not at all, 1 = Several days, 2 = More than half the days, 3 = Nearly every day), giving a minimum score = 0 and a maximum score = 28. Mild, moderate and severe anxiety are defined by scores of 5, 10 and 15 respectively. Individuals with score >= 10 require further evaluation."
+          },
+          "gt0002": {
+            "id": "gt0002",
+            "text": "Calculate GAD-7 Score",
+            "description": "This rule contains the expression logic for calculating the GAD-7 score."
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Feeling nervous, anxious or on edge",
+            "description": "Instantiates the EHR element Feeling nervous, anxious or on edge."
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Not being able to stop or control worrying",
+            "description": "Instantiates the EHR element Not being able to stop or control worrying"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Worrying too much about different things",
+            "description": "Instantiates the EHR element Worrying too much about different things."
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Trouble relaxing",
+            "description": "Instantiates the EHR element Trouble relaxing."
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "Being so restless that it is hard to sit still",
+            "description": "Instantiates the EHR element Being so restless that it is hard to sit still."
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "Becoming easily annoyed or irritable",
+            "description": "Instantiates the EHR element Becoming easily annoyed or irritable."
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "Feeling afraid as if something awful might happen",
+            "description": "Instantiates the EHR element Feeling afraid as if something awful might happen."
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0018": {
+            "id": "gt0018",
+            "text": "Set Feeling nervous, anxious, or on edge to 0"
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "text": "Feeling nervous, anxious or on edge",
+            "description": "Instantiates the CDS element Feeling nervous, anxious or on edge."
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "Set Feeling nervous, anxious, or on edge to 1"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "text": "Set Feeling nervous, anxious, or on edge to 2"
+          },
+          "gt0022": {
+            "id": "gt0022",
+            "text": "Set Feeling nervous, anxious, or on edge to 3"
+          },
+          "gt0023": {
+            "id": "gt0023",
+            "text": "Set Not being able to stop or control worrying to 0",
+            "description": ""
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "text": "Not being able to stop or control worrying",
+            "description": "Instantiates the CDS element Not being able to stop or control worrying."
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "text": "Set Not being able to stop or control worrying to 1"
+          },
+          "gt0026": {
+            "id": "gt0026",
+            "text": "Set Not being able to stop or control worrying to 2"
+          },
+          "gt0027": {
+            "id": "gt0027",
+            "text": "Set Not being able to stop or control worrying to 3"
+          },
+          "gt0028": {
+            "id": "gt0028",
+            "text": "Set Worrying too much about different things to 0"
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "text": "Worrying too much about different things",
+            "description": "Instantiates the CDS element Worrying too much about different things."
+          },
+          "gt0030": {
+            "id": "gt0030",
+            "text": "Set Worrying too much about different things to 1"
+          },
+          "gt0031": {
+            "id": "gt0031",
+            "text": "Set Worrying too much about different things to 2"
+          },
+          "gt0032": {
+            "id": "gt0032",
+            "text": "Set Worrying too much about different things to 3"
+          },
+          "gt0033": {
+            "id": "gt0033",
+            "text": "Set Trouble relaxing to 0"
+          },
+          "gt0034": {
+            "id": "gt0034",
+            "text": "Trouble relaxing",
+            "description": "Instantiates the CDS element Trouble relaxing."
+          },
+          "gt0035": {
+            "id": "gt0035",
+            "text": "Set Trouble relaxing to 1"
+          },
+          "gt0036": {
+            "id": "gt0036",
+            "text": "Set Trouble relaxing to 2"
+          },
+          "gt0037": {
+            "id": "gt0037",
+            "text": "Set Trouble relaxing to 3"
+          },
+          "gt0038": {
+            "id": "gt0038",
+            "text": "Set Being so restless that it is hard to sit still to 0"
+          },
+          "gt0039": {
+            "id": "gt0039",
+            "text": "Being so restless that it is hard to sit still",
+            "description": "Instantiates the CDS element Being so restless that it is hard to sit still."
+          },
+          "gt0040": {
+            "id": "gt0040",
+            "text": "Set Being so restless that it is hard to sit still to 1"
+          },
+          "gt0041": {
+            "id": "gt0041",
+            "text": "Set Being so restless that it is hard to sit still to 2"
+          },
+          "gt0042": {
+            "id": "gt0042",
+            "text": "Set Being so restless that it is hard to sit still to 3"
+          },
+          "gt0043": {
+            "id": "gt0043",
+            "text": "Set Becoming easily annoyed or irritable to 0"
+          },
+          "gt0044": {
+            "id": "gt0044",
+            "text": "Becoming easily annoyed or irritable",
+            "description": "Instantiates the CDS element Becoming easily annoyed or irritable."
+          },
+          "gt0045": {
+            "id": "gt0045",
+            "text": "Set Becoming easily annoyed or irritable to 1"
+          },
+          "gt0046": {
+            "id": "gt0046",
+            "text": "Set Becoming easily annoyed or irritable to 2"
+          },
+          "gt0047": {
+            "id": "gt0047",
+            "text": "Set Becoming easily annoyed or irritable to 3"
+          },
+          "gt0048": {
+            "id": "gt0048",
+            "text": "Set Feeling afraid as if something awful might happen to 0"
+          },
+          "gt0049": {
+            "id": "gt0049",
+            "text": "Feeling afraid as if something awful might happen",
+            "description": "Instantiates the CDS element Feeling afraid as if something awful might happen."
+          },
+          "gt0050": {
+            "id": "gt0050",
+            "text": "Set Feeling afraid as if something awful might happen to 1"
+          },
+          "gt0051": {
+            "id": "gt0051",
+            "text": "Set Feeling afraid as if something awful might happen to 2"
+          },
+          "gt0052": {
+            "id": "gt0052",
+            "text": "Set Feeling afraid as if something awful might happen to 3"
+          },
+          "gt0053": {
+            "id": "gt0053",
+            "text": "Set default",
+            "description": "This rule contains the expression logic setting the default values for all 7 questionnaire items to 0 (Not at all)."
+          },
+          "gt0055": {
+            "id": "gt0055",
+            "text": "GAD-7 Total score",
+            "description": "Sum of the ordinal scores recorded for each of the 7 GAD questionnaire responses."
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/GAD-7.v1.test.yml
+++ b/gdl2/GAD-7.v1.test.yml
@@ -1,0 +1,96 @@
+guidelines:
+  1: GAD-7.v1
+test_cases:
+- id: Default
+  input:
+    1: {}
+  expected_output:
+    1:
+      gt0024|Not being able to stop or control worrying: 0|local::at0011|Not at all|
+      gt0055|GAD-7 Total score: 0
+      gt0029|Worrying too much about different things: 0|local::at0016|Not at all|
+      gt0049|Feeling afraid as if something awful might happen: 0|local::at0037|Not at all|
+      gt0039|Being so restless that it is hard to sit still: 0|local::at0027|Not at all|
+      gt0044|Becoming easily annoyed or irritable: 0|local::at0032|Not at all|
+      gt0019|Feeling nervous, anxious or on edge: 0|local::at0006|Not at all|
+      gt0034|Trouble relaxing: 0|local::at0022|Not at all|
+- id: Negative
+  input:
+    1:
+      gt0008|Feeling nervous, anxious or on edge: 0|local::at0006|Not at all|
+      gt0009|Not being able to stop or control worrying: 0|local::at0011|Not at all|
+      gt0010|Worrying too much about different things: 0|local::at0016|Not at all|
+      gt0011|Trouble relaxing: 0|local::at0022|Not at all|
+      gt0012|Being so restless that it is hard to sit still: 0|local::at0027|Not at all|
+      gt0013|Becoming easily annoyed or irritable: 0|local::at0032|Not at all|
+      gt0014|Feeling afraid as if something awful might happen: 0|local::at0037|Not at all|
+  expected_output:
+    1:
+      gt0024|Not being able to stop or control worrying: 0|local::at0011|Not at all|
+      gt0055|GAD-7 Total score: 0
+      gt0029|Worrying too much about different things: 0|local::at0016|Not at all|
+      gt0049|Feeling afraid as if something awful might happen: 0|local::at0037|Not at all|
+      gt0039|Being so restless that it is hard to sit still: 0|local::at0027|Not at all|
+      gt0044|Becoming easily annoyed or irritable: 0|local::at0032|Not at all|
+      gt0019|Feeling nervous, anxious or on edge: 0|local::at0006|Not at all|
+      gt0034|Trouble relaxing: 0|local::at0022|Not at all|
+- id: Mild anxiety
+  input:
+    1:
+      gt0008|Feeling nervous, anxious or on edge: 1|local::at0007|Several days|
+      gt0009|Not being able to stop or control worrying: 1|local::at0012|Several days|
+      gt0010|Worrying too much about different things: 0|local::at0016|Not at all|
+      gt0011|Trouble relaxing: 2|local::at0024|More than half the days|
+      gt0012|Being so restless that it is hard to sit still: 0|local::at0027|Not at all|
+      gt0013|Becoming easily annoyed or irritable: 2|local::at0034|More than half the days|
+      gt0014|Feeling afraid as if something awful might happen: 0|local::at0037|Not at all|
+  expected_output:
+    1:
+      gt0024|Not being able to stop or control worrying: 1|local::at0012|Several days|
+      gt0055|GAD-7 Total score: 6
+      gt0029|Worrying too much about different things: 0|local::at0016|Not at all|
+      gt0049|Feeling afraid as if something awful might happen: 0|local::at0037|Not at all|
+      gt0039|Being so restless that it is hard to sit still: 0|local::at0027|Not at all|
+      gt0044|Becoming easily annoyed or irritable: 2|local::at0034|More than half the days|
+      gt0019|Feeling nervous, anxious or on edge: 1|local::at0007|Several days|
+      gt0034|Trouble relaxing: 2|local::at0024|More than half the days|
+- id: Moderate anxiety
+  input:
+    1:
+      gt0008|Feeling nervous, anxious or on edge: 3|local::at0009|Nearly every day|
+      gt0009|Not being able to stop or control worrying: 2|local::at0013|More than half the days|
+      gt0010|Worrying too much about different things: 3|local::at0019|Nearly every day|
+      gt0011|Trouble relaxing: 2|local::at0024|More than half the days|
+      gt0012|Being so restless that it is hard to sit still: 0|local::at0027|Not at all|
+      gt0013|Becoming easily annoyed or irritable: 2|local::at0034|More than half the days|
+      gt0014|Feeling afraid as if something awful might happen: 1|local::at0038|Several days|
+  expected_output:
+    1:
+      gt0024|Not being able to stop or control worrying: 2|local::at0013|More than half the days|
+      gt0055|GAD-7 Total score: 13
+      gt0029|Worrying too much about different things: 3|local::at0019|Nearly every day|
+      gt0049|Feeling afraid as if something awful might happen: 1|local::at0038|Several days|
+      gt0039|Being so restless that it is hard to sit still: 0|local::at0027|Not at all|
+      gt0044|Becoming easily annoyed or irritable: 2|local::at0034|More than half the days|
+      gt0019|Feeling nervous, anxious or on edge: 3|local::at0009|Nearly every day|
+      gt0034|Trouble relaxing: 2|local::at0024|More than half the days|
+- id: Severe anxiety
+  input:
+    1:
+      gt0008|Feeling nervous, anxious or on edge: 3|local::at0009|Nearly every day|
+      gt0009|Not being able to stop or control worrying: 2|local::at0013|More than half the days|
+      gt0010|Worrying too much about different things: 3|local::at0019|Nearly every day|
+      gt0011|Trouble relaxing: 3|local::at0025|Nearly every day|
+      gt0012|Being so restless that it is hard to sit still: 3|local::at0030|Nearly every day|
+      gt0013|Becoming easily annoyed or irritable: 2|local::at0034|More than half the days|
+      gt0014|Feeling afraid as if something awful might happen: 3|local::at0040|Nearly every day|
+  expected_output:
+    1:
+      gt0024|Not being able to stop or control worrying: 2|local::at0013|More than half the days|
+      gt0055|GAD-7 Total score: 19
+      gt0029|Worrying too much about different things: 3|local::at0019|Nearly every day|
+      gt0049|Feeling afraid as if something awful might happen: 3|local::at0040|Nearly every day|
+      gt0039|Being so restless that it is hard to sit still: 3|local::at0030|Nearly every day|
+      gt0044|Becoming easily annoyed or irritable: 2|local::at0034|More than half the days|
+      gt0019|Feeling nervous, anxious or on edge: 3|local::at0009|Nearly every day|
+      gt0034|Trouble relaxing: 3|local::at0025|Nearly every day|

--- a/gdl2/GAD-7_Assessment.v1.gdl2.json
+++ b/gdl2/GAD-7_Assessment.v1.gdl2.json
@@ -1,0 +1,208 @@
+{
+  "id": "GAD-7_Assessment.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2017-03-04",
+      "name": "Eneimi Allwell-Brown",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "other_contributors": [
+      "Dennis Forslund",
+      "Jimmy Axelsson"
+    ],
+    "lifecycle_state": "Author draft",
+    "details": {
+      "sv": {
+        "id": "sv",
+        "purpose": "Att utvärdera poäng genererad i enlighet med Generalized Anxiety Disorder score (GAD-7), ett screeningtest bestående av sju faktorer för identifiering av individer med generaliserat ångestsyndrom.",
+        "keywords": [
+          "GAD-7",
+          "generaliserat ångestsyndrom",
+          "ångest",
+          "panikångest",
+          "paniksyndrom",
+          "social fobi",
+          "socialt ångestsyndrom",
+          "post-traumatiskt stressyndrom",
+          "PTSD",
+          "psykiatri"
+        ],
+        "use": "Använd för att utvärdera poäng genererad i enlighet med Generalized Anxiety Disorder score (GAD-7), ett screeningtest bestående av sju faktorer för identifiering av individer med generaliserat ångestsyndrom.\r\n\r\nTestet baseras på individens psykiska hälsostatus under senaste två veckorna. Används även för att utvärdera och gradera ångestrelaterade symtom och deras förändring över tid. Ytterligare användningsområden inkluderar screening för paniksyndrom, social fobi (socialt ångestsyndrom) och post-traumatiskt stressyndrom. \r\n\r\nGAD-7-formuläret består av sju frågor som besvaras med ett av fyra alternativ (Likert-skala): 0 = Inte alls, 1 = Flera dagar, 2 = Mer än hälften av dagarna, 3 = Nästan varje dag.\r\n\r\nMaximal poäng är 21. Resultatet tolkas enligt:\r\n5-9p - mild ångest\r\n10-14p - måttlig ångest\r\n15 eller mer - svår ångest\r\n\r\nVidare, utvidgad utredning är indicerad vid en genererad poäng om tio eller mer.",
+        "misuse": "Är ej avsedd att användas diagnostiskt. Användning av GAD-7 ger endast indikation om förekomst av ångestsyndrom och måste bekräftas med vidare utredning.",
+        "copyright": "© Cambio Healthcare Systems"
+      },
+      "en": {
+        "id": "en",
+        "purpose": "To identify individuals with generalized anxiety disorder (GAD) and assess the severity of anxiety symptoms using a 7-item self-reported questionnaire (GAD-7).",
+        "keywords": [
+          "anxiety disorder",
+          "panic disorder",
+          "social anxiety disorder",
+          "post-traumatic stress disorder",
+          "GAD-7",
+          "PTSD",
+          "Psychiatry"
+        ],
+        "use": "Used to screen individuals for Generalized Anxiety Disorder (GAD) based on the individual's health status in the past 2 weeks. Also used to assess the severity of anxiety symptoms and their change over time. May be used to screen individuals for panic disorder, social anxiety disorder and post-traumatic stress disorder (PTSD), but the highest sensitivity and specificity is for GAD.\r\n\r\nThe GAD-7 scale consists of 7 questions with answers scored on a 4-point Likert scale:\r\n(0 = Not at all, 1 = Several days, 2 = More than half the days, 3 = Nearly every day). \r\n\r\nThe total score is the sum of the scores on all 7 items and gives a minimum score of 0 and maximum score of 21. \r\nScores of 5, 10 and 15 are cut-off points for mild, moderate and severe anxiety respectively.  Score > 8 is consistent with anxiety disorder or panic disorder, and further evaluation of the individual is recommended with a total score of 10 or greater. GAD-7 scoring is performing by a separate application: GAD-7.v1",
+        "misuse": "Not to be used for confirmatory diagnosis.\r\nGAD-7 provides only probable diagnosis which needs to be confirmed by further evaluation.\r\nAlways rule out other medical causes of anxiety first, e.g ECG for arrhythmias and TSH for thyroid disease.",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Spitzer RL, Kroenke K, Williams JB, Löwe B. A brief measure for assessing generalized anxiety disorder: the GAD-7. Archives of internal medicine. 2006 May 22;166(10):1092-7.\r\n\r\nKroenke K, Spitzer RL, Williams JB, Monahan PO, Löwe B. Anxiety disorders in primary care: prevalence, impairment, comorbidity, and detection. Annals of internal medicine. 2007 Mar 6;146(5):317-25."
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0002": {
+        "id": "gt0002",
+        "model_id": "openEHR-EHR-OBSERVATION.generalized_anxiety_disorder_7.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.generalized_anxiety_disorder_7.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0003": {
+            "id": "gt0003",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0042]"
+          }
+        }
+      },
+      "gt0004": {
+        "id": "gt0004",
+        "model_id": "openEHR-EHR-EVALUATION.generalized_anxiety_disorder_7.v1",
+        "template_id": "openEHR-EHR-EVALUATION.generalized_anxiety_disorder_7.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0005": {
+            "id": "gt0005",
+            "path": "/data[at0001]/items[at0002]"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "path": "/data[at0001]/items[at0008]"
+          }
+        }
+      }
+    },
+    "rules": {
+      "gt0007": {
+        "id": "gt0007",
+        "priority": 3,
+        "when": [
+          "$gt0003|GAD-7 Total score|<=9",
+          "$gt0003|GAD-7 Total score|>=5"
+        ],
+        "then": [
+          "$gt0010|Recommendation|=local::at0009|Monitor anxiety symptoms|",
+          "$gt0005|Anxiety severity|=local::at0003|Mild anxiety|"
+        ]
+      },
+      "gt0008": {
+        "id": "gt0008",
+        "priority": 2,
+        "when": [
+          "$gt0003|GAD-7 Total score|<=14",
+          "$gt0003|GAD-7 Total score|>=10"
+        ],
+        "then": [
+          "$gt0010|Recommendation|=local::at0010|Probable GAD-7; requires further evaluation|",
+          "$gt0005|Anxiety severity|=local::at0004|Moderate anxiety|"
+        ]
+      },
+      "gt0009": {
+        "id": "gt0009",
+        "priority": 1,
+        "when": [
+          "$gt0003|GAD-7 Total score|>15"
+        ],
+        "then": [
+          "$gt0010|Recommendation|=local::at0011|Active treatment probably warranted|",
+          "$gt0005|Anxiety severity|=local::at0005|Severe anxiety|"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "sv": {
+        "id": "sv",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Generalized Anxiety Disorder Score utvärdering",
+            "description": "Utvärdering av poäng genererad i enlighet med Generalized Anxiety Disorder score (GAD-7), ett screeningtest bestående av sju faktorer för identifiering av individer med generaliserat ångestsyndrom. "
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "GAD-7 Total poäng",
+            "description": "*(en) Sum of the ordinal scores recorded for each of the 7 GAD questionnaire responses."
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Ångestnivå",
+            "description": "*(en) The assessment of anxiety symptoms based on GAD-7 scale."
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "CDS lindrig ångest"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "CDS måttlig ångest"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "CDS svår ångest"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Rekommendation",
+            "description": "*(en) Recommendation based on assessed anxiety severity."
+          }
+        }
+      },
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Generalized Anxiety Disorder Score Assessment",
+            "description": "GAD-7 is a rapid seven-item screening test for identifying individuals with clinically significant anxiety disorder (generalized anxiety disorder [GAD], panic disorder [PD], social anxiety isorder [SAD] and post-traumatic stress disorder [PTSD]), especially in the out-patient setting. It consists of 7 questions regarding anxiety symptoms in the past 2 weeks, which are answered on a 4-point Likert scale: (0 = Not at all, 1 = Several days, 2 = More than half the days, 3 = Nearly every day), with a minimum score of 0 and a maximum score of 21. Scores of 5 - 9, 10 - 14, and >15 are cut-off points for mild, moderate and severe anxiety respectively. Score > 8 is consistent with anxiety disorder or panic disorder, and further evaluation of the individual is recommended with a total score of 10 or greater."
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "GAD-7 Total score",
+            "description": "Sum of the ordinal scores recorded for each of the 7 GAD questionnaire responses."
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Anxiety severity",
+            "description": "The assessment of anxiety symptoms based on GAD-7 scale."
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Set mild anxiety"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Set moderate anxiety"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Set severe anxiety"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Recommendation",
+            "description": "Recommendation based on assessed anxiety severity."
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/GAD-7_Assessment.v1.test.yml
+++ b/gdl2/GAD-7_Assessment.v1.test.yml
@@ -1,0 +1,28 @@
+guidelines:
+  1: GAD-7_Assessment.v1
+test_cases:
+- id: Mild
+  input:
+    1:
+      gt0003|GAD-7 Total score: 5
+  expected_output:
+    1:
+      gt0010|Recommendation: local::at0009|Monitor anxiety symptoms|
+      gt0005|Anxiety severity: local::at0003|Mild anxiety|
+- id: Moderate
+  input:
+    1:
+      gt0003|GAD-7 Total score: 11
+  expected_output:
+    1:
+      gt0010|Recommendation: local::at0010|Probable GAD-7; requires further evaluation|
+      gt0005|Anxiety severity: local::at0004|Moderate anxiety|
+- id: Severe
+  input:
+    1:
+      gt0003|GAD-7 Total score: 16
+  expected_output:
+    1:
+      gt0010|Recommendation: local::at0011|Active treatment probably warranted|
+      gt0005|Anxiety severity: local::at0005|Severe anxiety|
+


### PR DESCRIPTION
GAD Assessment migrated.
Similar changes than in the previous commits.
Note: There is no rule for total score < 5, i.e. no suspected anxiety, it might be useful to add this.