### PR TITLE
Glasgow Blatchford score migrated

### DIFF
--- a/gdl2/GBS_Assessment.v1.gdl2.json
+++ b/gdl2/GBS_Assessment.v1.gdl2.json
@@ -1,0 +1,196 @@
+{
+  "id": "GBS_Assessment.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2017-03-01",
+      "name": "Syeeda S Farruque",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "other_contributors": [
+      "Eneimi Allwell-Brown",
+      "Dennis Forslund",
+      "Jimmy Axelsson"
+    ],
+    "lifecycle_state": "Author draft",
+    "details": {
+      "sv": {
+        "id": "sv",
+        "purpose": "Att utvärdera poäng genererad i enlighet med Glasgow-Blatchford Bleeding Score, som används för att i initialt skede uppskatta risk med avseende på behandlingsbehov, re-blödning och mortalitet hos patienter med övre GI-blödning. Instrumentet baseras på åtta faktorer, och maximal poäng uppgår till 23p. Noll poäng indikerar låg komplikationsrisk (0,5%). Ju högre poäng, desto högre risk. Instrumentet har visats ha högre sensitivitet än Rockall score, och korrelerar väl med vårdtid och behov av blodtransfusion.",
+        "keywords": [
+          "GI-blödning",
+          "blödning",
+          "Glasgow-Blatchford"
+        ],
+        "use": "Använd för att utvärdera poäng genererad i enlighet med Glasgow-Blatchford Bleeding Score, som används för att i initialt skede uppskatta risk med avseende på behandlingsbehov, re-blödning och mortalitet hos patienter med övre GI-blödning. \r\n\r\nInstrumentet baseras på följande faktorer, registrerade vid ankomst:\r\n\r\n- Urea (0-6p)\r\n- Hemoglobin (0-6p)\r\n- Hjärtfrekvens (0-1p)\r\n- Systoliskt blodtryck (0-3p)\r\n- Synkope vid ankomst (0-2p)\r\n- Melena (0-1p)\r\n- Tecken på leversjukdom (0-2p)\r\n- Tecken på hjärtsjukdom (0-2p)\r\n\r\nMaximal poäng uppgår till 23p. 0p indikerar låg komplikationsrisk (0,5%). Ju högre poäng, desto högre risk. ",
+        "misuse": "Endast avsedd för bruk vid initial bedömning.",
+        "copyright": "© Cambio Healthcare Systems"
+      },
+      "en": {
+        "id": "en",
+        "purpose": "To stratify patients with acute UGIB into low or high risk groups for needing treatment, rebleeding or mortality",
+        "keywords": [
+          "upper GI bleeding",
+          "upper GI haemorrhage",
+          "Rockall score",
+          "nonvariceal bleeding"
+        ],
+        "use": "The points are summed to give a total score (Glasgow-Blatchford bleeding score) between 0 - 23, with score of 0 (zero) suggesting a low risk of complications (0.5%) and higher scores corresponding to increasing acuity, need for treatment, and mortality.",
+        "misuse": "Should only be used at initial patient ssessment.",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Ref. 1: Blatchford O, Murray WR, Blatchford M. A risk score to predict need for treatment for uppergastrointestinal haemorrhage. The Lancet. 2000 Oct 14;356(9238):1318-21.\r\n\r\nRef. 2: Chen IC, Hung MS, Chiu TF, Chen JC, Hsiao CT. Risk scoring systems to predict need for clinical intervention for patients with nonvariceal upper gastrointestinal tract bleeding. The American journal of emergency medicine. 2007 Sep 30;25(7):774-9.\r\n\r\nRef. 3: Srirajaskanthan R, Conn R, Bulwer C, Irving P. The Glasgow Blatchford scoring system enables accurate risk stratification of patients with upper gastrointestinal haemorrhage. International journal of clinical practice. 2010 Jun 1;64(7):868-74."
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0002": {
+        "id": "gt0002",
+        "model_id": "openEHR-EHR-EVALUATION.glasgow_blatchford_bleeding_score_assessment.v1",
+        "template_id": "openEHR-EHR-EVALUATION.glasgow_blatchford_bleeding_score_assessment.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0007": {
+            "id": "gt0007",
+            "path": "/data[at0001]/items[at0002]"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "path": "/data[at0001]/items[at0005]"
+          }
+        }
+      },
+      "gt0003": {
+        "id": "gt0003",
+        "model_id": "openEHR-EHR-OBSERVATION.glasgow_blatchford_bleeding_score.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.glasgow_blatchford_bleeding_score.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0006": {
+            "id": "gt0006",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0012]"
+          }
+        }
+      }
+    },
+    "rules": {
+      "gt0010": {
+        "id": "gt0010",
+        "priority": 2,
+        "when": [
+          "$gt0006|Total score|==0"
+        ],
+        "then": [
+          "$gt0007|Score interpretation|=0|local::at0003|Score 0 suggesting a 0.5% risk of complications|",
+          "$gt0008|Reccomendation|=0|local::at0006|No intervention required|"
+        ]
+      },
+      "gt0011": {
+        "id": "gt0011",
+        "priority": 1,
+        "when": [
+          "$gt0006|Total score|>0"
+        ],
+        "then": [
+          "$gt0008|Reccomendation|=1|local::at0007|Intervention required|",
+          "$gt0007|Score interpretation|=1|local::at0004|Score > 0 suggesting high risk of complications|"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "sv": {
+        "id": "sv",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Glasgow-Blatchford Bleeding Score utvärdering",
+            "description": "Utvärdering av poäng genererad i enlighet med Glasgow-Blatchford Bleeding Score, som används för att i initialt skede uppskatta risk med avseende på behandlingsbehov, re-blödning och mortalitet hos patienter med övre GI-blödning. Instrumentet baseras på åtta faktorer, och maximal poäng uppgår till 23p. Noll poäng indikerar låg komplikationsrisk (0,5%). Ju högre poäng, desto högre risk. Instrumentet har visats ha högre sensitivitet än Rockall score, och korrelerar väl med vårdtid och behov av blodtransfusion."
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Total poäng",
+            "description": "*(en) Sum of the individual scores assigned for each of the contributing variables."
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Total poäng",
+            "description": "*(en) Sum of the individual scores assigned for each of the contributing variables."
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Resultat",
+            "description": "*(en) A score of 0 (zero) suggesting a low risk of complications (0.5%) and higher scores corresponding to increasing acuity, need for treatment, and mortality.\r\n"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Rekommendation",
+            "description": "*(en) A score of 0 (zero) suggesting a low risk of complications (0.5%) and higher scores corresponding to increasing acuity, need for treatment, and mortality."
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Total poäng"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "CDS resultat: 0"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "CDS resultat: > 0"
+          }
+        }
+      },
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "GBS_Assessment",
+            "description": "A risk-stratification system for patients with acute upper-gastrointestinal bleeding (UGIB), to discriminate between patients at high or low risk of dying or rebleeding. GBS is more sensitive than clinical and complete Rockall scores for identifying high-risk patients with acute UGIB."
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Total score",
+            "description": "Sum of the individual scores assigned for each of the contributing variables."
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Total score",
+            "description": "Sum of the individual scores assigned for each of the contributing variables."
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Score interpretation",
+            "description": "A score of 0 (zero) suggesting a low risk of complications (0.5%) and higher scores corresponding to increasing acuity, need for treatment, and mortality.\r\n"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Reccomendation",
+            "description": "A score of 0 (zero) suggesting a low risk of complications (0.5%) and higher scores corresponding to increasing acuity, need for treatment, and mortality."
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Tot score"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Set Interpretation: 0"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Set Interpretation: > 0"
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/GBS_Assessment.v1.test.yml
+++ b/gdl2/GBS_Assessment.v1.test.yml
@@ -1,0 +1,19 @@
+guidelines:
+  1: GBS_Assessment.v1
+test_cases:
+- id: High risk
+  input:
+    1:
+      gt0006|Total score: 6
+  expected_output:
+    1:
+      gt0008|Reccomendation: 1|local::at0007|Intervention required|
+      gt0007|Score interpretation: 1|local::at0004|Score > 0 suggesting high risk of complications|
+- id: Low risk
+  input:
+    1:
+      gt0006|Total score: 0
+  expected_output:
+    1:
+      gt0008|Reccomendation: 0|local::at0006|No intervention required|
+      gt0007|Score interpretation: 0|local::at0003|Score 0 suggesting a 0.5% risk of complications|

--- a/gdl2/Glasgow_Blatchford_score_Calculation.v1.gdl2.json
+++ b/gdl2/Glasgow_Blatchford_score_Calculation.v1.gdl2.json
@@ -1,0 +1,1060 @@
+{
+  "id": "Glasgow_Blatchford_score_Calculation.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2017-01-03",
+      "name": "Eneimi Allwell-Brown",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "other_contributors": [
+      "Dennis Forslund",
+      "Jimmy Axelsson"
+    ],
+    "lifecycle_state": "Author draft",
+    "details": {
+      "sv": {
+        "id": "sv",
+        "purpose": "Att uppskatta risk med avseende på behandlingsbehov, re-blödning och mortalitet hos patienter med övre GI-blödning.\r\n",
+        "keywords": [
+          "GI-blödning",
+          "blödning",
+          "Rockall score",
+          "gastrointestinal blödning",
+          "gastrointestinal blödning, övre"
+        ],
+        "use": "Att registrera data och resultat i enlighet med Glasgow-Blatchford bleeding score i syfte att uppskatta risk med avseende på behandlingsbehov (blodtransfusion, endoskopi, kirurgi), re-blödning och mortalitet hos patienter med övre GI-blödning.\r\n\r\nInstrumentet baseras på följande faktorer, registrerade vid ankomst:\r\n\r\n- Urea (0-6p)\r\n- Hemoglobin (0-6p)\r\n- Hjärtfrekvens (0-1p)\r\n- Systoliskt blodtryck (0-3p)\r\n- Synkope vid ankomst (0-2p)\r\n- Melena (0-1p)\r\n- Tecken på leversjukdom (0-2p)\r\n- Tecken på hjärtsjukdom (0-2p)\r\n\r\nMaximal poäng uppgår till 23p. 0p indikerar låg komplikationsrisk (0,5%). Ju högre poäng, desto högre risk. ",
+        "misuse": "Endast avsedd för bruk vid initial bedömning.",
+        "copyright": "© Cambio Healthcare Systems"
+      },
+      "en": {
+        "id": "en",
+        "purpose": "To stratify patients with acute UGIB into low or high risk groups for needing treatment, rebleeding or mortality.",
+        "keywords": [
+          "nonvariceal bleeding",
+          "upper GI bleeding",
+          "upper GI haemorrhage",
+          "Rockall score"
+        ],
+        "use": "To calculate the Glasgow-Blatchford bleeding score and stratify patients with acute UGIB as low or high risk of needing treatment (blood transfusion, endoscopy or surgery), rebleeding, or dying. Points are assigned for patients' admission haemoglobin (0 - 6), blood urea (0 - 6), pulse rate (0 -1), and systolic blood pressure (0 -3), as well as presentation with syncope (0 - 2) or melaena (0 - 1), and evidence of hepatic disease (0 - 2) or cardiac failure (0 - 2). The points are summed to give a total score (Glasgow-Blatchford bleeding score) between 0 - 23, with score of 0 (zero) suggesting a low risk of complications (0.5%) and higher scores corresponding to increasing acuity, need for treatment, duration of hospital stay, and mortality.\nBlood urea concentration is given as mg/dl (divide by 0.3571 to convert from mmol/L to mg/dl), while haemoglobin concentration is given as g/dl (divide by 10 to convert from g/L to g/dl).",
+        "misuse": "Should only be used with clinical and laboratory values obtained at initial patient assessment.",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Blatchford O, Murray WR, Blatchford M. A risk score to predict need for treatment for uppergastrointestinal haemorrhage. The Lancet. 2000 Oct 14;356(9238):1318-21.\r\n\r\nChen IC, Hung MS, Chiu TF, Chen JC, Hsiao CT. Risk scoring systems to predict need for clinical intervention for patients with nonvariceal upper gastrointestinal tract bleeding. The American journal of emergency medicine. 2007 Sep 30;25(7):774-9.\r\n\r\nSrirajaskanthan R, Conn R, Bulwer C, Irving P. The Glasgow Blatchford scoring system enables accurate risk stratification of patients with upper gastrointestinal haemorrhage. International journal of clinical practice. 2010 Jun 1;64(7):868-74."
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0002": {
+        "id": "gt0002",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-full_blood_count.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-full_blood_count.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0003": {
+            "id": "gt0003",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.4]"
+          },
+          "gt0067": {
+            "id": "gt0067",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0004": {
+        "id": "gt0004",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-urea_and_electrolytes.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-urea_and_electrolytes.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0005": {
+            "id": "gt0005",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.1]"
+          },
+          "gt0068": {
+            "id": "gt0068",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0006": {
+        "id": "gt0006",
+        "model_id": "openEHR-EHR-OBSERVATION.blood_pressure.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.blood_pressure.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0007": {
+            "id": "gt0007",
+            "path": "/data[at0001]/events[at0006]/data[at0003]/items[at0004]"
+          },
+          "gt0069": {
+            "id": "gt0069",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0008": {
+        "id": "gt0008",
+        "model_id": "openEHR-EHR-OBSERVATION.basic_demographic.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.basic_demographic.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0009": {
+            "id": "gt0009",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0004]"
+          },
+          "gt0071": {
+            "id": "gt0071",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0010": {
+        "id": "gt0010",
+        "model_id": "openEHR-EHR-OBSERVATION.pulse.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.pulse.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0011": {
+            "id": "gt0011",
+            "path": "/data[at0002]/events[at0003]/data[at0001]/items[at0004]"
+          },
+          "gt0070": {
+            "id": "gt0070",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0012": {
+        "id": "gt0012",
+        "model_id": "openEHR-EHR-OBSERVATION.glasgow_blatchford_bleeding_score.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.glasgow_blatchford_bleeding_score.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0013": {
+            "id": "gt0013",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0008]"
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0009]"
+          },
+          "gt0072": {
+            "id": "gt0072",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0015": {
+        "id": "gt0015",
+        "model_id": "openEHR-EHR-OBSERVATION.history_prior_medical_diagnosis.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.history_prior_medical_diagnosis.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0017": {
+            "id": "gt0017",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0040]"
+          },
+          "gt0018": {
+            "id": "gt0018",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0019]/items[at0043]"
+          },
+          "gt0073": {
+            "id": "gt0073",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0031": {
+        "id": "gt0031",
+        "model_id": "openEHR-EHR-OBSERVATION.glasgow_blatchford_bleeding_score.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.glasgow_blatchford_bleeding_score.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0032": {
+            "id": "gt0032",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0004]"
+          },
+          "gt0033": {
+            "id": "gt0033",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0005]"
+          },
+          "gt0034": {
+            "id": "gt0034",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0014]"
+          },
+          "gt0035": {
+            "id": "gt0035",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0006]"
+          },
+          "gt0036": {
+            "id": "gt0036",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0007]"
+          },
+          "gt0037": {
+            "id": "gt0037",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0008]"
+          },
+          "gt0038": {
+            "id": "gt0038",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0009]"
+          },
+          "gt0039": {
+            "id": "gt0039",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0010]"
+          },
+          "gt0040": {
+            "id": "gt0040",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0011]"
+          },
+          "gt0041": {
+            "id": "gt0041",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0012]"
+          }
+        }
+      }
+    },
+    "rules": {
+      "gt0042": {
+        "id": "gt0042",
+        "priority": 25,
+        "when": [
+          "$gt0040|Heart failure|==null",
+          "$gt0039|Liver disease|==null",
+          "$gt0038|Syncope|==null",
+          "$gt0037|Melaena|==null",
+          "$gt0036|Pulse|==null",
+          "$gt0035|Systolic blood pressure (SBP)|==null",
+          "$gt0032|Blood Urea Nitrogen (BUN)|==null",
+          "$gt0033|Haemoglobin (Hb)|==null"
+        ],
+        "then": [
+          "$gt0040|Heart failure|=0|local::at0023|No|",
+          "$gt0039|Liver disease|=0|local::at0021|No|",
+          "$gt0038|Syncope|=0|local::at0019|No|",
+          "$gt0037|Melaena|=0|local::at0017|No|",
+          "$gt0036|Pulse|=0|local::at0025|Pulse <100 /min|",
+          "$gt0035|Systolic blood pressure (SBP)|=0|local::at0027|SBP >=110 mmHg|",
+          "$gt0032|Blood Urea Nitrogen (BUN)|=0|local::at0031|BUN <18.2 mg/dl|",
+          "$gt0033|Haemoglobin (Hb)|=0|local::at0036|Hb >13 g/dl in men (or >12 g/dl in women)|"
+        ]
+      },
+      "gt0043": {
+        "id": "gt0043",
+        "priority": 24,
+        "when": [
+          "$gt0005|Urea|<18.2,mg/dl"
+        ],
+        "then": [
+          "$gt0032|Blood Urea Nitrogen (BUN)|=0|local::at0031|BUN <18.2 mg/dl|"
+        ]
+      },
+      "gt0044": {
+        "id": "gt0044",
+        "priority": 23,
+        "when": [
+          "$gt0005|Urea|>=18.2,mg/dl",
+          "$gt0005|Urea|<22.4,mg/dl"
+        ],
+        "then": [
+          "$gt0032|Blood Urea Nitrogen (BUN)|=2|local::at0032|BUN = 18.2 - <22.4 mg/dl|"
+        ]
+      },
+      "gt0045": {
+        "id": "gt0045",
+        "priority": 22,
+        "when": [
+          "$gt0005|Urea|>=22.4,mg/dl",
+          "$gt0005|Urea|<28,mg/dl"
+        ],
+        "then": [
+          "$gt0032|Blood Urea Nitrogen (BUN)|=3|local::at0033|BUN = 22.4 - <28 mg/dl|"
+        ]
+      },
+      "gt0046": {
+        "id": "gt0046",
+        "priority": 21,
+        "when": [
+          "$gt0005|Urea|>=28,mg/dl",
+          "$gt0005|Urea|<=70.01,mg/dl"
+        ],
+        "then": [
+          "$gt0032|Blood Urea Nitrogen (BUN)|=4|local::at0034|BUN = 28 - <70.01 mg/dl|"
+        ]
+      },
+      "gt0047": {
+        "id": "gt0047",
+        "priority": 20,
+        "when": [
+          "$gt0005|Urea|>=70.01,mg/dl"
+        ],
+        "then": [
+          "$gt0032|Blood Urea Nitrogen (BUN)|=6|local::at0035|BUN >=70.01 mg/dl|"
+        ]
+      },
+      "gt0048": {
+        "id": "gt0048",
+        "priority": 19,
+        "when": [
+          "$gt0007|Systolic|>=110,mm[Hg]"
+        ],
+        "then": [
+          "$gt0035|Systolic blood pressure (SBP)|=0|local::at0027|SBP >=110 mmHg|"
+        ]
+      },
+      "gt0049": {
+        "id": "gt0049",
+        "priority": 18,
+        "when": [
+          "$gt0007|Systolic|<=109,mm[Hg]",
+          "$gt0007|Systolic|>=100,mm[Hg]"
+        ],
+        "then": [
+          "$gt0035|Systolic blood pressure (SBP)|=1|local::at0028|SBP = 100 - 109 mmHg|"
+        ]
+      },
+      "gt0050": {
+        "id": "gt0050",
+        "priority": 17,
+        "when": [
+          "$gt0007|Systolic|<=99,mm[Hg]",
+          "$gt0007|Systolic|>=90,mm[Hg]"
+        ],
+        "then": [
+          "$gt0035|Systolic blood pressure (SBP)|=2|local::at0029|SBP = 90 - 99 mmHg|"
+        ]
+      },
+      "gt0051": {
+        "id": "gt0051",
+        "priority": 16,
+        "when": [
+          "$gt0007|Systolic|<90,mm[Hg]"
+        ],
+        "then": [
+          "$gt0035|Systolic blood pressure (SBP)|=3|local::at0030|SBP <90 mmHg|"
+        ]
+      },
+      "gt0052": {
+        "id": "gt0052",
+        "priority": 15,
+        "when": [
+          "$gt0011|Rate|<100,/min"
+        ],
+        "then": [
+          "$gt0036|Pulse|=0|local::at0025|Pulse <100 /min|"
+        ]
+      },
+      "gt0053": {
+        "id": "gt0053",
+        "priority": 14,
+        "when": [
+          "$gt0011|Rate|>=100,/min"
+        ],
+        "then": [
+          "$gt0036|Pulse|=1|local::at0026|Pulse >=100 /min|"
+        ]
+      },
+      "gt0054": {
+        "id": "gt0054",
+        "priority": 13,
+        "when": [
+          "(($gt0003|Haemoglobin|>13,gm/dl)&&($gt0009|Gender|==local::at0005|Male|))||(($gt0003|Haemoglobin|>12,gm/dl)&&($gt0009|Gender|==local::at0006|Female|))"
+        ],
+        "then": [
+          "$gt0033|Haemoglobin (Hb)|=0|local::at0036|Hb >13 g/dl in men (or >12 g/dl in women)|"
+        ]
+      },
+      "gt0055": {
+        "id": "gt0055",
+        "priority": 12,
+        "when": [
+          "(($gt0003|Haemoglobin|>=12,gm/dl)&&(($gt0003|Haemoglobin|<=13,gm/dl)&&($gt0009|Gender|==local::at0005|Male|)))||(($gt0003|Haemoglobin|>=10,gm/dl)&&(($gt0003|Haemoglobin|<=12,gm/dl)&&($gt0009|Gender|==local::at0006|Female|)))"
+        ],
+        "then": [
+          "$gt0033|Haemoglobin (Hb)|=1|local::at0037|Hb 12 - 13 g/dl in men (or 10 - 12 g/dl in women)|"
+        ]
+      },
+      "gt0056": {
+        "id": "gt0056",
+        "priority": 11,
+        "when": [
+          "$gt0009|Gender|==local::at0005|Male|",
+          "$gt0003|Haemoglobin|<=12,gm/dl",
+          "$gt0003|Haemoglobin|>=10,gm/dl"
+        ],
+        "then": [
+          "$gt0033|Haemoglobin (Hb)|=3|local::at0038|Hb 10 - 12 g/dl in men|"
+        ]
+      },
+      "gt0057": {
+        "id": "gt0057",
+        "priority": 10,
+        "when": [
+          "$gt0003|Haemoglobin|<10,gm/dl"
+        ],
+        "then": [
+          "$gt0033|Haemoglobin (Hb)|=6|local::at0039|Hb <10 g/dl in men or women|"
+        ]
+      },
+      "gt0058": {
+        "id": "gt0058",
+        "priority": 9,
+        "when": [
+          "$gt0009|Gender|==local::at0005|Male|"
+        ],
+        "then": [
+          "$gt0034|Sex|=1|local::at0016|Male|"
+        ]
+      },
+      "gt0059": {
+        "id": "gt0059",
+        "priority": 8,
+        "when": [
+          "$gt0009|Gender|==local::at0006|Female|"
+        ],
+        "then": [
+          "$gt0034|Sex|=0|local::at0015|Female|"
+        ]
+      },
+      "gt0060": {
+        "id": "gt0060",
+        "priority": 7,
+        "when": [
+          "$gt0013|Melaena|!=null"
+        ],
+        "then": [
+          "$gt0037|Melaena|=$gt0013|Melaena|"
+        ]
+      },
+      "gt0061": {
+        "id": "gt0061",
+        "priority": 6,
+        "when": [
+          "$gt0014|Syncope|!=null"
+        ],
+        "then": [
+          "$gt0038|Syncope|=$gt0014|Syncope|"
+        ]
+      },
+      "gt0062": {
+        "id": "gt0062",
+        "priority": 5,
+        "when": [
+          "$gt0017|Liver disease|==0|local::at0041|No|"
+        ],
+        "then": [
+          "$gt0039|Liver disease|=0|local::at0021|No|"
+        ]
+      },
+      "gt0063": {
+        "id": "gt0063",
+        "priority": 4,
+        "when": [
+          "$gt0017|Liver disease|==1|local::at0042|Yes|"
+        ],
+        "then": [
+          "$gt0039|Liver disease|=2|local::at0022|Yes|"
+        ]
+      },
+      "gt0064": {
+        "id": "gt0064",
+        "priority": 3,
+        "when": [
+          "$gt0018|Heart failure (unspecified)|==0|local::at0044|No|"
+        ],
+        "then": [
+          "$gt0040|Heart failure|=0|local::at0023|No|"
+        ]
+      },
+      "gt0065": {
+        "id": "gt0065",
+        "priority": 2,
+        "when": [
+          "$gt0018|Heart failure (unspecified)|==1|local::at0045|Yes|"
+        ],
+        "then": [
+          "$gt0040|Heart failure|=2|local::at0024|Yes|"
+        ]
+      },
+      "gt0066": {
+        "id": "gt0066",
+        "priority": 1,
+        "then": [
+          "$gt0041|Total score|.magnitude=(((((($gt0032.value+$gt0033.value)+$gt0035.value)+$gt0040.value)+$gt0036.value)+$gt0037.value)+$gt0038.value)+$gt0039.value"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "sv": {
+        "id": "sv",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Glasgow-Blatchford Bleeding Score (GBS) Calculator",
+            "description": "Glasgow-Blatchford bleeding score används för att i initialt skede uppskatta risk med avseende på behandlingsbehov, re-blödning och mortalitet hos patienter med övre GI-blödning. Instrumentet baseras på åtta faktorer, och maximal poäng uppgår till 23p. Noll poäng indikerar låg komplikationsrisk (0,5%). Ju högre poäng, desto högre risk. Instrumentet har visats ha högre sensitivitet än Rockall score, och korrelerar väl med vårdtid och behov av blodtransfusion."
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "Hemoglobin (Hb)",
+            "description": "*(en) The mass concentration of haemoglobin"
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Urea",
+            "description": "*(en) Urea level in this specimen."
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Systoliskt blodtryck",
+            "description": "*(en) Peak systemic arterial blood pressure  - measured in systolic or contraction phase of the heart cycle."
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Kön",
+            "description": "*(en) *"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Hjärtfrekvens",
+            "description": "*(en) The rate, measured in beats per minute."
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "Melena",
+            "description": "*(en) Score assigned for presence or absence of melena at admission."
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "Synkope",
+            "description": "*(en) Score assigned for presence or absence of syncope at admission."
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "text": "Leversjukdom",
+            "description": "*(en) Has the individual ever been diagnosed with any kind of liver disease?"
+          },
+          "gt0018": {
+            "id": "gt0018",
+            "text": "Hjärtsvikt (ospecificerad)",
+            "description": "*(en) Has the individual ever been diagnosed with heart failure?"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "text": "Hjärtfrekvens",
+            "description": "*(en) The rate, measured in beats per minute."
+          },
+          "gt0023": {
+            "id": "gt0023",
+            "text": "Hemoglobin (Hb)",
+            "description": "*(en) The mass concentration of haemoglobin"
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "text": "Urea",
+            "description": "*(en) Urea level in this specimen."
+          },
+          "gt0027": {
+            "id": "gt0027",
+            "text": "Systoliskt blodtryck",
+            "description": "*(en) Peak systemic arterial blood pressure  - measured in systolic or contraction phase of the heart cycle."
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "text": "Hjärtsvikt (ospecificerad)",
+            "description": "*(en) Has the individual ever been diagnosed with heart failure?"
+          },
+          "gt0030": {
+            "id": "gt0030",
+            "text": "Leversjukdom",
+            "description": "*(en) Has the individual ever been diagnosed with any kind of liver disease?"
+          },
+          "gt0032": {
+            "id": "gt0032",
+            "text": "Urea",
+            "description": "*(en) Score assigned for concentration of blood urea nitrogen (BUN) at admission."
+          },
+          "gt0033": {
+            "id": "gt0033",
+            "text": "Hemoglobin (Hb)",
+            "description": "*(en) Score assigned for haemogloin concentration at admission (male and female)."
+          },
+          "gt0034": {
+            "id": "gt0034",
+            "text": "Kön",
+            "description": "*(en) The patient's gender."
+          },
+          "gt0035": {
+            "id": "gt0035",
+            "text": "Systoliskt blodtryck",
+            "description": "*(en) Score assigned for systolic blood pressure at admission."
+          },
+          "gt0036": {
+            "id": "gt0036",
+            "text": "Hjärtfrekvens",
+            "description": "*(en) Score assigned for pulse rate at admission."
+          },
+          "gt0037": {
+            "id": "gt0037",
+            "text": "Melena",
+            "description": "*(en) Score assigned for presence or absence of melena at admission."
+          },
+          "gt0038": {
+            "id": "gt0038",
+            "text": "Synkope",
+            "description": "*(en) Score assigned for presence or absence of syncope at admission."
+          },
+          "gt0039": {
+            "id": "gt0039",
+            "text": "Leversjukdom",
+            "description": "*(en) Score assigned for any evidence of liver disease."
+          },
+          "gt0040": {
+            "id": "gt0040",
+            "text": "Hjärtsvikt (ospecificerad)",
+            "description": "*(en) Score assigned for any evidence of heart failure."
+          },
+          "gt0041": {
+            "id": "gt0041",
+            "text": "Total poäng",
+            "description": "*(en) Sum of the individual scores assigned for each of the contributing variables."
+          },
+          "gt0042": {
+            "id": "gt0042",
+            "text": "Standard"
+          },
+          "gt0043": {
+            "id": "gt0043",
+            "text": "CDS urea = 0"
+          },
+          "gt0044": {
+            "id": "gt0044",
+            "text": "CDS urea = 2"
+          },
+          "gt0045": {
+            "id": "gt0045",
+            "text": "CDS urea = 3"
+          },
+          "gt0046": {
+            "id": "gt0046",
+            "text": "CDS urea = 4"
+          },
+          "gt0047": {
+            "id": "gt0047",
+            "text": "CDS urea = 6"
+          },
+          "gt0048": {
+            "id": "gt0048",
+            "text": "CDS systoliskt blodtryck = 0"
+          },
+          "gt0049": {
+            "id": "gt0049",
+            "text": "CDS systoliskt blodtryck = 1"
+          },
+          "gt0050": {
+            "id": "gt0050",
+            "text": "CDS systoliskt blodtryck = 2"
+          },
+          "gt0051": {
+            "id": "gt0051",
+            "text": "CDS systoliskt blodtryck = 3"
+          },
+          "gt0052": {
+            "id": "gt0052",
+            "text": "CDS hjärtfrekvens = 0"
+          },
+          "gt0053": {
+            "id": "gt0053",
+            "text": "CDS hjärtfrekvens = 1"
+          },
+          "gt0054": {
+            "id": "gt0054",
+            "text": "CDS Hb = 0"
+          },
+          "gt0055": {
+            "id": "gt0055",
+            "text": "CDS Hb = 1"
+          },
+          "gt0056": {
+            "id": "gt0056",
+            "text": "CDS Hb = 3"
+          },
+          "gt0057": {
+            "id": "gt0057",
+            "text": "CDS Hb = 6"
+          },
+          "gt0058": {
+            "id": "gt0058",
+            "text": "CDS kön = man"
+          },
+          "gt0059": {
+            "id": "gt0059",
+            "text": "CDS kön = kvinna"
+          },
+          "gt0060": {
+            "id": "gt0060",
+            "text": "CDS Melena"
+          },
+          "gt0061": {
+            "id": "gt0061",
+            "text": "CDS synkope"
+          },
+          "gt0062": {
+            "id": "gt0062",
+            "text": "CDS leversjukdom = 0"
+          },
+          "gt0063": {
+            "id": "gt0063",
+            "text": "CDS leversjukdom = 2"
+          },
+          "gt0064": {
+            "id": "gt0064",
+            "text": "CDS hjärtsvikt = 0"
+          },
+          "gt0065": {
+            "id": "gt0065",
+            "text": "CDS hjärtsvikt = 2"
+          },
+          "gt0066": {
+            "id": "gt0066",
+            "text": "Beräkna total poäng"
+          },
+          "gt0067": {
+            "id": "gt0067",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0068": {
+            "id": "gt0068",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0069": {
+            "id": "gt0069",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0070": {
+            "id": "gt0070",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0071": {
+            "id": "gt0071",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0072": {
+            "id": "gt0072",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0073": {
+            "id": "gt0073",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      },
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Glasgow-Blatchford Bleeding Score (GBS) Calculator",
+            "description": "A risk-stratification system for patients with acute upper-gastrointestinal bleeding (UGIB), to discriminate between patients at high or low risk of dying or rebleeding. The score is calculated based on clinical and laboratory variables only: patients' admission haemoglobin, blood urea, pulse, and systolic blood pressure, as well as presentation with syncope or melaena, and evidence of hepatic disease or cardiac failure. Component points assigned for presence, absence, or value of each variable are summed to give the Glasgow-Blatchford bleeding score (GBS) with value between 0 - 23. A score above 0 (zero) implies the patient is at high risk of needing clinical intervention (transfusion, endoscopy or surgery), and correlates well with length of hospital stay and number of units of blood transfused. GBS is more sensitive than clinical and complete Rockall scores for identifying high-risk patients with acute UGIB."
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "Haemoglobin",
+            "description": "The mass concentration of haemoglobin"
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Urea",
+            "description": "Urea level in this specimen."
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Systolic",
+            "description": "Peak systemic arterial blood pressure  - measured in systolic or contraction phase of the heart cycle."
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Gender",
+            "description": "*"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Rate",
+            "description": "The rate, measured in beats per minute."
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "Melaena",
+            "description": "Score assigned for presence or absence of melena at admission."
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "Syncope",
+            "description": "Score assigned for presence or absence of syncope at admission."
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "text": "Liver disease",
+            "description": "Has the individual ever been diagnosed with any kind of liver disease?"
+          },
+          "gt0018": {
+            "id": "gt0018",
+            "text": "Heart failure (unspecified)",
+            "description": "Has the individual ever been diagnosed with heart failure?"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "text": "Rate",
+            "description": "The rate, measured in beats per minute."
+          },
+          "gt0023": {
+            "id": "gt0023",
+            "text": "Haemoglobin",
+            "description": "The mass concentration of haemoglobin"
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "text": "Urea",
+            "description": "Urea level in this specimen."
+          },
+          "gt0027": {
+            "id": "gt0027",
+            "text": "Systolic",
+            "description": "Peak systemic arterial blood pressure  - measured in systolic or contraction phase of the heart cycle."
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "text": "Heart failure (unspecified)",
+            "description": "Has the individual ever been diagnosed with heart failure?"
+          },
+          "gt0030": {
+            "id": "gt0030",
+            "text": "Liver disease",
+            "description": "Has the individual ever been diagnosed with any kind of liver disease?"
+          },
+          "gt0032": {
+            "id": "gt0032",
+            "text": "Blood Urea Nitrogen (BUN)",
+            "description": "Score assigned for concentration of blood urea nitrogen (BUN) at admission."
+          },
+          "gt0033": {
+            "id": "gt0033",
+            "text": "Haemoglobin (Hb)",
+            "description": "Score assigned for haemogloin concentration at admission (male and female)."
+          },
+          "gt0034": {
+            "id": "gt0034",
+            "text": "Sex",
+            "description": "The patient's gender."
+          },
+          "gt0035": {
+            "id": "gt0035",
+            "text": "Systolic blood pressure (SBP)",
+            "description": "Score assigned for systolic blood pressure at admission."
+          },
+          "gt0036": {
+            "id": "gt0036",
+            "text": "Pulse",
+            "description": "Score assigned for pulse rate at admission."
+          },
+          "gt0037": {
+            "id": "gt0037",
+            "text": "Melaena",
+            "description": "Score assigned for presence or absence of melena at admission."
+          },
+          "gt0038": {
+            "id": "gt0038",
+            "text": "Syncope",
+            "description": "Score assigned for presence or absence of syncope at admission."
+          },
+          "gt0039": {
+            "id": "gt0039",
+            "text": "Liver disease",
+            "description": "Score assigned for any evidence of liver disease."
+          },
+          "gt0040": {
+            "id": "gt0040",
+            "text": "Heart failure",
+            "description": "Score assigned for any evidence of heart failure."
+          },
+          "gt0041": {
+            "id": "gt0041",
+            "text": "Total score",
+            "description": "Sum of the individual scores assigned for each of the contributing variables."
+          },
+          "gt0042": {
+            "id": "gt0042",
+            "text": "Set defaults"
+          },
+          "gt0043": {
+            "id": "gt0043",
+            "text": "Set BUN score = 0"
+          },
+          "gt0044": {
+            "id": "gt0044",
+            "text": "Set BUN score = 2"
+          },
+          "gt0045": {
+            "id": "gt0045",
+            "text": "Set BUN score = 3"
+          },
+          "gt0046": {
+            "id": "gt0046",
+            "text": "Set BUN score = 4"
+          },
+          "gt0047": {
+            "id": "gt0047",
+            "text": "Set BUN score = 6"
+          },
+          "gt0048": {
+            "id": "gt0048",
+            "text": "Set SBP = 0"
+          },
+          "gt0049": {
+            "id": "gt0049",
+            "text": "Set SBP = 1"
+          },
+          "gt0050": {
+            "id": "gt0050",
+            "text": "Set SBP = 2"
+          },
+          "gt0051": {
+            "id": "gt0051",
+            "text": "Set SBP = 3"
+          },
+          "gt0052": {
+            "id": "gt0052",
+            "text": "Set Pulse = 0"
+          },
+          "gt0053": {
+            "id": "gt0053",
+            "text": "Set Pulse = 1"
+          },
+          "gt0054": {
+            "id": "gt0054",
+            "text": "Set Hb = 0"
+          },
+          "gt0055": {
+            "id": "gt0055",
+            "text": "Set Hb = 1"
+          },
+          "gt0056": {
+            "id": "gt0056",
+            "text": "Set Hb = 3"
+          },
+          "gt0057": {
+            "id": "gt0057",
+            "text": "Set Hb = 6"
+          },
+          "gt0058": {
+            "id": "gt0058",
+            "text": "Set Sex = Male"
+          },
+          "gt0059": {
+            "id": "gt0059",
+            "text": "Set Sex = Female"
+          },
+          "gt0060": {
+            "id": "gt0060",
+            "text": "Set Melaena"
+          },
+          "gt0061": {
+            "id": "gt0061",
+            "text": "Set Syncope"
+          },
+          "gt0062": {
+            "id": "gt0062",
+            "text": "Set Liver disease = 0"
+          },
+          "gt0063": {
+            "id": "gt0063",
+            "text": "Set Liver disease = 2"
+          },
+          "gt0064": {
+            "id": "gt0064",
+            "text": "Set Heart failure = 0"
+          },
+          "gt0065": {
+            "id": "gt0065",
+            "text": "Set Heart failure = 2"
+          },
+          "gt0066": {
+            "id": "gt0066",
+            "text": "Calculate Total score"
+          },
+          "gt0067": {
+            "id": "gt0067",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0068": {
+            "id": "gt0068",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0069": {
+            "id": "gt0069",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0070": {
+            "id": "gt0070",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0071": {
+            "id": "gt0071",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0072": {
+            "id": "gt0072",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0073": {
+            "id": "gt0073",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/Glasgow_Blatchford_score_Calculation.v1.test.yml
+++ b/gdl2/Glasgow_Blatchford_score_Calculation.v1.test.yml
@@ -1,0 +1,282 @@
+guidelines:
+  1: Glasgow_Blatchford_score_Calculation.v1
+test_cases:
+- id: Female, HB, Urea out-of-range
+  input:
+    1:
+      gt0003|Haemoglobin: 11,gm/dl
+      gt0067|Event time: 2019-03-20T01:18Z
+      gt0005|Urea: 19,mg/dl
+      gt0068|Event time: 2019-03-20T01:19Z
+      gt0007|Systolic: 109,mm[Hg]
+      gt0069|Event time: 2019-03-27T01:20Z
+      gt0009|Gender: local::at0006|Female|
+      gt0071|Event time: 2019-03-27T01:20Z
+      gt0011|Rate: 76,/min
+      gt0070|Event time: 2019-03-27T01:20Z
+      gt0013|Melaena: 0|local::at0017|No|
+      gt0014|Syncope: 0|local::at0019|No|
+      gt0072|Event time: 2019-03-27T01:21Z
+      gt0017|Liver disease: 0|local::at0041|No|
+      gt0018|Heart failure (unspecified): 0|local::at0044|No|
+      gt0073|Event time: 2019-03-27T01:21Z
+  expected_output:
+    1:
+      gt0033|Haemoglobin (Hb): 1|local::at0037|Hb 12 - 13 g/dl in men (or 10 - 12 g/dl in women)|
+      gt0036|Pulse: 0|local::at0025|Pulse <100 /min|
+      gt0040|Heart failure: 0|local::at0023|No|
+      gt0034|Sex: 0|local::at0015|Female|
+      gt0039|Liver disease: 0|local::at0021|No|
+      gt0037|Melaena: 0|local::at0017|No|
+      gt0038|Syncope: 0|local::at0019|No|
+      gt0032|Blood Urea Nitrogen (BUN): 2|local::at0032|BUN = 18.2 - <22.4 mg/dl|
+      gt0035|Systolic blood pressure (SBP): 1|local::at0028|SBP = 100 - 109 mmHg|
+      gt0041|Total score: 4
+- id: Female, Low BP, urea out-of-range
+  input:
+    1:
+      gt0003|Haemoglobin: 13,gm/dl
+      gt0067|Event time: 2019-03-20T01:18Z
+      gt0005|Urea: 19,mg/dl
+      gt0068|Event time: 2019-03-20T01:19Z
+      gt0007|Systolic: 109,mm[Hg]
+      gt0069|Event time: 2019-03-27T01:20Z
+      gt0009|Gender: local::at0006|Female|
+      gt0071|Event time: 2019-03-27T01:20Z
+      gt0011|Rate: 76,/min
+      gt0070|Event time: 2019-03-27T01:20Z
+      gt0013|Melaena: 0|local::at0017|No|
+      gt0014|Syncope: 0|local::at0019|No|
+      gt0072|Event time: 2019-03-27T01:21Z
+      gt0017|Liver disease: 0|local::at0041|No|
+      gt0018|Heart failure (unspecified): 0|local::at0044|No|
+      gt0073|Event time: 2019-03-27T01:21Z
+  expected_output:
+    1:
+      gt0033|Haemoglobin (Hb): 0|local::at0036|Hb >13 g/dl in men (or >12 g/dl in women)|
+      gt0036|Pulse: 0|local::at0025|Pulse <100 /min|
+      gt0040|Heart failure: 0|local::at0023|No|
+      gt0034|Sex: 0|local::at0015|Female|
+      gt0039|Liver disease: 0|local::at0021|No|
+      gt0037|Melaena: 0|local::at0017|No|
+      gt0038|Syncope: 0|local::at0019|No|
+      gt0032|Blood Urea Nitrogen (BUN): 2|local::at0032|BUN = 18.2 - <22.4 mg/dl|
+      gt0035|Systolic blood pressure (SBP): 1|local::at0028|SBP = 100 - 109 mmHg|
+      gt0041|Total score: 3
+- id: Healthy female
+  input:
+    1:
+      gt0003|Haemoglobin: 13,gm/dl
+      gt0067|Event time: 2019-03-20T01:18Z
+      gt0005|Urea: 18,mg/dl
+      gt0068|Event time: 2019-03-20T01:19Z
+      gt0007|Systolic: 120,mm[Hg]
+      gt0069|Event time: 2019-03-27T01:20Z
+      gt0009|Gender: local::at0006|Female|
+      gt0071|Event time: 2019-03-27T01:20Z
+      gt0011|Rate: 76,/min
+      gt0070|Event time: 2019-03-27T01:20Z
+      gt0013|Melaena: 0|local::at0017|No|
+      gt0014|Syncope: 0|local::at0019|No|
+      gt0072|Event time: 2019-03-27T01:21Z
+      gt0017|Liver disease: 0|local::at0041|No|
+      gt0018|Heart failure (unspecified): 0|local::at0044|No|
+      gt0073|Event time: 2019-03-27T01:21Z
+  expected_output:
+    1:
+      gt0033|Haemoglobin (Hb): 0|local::at0036|Hb >13 g/dl in men (or >12 g/dl in women)|
+      gt0036|Pulse: 0|local::at0025|Pulse <100 /min|
+      gt0040|Heart failure: 0|local::at0023|No|
+      gt0034|Sex: 0|local::at0015|Female|
+      gt0039|Liver disease: 0|local::at0021|No|
+      gt0037|Melaena: 0|local::at0017|No|
+      gt0038|Syncope: 0|local::at0019|No|
+      gt0032|Blood Urea Nitrogen (BUN): 0|local::at0031|BUN <18.2 mg/dl|
+      gt0035|Systolic blood pressure (SBP): 0|local::at0027|SBP >=110 mmHg|
+      gt0041|Total score: 0
+- id: Same in male, means too low Hb
+  input:
+    1:
+      gt0003|Haemoglobin: 13,gm/dl
+      gt0067|Event time: 2019-03-20T01:18Z
+      gt0005|Urea: 18,mg/dl
+      gt0068|Event time: 2019-03-20T01:19Z
+      gt0007|Systolic: 120,mm[Hg]
+      gt0069|Event time: 2019-03-27T01:20Z
+      gt0009|Gender: local::at0005|Male|
+      gt0071|Event time: 2019-03-27T01:20Z
+      gt0011|Rate: 76,/min
+      gt0070|Event time: 2019-03-27T01:20Z
+      gt0013|Melaena: 0|local::at0017|No|
+      gt0014|Syncope: 0|local::at0019|No|
+      gt0072|Event time: 2019-03-27T01:21Z
+      gt0017|Liver disease: 0|local::at0041|No|
+      gt0018|Heart failure (unspecified): 0|local::at0044|No|
+      gt0073|Event time: 2019-03-27T01:21Z
+  expected_output:
+    1:
+      gt0033|Haemoglobin (Hb): 1|local::at0037|Hb 12 - 13 g/dl in men (or 10 - 12 g/dl in women)|
+      gt0036|Pulse: 0|local::at0025|Pulse <100 /min|
+      gt0040|Heart failure: 0|local::at0023|No|
+      gt0034|Sex: 1|local::at0016|Male|
+      gt0039|Liver disease: 0|local::at0021|No|
+      gt0037|Melaena: 0|local::at0017|No|
+      gt0038|Syncope: 0|local::at0019|No|
+      gt0032|Blood Urea Nitrogen (BUN): 0|local::at0031|BUN <18.2 mg/dl|
+      gt0035|Systolic blood pressure (SBP): 0|local::at0027|SBP >=110 mmHg|
+      gt0041|Total score: 1
+- id: High pulse
+  input:
+    1:
+      gt0003|Haemoglobin: 13,gm/dl
+      gt0067|Event time: 2019-03-20T01:18Z
+      gt0005|Urea: 18,mg/dl
+      gt0068|Event time: 2019-03-20T01:19Z
+      gt0007|Systolic: 120,mm[Hg]
+      gt0069|Event time: 2019-03-27T01:20Z
+      gt0009|Gender: local::at0005|Male|
+      gt0071|Event time: 2019-03-27T01:20Z
+      gt0011|Rate: 120,/min
+      gt0070|Event time: 2019-03-27T01:20Z
+      gt0013|Melaena: 0|local::at0017|No|
+      gt0014|Syncope: 0|local::at0019|No|
+      gt0072|Event time: 2019-03-27T01:21Z
+      gt0017|Liver disease: 0|local::at0041|No|
+      gt0018|Heart failure (unspecified): 0|local::at0044|No|
+      gt0073|Event time: 2019-03-27T01:21Z
+  expected_output:
+    1:
+      gt0033|Haemoglobin (Hb): 1|local::at0037|Hb 12 - 13 g/dl in men (or 10 - 12 g/dl in women)|
+      gt0036|Pulse: 1|local::at0026|Pulse >=100 /min|
+      gt0040|Heart failure: 0|local::at0023|No|
+      gt0034|Sex: 1|local::at0016|Male|
+      gt0039|Liver disease: 0|local::at0021|No|
+      gt0037|Melaena: 0|local::at0017|No|
+      gt0038|Syncope: 0|local::at0019|No|
+      gt0032|Blood Urea Nitrogen (BUN): 0|local::at0031|BUN <18.2 mg/dl|
+      gt0035|Systolic blood pressure (SBP): 0|local::at0027|SBP >=110 mmHg|
+      gt0041|Total score: 2
+- id: Melanea
+  input:
+    1:
+      gt0003|Haemoglobin: 13,gm/dl
+      gt0067|Event time: 2019-03-20T01:18Z
+      gt0005|Urea: 18,mg/dl
+      gt0068|Event time: 2019-03-20T01:19Z
+      gt0007|Systolic: 120,mm[Hg]
+      gt0069|Event time: 2019-03-27T01:20Z
+      gt0009|Gender: local::at0005|Male|
+      gt0071|Event time: 2019-03-27T01:20Z
+      gt0011|Rate: 120,/min
+      gt0070|Event time: 2019-03-27T01:20Z
+      gt0013|Melaena: 1|local::at0018|Yes|
+      gt0014|Syncope: 0|local::at0019|No|
+      gt0072|Event time: 2019-03-27T01:21Z
+      gt0017|Liver disease: 0|local::at0041|No|
+      gt0018|Heart failure (unspecified): 0|local::at0044|No|
+      gt0073|Event time: 2019-03-27T01:21Z
+  expected_output:
+    1:
+      gt0033|Haemoglobin (Hb): 1|local::at0037|Hb 12 - 13 g/dl in men (or 10 - 12 g/dl in women)|
+      gt0036|Pulse: 1|local::at0026|Pulse >=100 /min|
+      gt0040|Heart failure: 0|local::at0023|No|
+      gt0034|Sex: 1|local::at0016|Male|
+      gt0039|Liver disease: 0|local::at0021|No|
+      gt0037|Melaena: 1|local::at0018|Yes|
+      gt0038|Syncope: 0|local::at0019|No|
+      gt0032|Blood Urea Nitrogen (BUN): 0|local::at0031|BUN <18.2 mg/dl|
+      gt0035|Systolic blood pressure (SBP): 0|local::at0027|SBP >=110 mmHg|
+      gt0041|Total score: 3
+- id: Syncope
+  input:
+    1:
+      gt0003|Haemoglobin: 13,gm/dl
+      gt0067|Event time: 2019-03-20T01:18Z
+      gt0005|Urea: 18,mg/dl
+      gt0068|Event time: 2019-03-20T01:19Z
+      gt0007|Systolic: 120,mm[Hg]
+      gt0069|Event time: 2019-03-27T01:20Z
+      gt0009|Gender: local::at0005|Male|
+      gt0071|Event time: 2019-03-27T01:20Z
+      gt0011|Rate: 120,/min
+      gt0070|Event time: 2019-03-27T01:20Z
+      gt0013|Melaena: 0|local::at0017|No|
+      gt0014|Syncope: 2|local::at0020|Yes|
+      gt0072|Event time: 2019-03-27T01:21Z
+      gt0017|Liver disease: 0|local::at0041|No|
+      gt0018|Heart failure (unspecified): 0|local::at0044|No|
+      gt0073|Event time: 2019-03-27T01:21Z
+  expected_output:
+    1:
+      gt0033|Haemoglobin (Hb): 1|local::at0037|Hb 12 - 13 g/dl in men (or 10 - 12 g/dl in women)|
+      gt0036|Pulse: 1|local::at0026|Pulse >=100 /min|
+      gt0040|Heart failure: 0|local::at0023|No|
+      gt0034|Sex: 1|local::at0016|Male|
+      gt0039|Liver disease: 0|local::at0021|No|
+      gt0037|Melaena: 0|local::at0017|No|
+      gt0038|Syncope: 2|local::at0020|Yes|
+      gt0032|Blood Urea Nitrogen (BUN): 0|local::at0031|BUN <18.2 mg/dl|
+      gt0035|Systolic blood pressure (SBP): 0|local::at0027|SBP >=110 mmHg|
+      gt0041|Total score: 4
+- id: Liver disease
+  input:
+    1:
+      gt0003|Haemoglobin: 13,gm/dl
+      gt0067|Event time: 2019-03-20T01:18Z
+      gt0005|Urea: 18,mg/dl
+      gt0068|Event time: 2019-03-20T01:19Z
+      gt0007|Systolic: 120,mm[Hg]
+      gt0069|Event time: 2019-03-27T01:20Z
+      gt0009|Gender: local::at0005|Male|
+      gt0071|Event time: 2019-03-27T01:20Z
+      gt0011|Rate: 120,/min
+      gt0070|Event time: 2019-03-27T01:20Z
+      gt0013|Melaena: 0|local::at0017|No|
+      gt0014|Syncope: 2|local::at0020|Yes|
+      gt0072|Event time: 2019-03-27T01:21Z
+      gt0017|Liver disease: 1|local::at0042|Yes|
+      gt0018|Heart failure (unspecified): 0|local::at0044|No|
+      gt0073|Event time: 2019-03-27T01:21Z
+  expected_output:
+    1:
+      gt0033|Haemoglobin (Hb): 1|local::at0037|Hb 12 - 13 g/dl in men (or 10 - 12 g/dl in women)|
+      gt0036|Pulse: 1|local::at0026|Pulse >=100 /min|
+      gt0040|Heart failure: 0|local::at0023|No|
+      gt0034|Sex: 1|local::at0016|Male|
+      gt0039|Liver disease: 2|local::at0022|Yes|
+      gt0037|Melaena: 0|local::at0017|No|
+      gt0038|Syncope: 2|local::at0020|Yes|
+      gt0032|Blood Urea Nitrogen (BUN): 0|local::at0031|BUN <18.2 mg/dl|
+      gt0035|Systolic blood pressure (SBP): 0|local::at0027|SBP >=110 mmHg|
+      gt0041|Total score: 6
+- id: Liver disease and heart failure
+  input:
+    1:
+      gt0003|Haemoglobin: 13,gm/dl
+      gt0067|Event time: 2019-03-20T01:18Z
+      gt0005|Urea: 18,mg/dl
+      gt0068|Event time: 2019-03-20T01:19Z
+      gt0007|Systolic: 120,mm[Hg]
+      gt0069|Event time: 2019-03-27T01:20Z
+      gt0009|Gender: local::at0005|Male|
+      gt0071|Event time: 2019-03-27T01:20Z
+      gt0011|Rate: 120,/min
+      gt0070|Event time: 2019-03-27T01:20Z
+      gt0013|Melaena: 0|local::at0017|No|
+      gt0014|Syncope: 2|local::at0020|Yes|
+      gt0072|Event time: 2019-03-27T01:21Z
+      gt0017|Liver disease: 1|local::at0042|Yes|
+      gt0018|Heart failure (unspecified): 1|local::at0045|Yes|
+      gt0073|Event time: 2019-03-27T01:21Z
+  expected_output:
+    1:
+      gt0033|Haemoglobin (Hb): 1|local::at0037|Hb 12 - 13 g/dl in men (or 10 - 12 g/dl in women)|
+      gt0036|Pulse: 1|local::at0026|Pulse >=100 /min|
+      gt0040|Heart failure: 2|local::at0024|Yes|
+      gt0034|Sex: 1|local::at0016|Male|
+      gt0039|Liver disease: 2|local::at0022|Yes|
+      gt0037|Melaena: 0|local::at0017|No|
+      gt0038|Syncope: 2|local::at0020|Yes|
+      gt0032|Blood Urea Nitrogen (BUN): 0|local::at0031|BUN <18.2 mg/dl|
+      gt0035|Systolic blood pressure (SBP): 0|local::at0027|SBP >=110 mmHg|
+      gt0041|Total score: 8


### PR DESCRIPTION
GBS calculation migrated. Small changes: event time, output -> input.
Note: only works with mg/dL, but this is specified in the description