### PR TITLE
Glasgow Imrie Evaluation migrated

### DIFF
--- a/gdl2/Glasgow-Imrie_Criteria_for_Acute_Pancreatitis.v1.gdl2.json
+++ b/gdl2/Glasgow-Imrie_Criteria_for_Acute_Pancreatitis.v1.gdl2.json
@@ -1,0 +1,867 @@
+{
+  "id": "Glasgow-Imrie_Criteria_for_Acute_Pancreatitis.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2017-11-03",
+      "name": "Syeeda S Farruque",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "other_contributors": [
+      "Dennis Forslund, Cambio Healthcare Systems"
+    ],
+    "lifecycle_state": "Author draft",
+    "details": {
+      "sv": {
+        "id": "sv",
+        "purpose": "Att i enlighet med Glasgow-Imries kriterier utvärdera svårighetsgrad av akut pankreatit baserat på åtta laborationsparametrar.",
+        "keywords": [
+          "akut pankreatit",
+          "pankreatit",
+          "Glasgow Imrie"
+        ],
+        "use": "Metoden baseras på åtta provsvar vilka poängsätts med 0-1p, vilket ger en maximal poängsumma om 8p:\r\n\r\n    PaO2< 7.9kPa\r\n    Ålder > 55 år\r\n    Neutrofiler (LPK > 15 x 10⁹/L)\r\n    Kalcium < 2 mmol/L\r\n    Njurfunktion: Urea > 16 mmol/L\r\n    LDH > 600 IU/L\r\n    Albumin < 32 g/L (serum)\r\n    B-glukos > 10 mmol/L\r\n \r\n\r\nResultatet tolkas enligt: \r\n\r\n* ≥3p indikerar förhöjd risk för svår pankretatit\r\n* <3p indikerar lägre sannolikhet för svår pankreatit\r\n\r\nPoäng\tSvår pankreatit*\r\n0 \t7%\r\n1 \t6%\r\n2 \t16%\r\n3 \t20%\r\n4 \t61%\r\n5 \t55%\r\n6 \t100%\r\n7 \t0%\r\n8 \t100%",
+        "misuse": "Endast tillämpbar först 48h efter initial bedömning.",
+        "copyright": "© Cambio Healthcare Systems"
+      },
+      "en": {
+        "id": "en",
+        "purpose": "The Glasgow-Imrie Criteria for Severity of Acute Pancreatitis provides an assessment of the severity of pancreatitis using 8 laboratory values",
+        "keywords": [
+          "Glasgow-Imrie Criteria for Severity of Acute Pancreatitis"
+        ],
+        "use": "The tool uses 8 lab values as shown below. Each variable is score 0 or 1 and the tool sums the scores for a range of 0 to 8.\n\nUseful mnemonic: PANCREAS\n    PaO2< 7.9kPa\n    Age > 55 years\n    Neutrophils (WBC > 15 x 10⁹/L)\n    Calcium < 2 mmol/L\n    Renal function: Urea > 16 mmol/L\n    Enzymes LDH > 600 IU/L\n    Albumin < 32 g/L (serum)\n    Sugar (blood glucose) > 10 mmol/L\n\nScores ≥3 suggest increased likelihood of severe pancreatitis\nScores < 3 suggest decreased likelihood of severe pancreatitis\n\nScore interpretation:\n\nScore \t\tSevere Pancreatitis*\n0 \t\t7%\n1 \t\t6%\n2 \t\t16%\n3 \t \t20%\n4 \t \t61%\n5 \t \t55%\n6 \t\t100%\n7 \t\t0%\n8 \t \t100%\n",
+        "misuse": "Do not use sooner than 48 hours from presentation",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Ref. 1: Blamey SL, Imrie CW, O'Neill J, Gilmour WH, Carter DC. Prognostic factors in acute pancreatitis. Gut. 1984 Dec;25(12):1340-6."
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0002": {
+        "id": "gt0002",
+        "model_id": "openEHR-EHR-OBSERVATION.glasgow_imrie_criteria_for_severity_of_acute_pancreatitis.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.glasgow_imrie_criteria_for_severity_of_acute_pancreatitis.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0003": {
+            "id": "gt0003",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0004]"
+          },
+          "gt0004": {
+            "id": "gt0004",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0005]"
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0006]"
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0007]"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0008]"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0009]"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0010]"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0011]"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0012]"
+          }
+        }
+      },
+      "gt0012": {
+        "id": "gt0012",
+        "model_id": "openEHR-EHR-OBSERVATION.basic_demographic.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.basic_demographic.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0027": {
+            "id": "gt0027",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0008]"
+          },
+          "gt0048": {
+            "id": "gt0048",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0013": {
+        "id": "gt0013",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-blood_gases.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-blood_gases.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0026": {
+            "id": "gt0026",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.11]"
+          },
+          "gt0049": {
+            "id": "gt0049",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0014": {
+        "id": "gt0014",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-full_blood_count.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-full_blood_count.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0025": {
+            "id": "gt0025",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.13]"
+          },
+          "gt0050": {
+            "id": "gt0050",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0015": {
+        "id": "gt0015",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test_serum_calcium.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test_serum_calcium.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0024": {
+            "id": "gt0024",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078]"
+          },
+          "gt0051": {
+            "id": "gt0051",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0016": {
+        "id": "gt0016",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-urea_and_electrolytes.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-urea_and_electrolytes.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0023": {
+            "id": "gt0023",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.1]"
+          },
+          "gt0052": {
+            "id": "gt0052",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0017": {
+        "id": "gt0017",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test_ldh.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test_ldh.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0022": {
+            "id": "gt0022",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078]"
+          },
+          "gt0053": {
+            "id": "gt0053",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0018": {
+        "id": "gt0018",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-serum_albumin.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-serum_albumin.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0021": {
+            "id": "gt0021",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.3]"
+          },
+          "gt0054": {
+            "id": "gt0054",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0019": {
+        "id": "gt0019",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test_glucose.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test_glucose.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0020": {
+            "id": "gt0020",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078]"
+          },
+          "gt0055": {
+            "id": "gt0055",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0028": {
+        "id": "gt0028",
+        "model_id": "openEHR-EHR-OBSERVATION.basic_demographic.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.basic_demographic.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0029": {
+            "id": "gt0029",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0013]"
+          }
+        }
+      }
+    },
+    "rules": {
+      "gt0030": {
+        "id": "gt0030",
+        "priority": 18,
+        "when": [
+          "$gt0027|Birthdate|!=null"
+        ],
+        "then": [
+          "$gt0029|Age|.unit='a'",
+          "$gt0029|Age|.magnitude=$currentDateTime.year-$gt0027.year"
+        ]
+      },
+      "gt0031": {
+        "id": "gt0031",
+        "priority": 17,
+        "when": [
+          "$gt0026|PaO2|<59.3,mm[Hg]"
+        ],
+        "then": [
+          "$gt0003|PaO₂ <59.3 mmHg (7.9 kPa) Score|=1|local::at0029|Yes|"
+        ]
+      },
+      "gt0032": {
+        "id": "gt0032",
+        "priority": 16,
+        "when": [
+          "$gt0026|PaO2|>=59.3,mm[Hg]"
+        ],
+        "then": [
+          "$gt0003|PaO₂ <59.3 mmHg (7.9 kPa) Score|=0|local::at0028|No|"
+        ]
+      },
+      "gt0033": {
+        "id": "gt0033",
+        "priority": 15,
+        "when": [
+          "$gt0029|Age|>55,a"
+        ],
+        "then": [
+          "$gt0004|Age >55 years Score|=1|local::at0027|Yes|"
+        ]
+      },
+      "gt0034": {
+        "id": "gt0034",
+        "priority": 14,
+        "when": [
+          "$gt0029|Age|<=55,a"
+        ],
+        "then": [
+          "$gt0004|Age >55 years Score|=0|local::at0026|No|"
+        ]
+      },
+      "gt0035": {
+        "id": "gt0035",
+        "priority": 13,
+        "when": [
+          "$gt0025|White cell count|>15,10*9/l"
+        ],
+        "then": [
+          "$gt0005|WBC >15 x 10³/µL (10⁹/L) Score|=1|local::at0025|Yes|"
+        ]
+      },
+      "gt0036": {
+        "id": "gt0036",
+        "priority": 12,
+        "when": [
+          "$gt0025|White cell count|<=15,10*9/l"
+        ],
+        "then": [
+          "$gt0005|WBC >15 x 10³/µL (10⁹/L) Score|=0|local::at0024|No|"
+        ]
+      },
+      "gt0037": {
+        "id": "gt0037",
+        "priority": 11,
+        "when": [
+          "$gt0024|Serum Calcium|<8,mg/dl"
+        ],
+        "then": [
+          "$gt0006|Calcium <8 mg/dL (2 mmol/L) Score|=1|local::at0023|Yes|"
+        ]
+      },
+      "gt0038": {
+        "id": "gt0038",
+        "priority": 10,
+        "when": [
+          "$gt0024|Serum Calcium|>=8,mg/dl"
+        ],
+        "then": [
+          "$gt0006|Calcium <8 mg/dL (2 mmol/L) Score|=0|local::at0022|No|"
+        ]
+      },
+      "gt0039": {
+        "id": "gt0039",
+        "priority": 9,
+        "when": [
+          "$gt0023|Urea|>44.8,mg/dl"
+        ],
+        "then": [
+          "$gt0007|Urea >44.8 mg/dL (16 mmol/L) Score|=1|local::at0021|Yes|"
+        ]
+      },
+      "gt0040": {
+        "id": "gt0040",
+        "priority": 8,
+        "when": [
+          "$gt0023|Urea|<=44.8,mg/dl"
+        ],
+        "then": [
+          "$gt0007|Urea >44.8 mg/dL (16 mmol/L) Score|=0|local::at0020|No|"
+        ]
+      },
+      "gt0041": {
+        "id": "gt0041",
+        "priority": 7,
+        "when": [
+          "$gt0022|LDH|>600,u/l"
+        ],
+        "then": [
+          "$gt0008|LDH >600 IU/L Score|=1|local::at0019|Yes|"
+        ]
+      },
+      "gt0042": {
+        "id": "gt0042",
+        "priority": 6,
+        "when": [
+          "$gt0022|LDH|<=600,u/l"
+        ],
+        "then": [
+          "$gt0008|LDH >600 IU/L Score|=0|local::at0018|No|"
+        ]
+      },
+      "gt0043": {
+        "id": "gt0043",
+        "priority": 5,
+        "when": [
+          "$gt0021|Serum albumin|<3.2,gm/dl"
+        ],
+        "then": [
+          "$gt0009|Albumin <3.2 g/dL (32 g/L) Score|=1|local::at0017|Yes|"
+        ]
+      },
+      "gt0044": {
+        "id": "gt0044",
+        "priority": 4,
+        "when": [
+          "$gt0021|Serum albumin|>=3.2,gm/dl"
+        ],
+        "then": [
+          "$gt0009|Albumin <3.2 g/dL (32 g/L) Score|=0|local::at0016|No|"
+        ]
+      },
+      "gt0045": {
+        "id": "gt0045",
+        "priority": 3,
+        "when": [
+          "$gt0020|Glucose result|>180,mg/dl"
+        ],
+        "then": [
+          "$gt0010|Glucose >180 mg/dL (10 mmol/L) Score|=1|local::at0015|Yes|"
+        ]
+      },
+      "gt0046": {
+        "id": "gt0046",
+        "priority": 2,
+        "when": [
+          "$gt0020|Glucose result|<=180,mg/dl"
+        ],
+        "then": [
+          "$gt0010|Glucose >180 mg/dL (10 mmol/L) Score|=0|local::at0014|No|"
+        ]
+      },
+      "gt0047": {
+        "id": "gt0047",
+        "priority": 1,
+        "then": [
+          "$gt0011|Total score|.magnitude=(((((($gt0010.value+$gt0007.value)+$gt0008.value)+$gt0009.value)+$gt0003.value)+$gt0004.value)+$gt0005.value)+$gt0006.value"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "sv": {
+        "id": "sv",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Glasgow Imries kriterier för bedömning av akut pankreatit",
+            "description": "Att i enlighet med Glasgow-Imries kriterier utvärdera svårighetsgrad av akut pankreatit med hjälp av åtta laborationsparametrar."
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "PaO₂ <59.3 mmHg (7.9 kPa) - poäng",
+            "description": ""
+          },
+          "gt0004": {
+            "id": "gt0004",
+            "text": "Ålder >55 år - poäng",
+            "description": ""
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "LPK >15 x 10³/µl (10⁹/l) - poäng",
+            "description": ""
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Kalcium <8 mg/dl (2 mmol/l) - poäng",
+            "description": ""
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Urea >44.8 mg/dl (16 mmol/l) - poäng",
+            "description": ""
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "LDH >600 IU/l - poäng",
+            "description": ""
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Albumin <3.2 g/dl (32 g/l) - poäng",
+            "description": ""
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Glukos >180 mg/dl (10 mmol/l) - poäng",
+            "description": ""
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Poängsumma",
+            "description": ""
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "Glukos",
+            "description": ""
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "text": "Serum-albumin",
+            "description": ""
+          },
+          "gt0022": {
+            "id": "gt0022",
+            "text": "LDH",
+            "description": ""
+          },
+          "gt0023": {
+            "id": "gt0023",
+            "text": "Urea",
+            "description": ""
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "text": "Serum-kalcium",
+            "description": ""
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "text": "LPK",
+            "description": ""
+          },
+          "gt0026": {
+            "id": "gt0026",
+            "text": "PaO2",
+            "description": ""
+          },
+          "gt0027": {
+            "id": "gt0027",
+            "text": "Födelsedatum",
+            "description": ""
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "text": "Ålder",
+            "description": ""
+          },
+          "gt0030": {
+            "id": "gt0030",
+            "text": "Beräkna ålder"
+          },
+          "gt0031": {
+            "id": "gt0031",
+            "text": "CDS PaO₂ <59.3 mmHg (7.9 kPa) - JA"
+          },
+          "gt0032": {
+            "id": "gt0032",
+            "text": "CDS PaO₂ <59.3 mmHg (7.9 kPa) - NEJ"
+          },
+          "gt0033": {
+            "id": "gt0033",
+            "text": "Ålder >55 år - JA"
+          },
+          "gt0034": {
+            "id": "gt0034",
+            "text": "Ålder >55 år - NEJ"
+          },
+          "gt0035": {
+            "id": "gt0035",
+            "text": "LPK >15 x 10³/µl (10⁹/l) - JA"
+          },
+          "gt0036": {
+            "id": "gt0036",
+            "text": "LPK >15 x 10³/µl (10⁹/l) - NEJ"
+          },
+          "gt0037": {
+            "id": "gt0037",
+            "text": "Kalcium <8 mg/dl (2 mmol/l) - JA"
+          },
+          "gt0038": {
+            "id": "gt0038",
+            "text": "Kalcium <8 mg/dl (2 mmol/l) - NEJ"
+          },
+          "gt0039": {
+            "id": "gt0039",
+            "text": "Urea >44.8 mg/dl (16 mmol/l) - JA"
+          },
+          "gt0040": {
+            "id": "gt0040",
+            "text": "Urea >44.8 mg/dl (16 mmol/l)  - NEJ"
+          },
+          "gt0041": {
+            "id": "gt0041",
+            "text": "LDH >600 IU/l - JA"
+          },
+          "gt0042": {
+            "id": "gt0042",
+            "text": "LDH >600 IU/l - NEJ"
+          },
+          "gt0043": {
+            "id": "gt0043",
+            "text": "Albumin <3.2 g/dl (32 g/l) - JA"
+          },
+          "gt0044": {
+            "id": "gt0044",
+            "text": "Albumin <3.2 g/dl (32 g/l) - NEJ"
+          },
+          "gt0045": {
+            "id": "gt0045",
+            "text": "Glukos >180 mg/dl (10 mmol/l) - JA"
+          },
+          "gt0046": {
+            "id": "gt0046",
+            "text": "Glukos >180 mg/dl (10 mmol/l) - NEJ"
+          },
+          "gt0047": {
+            "id": "gt0047",
+            "text": "Beräkna poängsumma"
+          },
+          "gt0048": {
+            "id": "gt0048",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0049": {
+            "id": "gt0049",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0050": {
+            "id": "gt0050",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0051": {
+            "id": "gt0051",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0052": {
+            "id": "gt0052",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0053": {
+            "id": "gt0053",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0054": {
+            "id": "gt0054",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0055": {
+            "id": "gt0055",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      },
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Glasgow imrie for acute pancreatitis",
+            "description": "The Glasgow-Imrie Criteria for Severity of Acute Pancreatitis provides an assessment of the severity of pancreatitis using 8 laboratory values"
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "PaO₂ <59.3 mmHg (7.9 kPa) Score",
+            "description": "PaO₂ <59.3 mmHg (7.9 kPa) Score"
+          },
+          "gt0004": {
+            "id": "gt0004",
+            "text": "Age >55 years Score",
+            "description": "Age >55 years Score"
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "WBC >15 x 10³/µL (10⁹/L) Score",
+            "description": "WBC >15 x 10³/µL (10⁹/L) score"
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Calcium <8 mg/dL (2 mmol/L) Score",
+            "description": "Calcium <8 mg/dL (2 mmol/L) Score"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Urea >44.8 mg/dL (16 mmol/L) Score",
+            "description": "Urea >44.8 mg/dL (16 mmol/L) Score"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "LDH >600 IU/L Score",
+            "description": "LDH >600 IU/L Score"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Albumin <3.2 g/dL (32 g/L) Score",
+            "description": "Albumin <3.2 g/dL (32 g/L) Score"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Glucose >180 mg/dL (10 mmol/L) Score",
+            "description": "Glucose >180 mg/dL (10 mmol/L) Score"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Total score",
+            "description": "Sum of the individual scores. Range 0 to 8"
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "Glucose result",
+            "description": "The result of the test."
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "text": "Serum albumin",
+            "description": "Serum albumin level in this specimen."
+          },
+          "gt0022": {
+            "id": "gt0022",
+            "text": "LDH",
+            "description": "The LDH concentration value in Units/L"
+          },
+          "gt0023": {
+            "id": "gt0023",
+            "text": "Urea",
+            "description": "Urea level in this specimen."
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "text": "Serum Calcium",
+            "description": "Serum calcium in mg/dL"
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "text": "White cell count",
+            "description": "The number of white cells per litre"
+          },
+          "gt0026": {
+            "id": "gt0026",
+            "text": "PaO2",
+            "description": "The oxygen pressure in the arterial blood."
+          },
+          "gt0027": {
+            "id": "gt0027",
+            "text": "Birthdate",
+            "description": "The patient's date of birth."
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "text": "Age",
+            "description": "Age in years, and for babies: months, weeks or days"
+          },
+          "gt0030": {
+            "id": "gt0030",
+            "text": "Calculate Age"
+          },
+          "gt0031": {
+            "id": "gt0031",
+            "text": "Set PaO₂ <59.3 mmHg (7.9 kPa) - YES"
+          },
+          "gt0032": {
+            "id": "gt0032",
+            "text": "Set PaO₂ <59.3 mmHg (7.9 kPa) - NO"
+          },
+          "gt0033": {
+            "id": "gt0033",
+            "text": "Age >55 years - YES"
+          },
+          "gt0034": {
+            "id": "gt0034",
+            "text": "Age >55 years - NO"
+          },
+          "gt0035": {
+            "id": "gt0035",
+            "text": "WBC >15 x 10³/µL (10⁹/L) - YES"
+          },
+          "gt0036": {
+            "id": "gt0036",
+            "text": "WBC >15 x 10³/µL (10⁹/L) - NO"
+          },
+          "gt0037": {
+            "id": "gt0037",
+            "text": "Calcium <8 mg/dL (2 mmol/L) - YES"
+          },
+          "gt0038": {
+            "id": "gt0038",
+            "text": "Calcium <8 mg/dL (2 mmol/L) - NO"
+          },
+          "gt0039": {
+            "id": "gt0039",
+            "text": "Urea >44.8 mg/dL (16 mmol/L) - YES"
+          },
+          "gt0040": {
+            "id": "gt0040",
+            "text": "Urea >44.8 mg/dL (16 mmol/L)  - NO"
+          },
+          "gt0041": {
+            "id": "gt0041",
+            "text": "LDH >600 IU/L - YES"
+          },
+          "gt0042": {
+            "id": "gt0042",
+            "text": "LDH >600 IU/L - NO"
+          },
+          "gt0043": {
+            "id": "gt0043",
+            "text": "Albumin <3.2 g/dL (32 g/L) - YES"
+          },
+          "gt0044": {
+            "id": "gt0044",
+            "text": "Albumin <3.2 g/dL (32 g/L) - NO"
+          },
+          "gt0045": {
+            "id": "gt0045",
+            "text": "Glucose >180 mg/dL (10 mmol/L) - YES"
+          },
+          "gt0046": {
+            "id": "gt0046",
+            "text": "Glucose >180 mg/dL (10 mmol/L) - NO"
+          },
+          "gt0047": {
+            "id": "gt0047",
+            "text": "Calculate Total Score"
+          },
+          "gt0048": {
+            "id": "gt0048",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0049": {
+            "id": "gt0049",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0050": {
+            "id": "gt0050",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0051": {
+            "id": "gt0051",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0052": {
+            "id": "gt0052",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0053": {
+            "id": "gt0053",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0054": {
+            "id": "gt0054",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0055": {
+            "id": "gt0055",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/Glasgow-Imrie_Criteria_for_Acute_Pancreatitis.v1.test.yml
+++ b/gdl2/Glasgow-Imrie_Criteria_for_Acute_Pancreatitis.v1.test.yml
@@ -1,0 +1,252 @@
+guidelines:
+  1: Glasgow-Imrie_Criteria_for_Acute_Pancreatitis.v1
+test_cases:
+- id: Calcium, Albumin, PaO2, Age risk factors
+  input:
+    1:
+      gt0027|Birthdate: 1956-03-04T15:07Z
+      gt0048|Event time: 2019-03-27T15:07Z
+      gt0026|PaO2: 55,mm[Hg]
+      gt0049|Event time: 2019-03-27T15:08Z
+      gt0025|White cell count: 15,10*9/l
+      gt0050|Event time: 2019-03-27T15:09Z
+      gt0024|Serum Calcium: 7,mg/dl
+      gt0051|Event time: 2019-03-27T15:10Z
+      gt0023|Urea: 43,mg/dl
+      gt0052|Event time: 2019-03-26T15:10Z
+      gt0022|LDH: 500,u/l
+      gt0053|Event time: 2019-03-27T15:11Z
+      gt0021|Serum albumin: 3,gm/dl
+      gt0054|Event time: 2019-03-27T15:11Z
+      gt0020|Glucose result: 150,mg/dl
+      gt0055|Event time: 2019-03-27T15:12Z
+  expected_output:
+    1:
+      gt0004|Age >55 years Score: 1|local::at0027|Yes|
+      gt0007|Urea >44.8 mg/dL (16 mmol/L) Score: 0|local::at0020|No|
+      gt0011|Total score: 4
+      gt0010|Glucose >180 mg/dL (10 mmol/L) Score: 0|local::at0014|No|
+      gt0005|WBC >15 x 10³/µL (10⁹/L) Score: 0|local::at0024|No|
+      gt0008|LDH >600 IU/L Score: 0|local::at0018|No|
+      gt0006|Calcium <8 mg/dL (2 mmol/L) Score: 1|local::at0023|Yes|
+      gt0009|Albumin <3.2 g/dL (32 g/L) Score: 1|local::at0017|Yes|
+      gt0003|PaO₂ <59.3 mmHg (7.9 kPa) Score: 1|local::at0029|Yes|
+      gt0029|Age: 63,a
+- id: Calcium, Albumin risk factors
+  input:
+    1:
+      gt0027|Birthdate: 1966-03-01T15:07Z
+      gt0048|Event time: 2019-03-27T15:07Z
+      gt0026|PaO2: 60,mm[Hg]
+      gt0049|Event time: 2019-03-27T15:08Z
+      gt0025|White cell count: 15,10*9/l
+      gt0050|Event time: 2019-03-27T15:09Z
+      gt0024|Serum Calcium: 7,mg/dl
+      gt0051|Event time: 2019-03-27T15:10Z
+      gt0023|Urea: 43,mg/dl
+      gt0052|Event time: 2019-03-26T15:10Z
+      gt0022|LDH: 500,u/l
+      gt0053|Event time: 2019-03-27T15:11Z
+      gt0021|Serum albumin: 3,gm/dl
+      gt0054|Event time: 2019-03-27T15:11Z
+      gt0020|Glucose result: 150,mg/dl
+      gt0055|Event time: 2019-03-27T15:12Z
+  expected_output:
+    1:
+      gt0004|Age >55 years Score: 0|local::at0026|No|
+      gt0007|Urea >44.8 mg/dL (16 mmol/L) Score: 0|local::at0020|No|
+      gt0011|Total score: 2
+      gt0010|Glucose >180 mg/dL (10 mmol/L) Score: 0|local::at0014|No|
+      gt0005|WBC >15 x 10³/µL (10⁹/L) Score: 0|local::at0024|No|
+      gt0008|LDH >600 IU/L Score: 0|local::at0018|No|
+      gt0006|Calcium <8 mg/dL (2 mmol/L) Score: 1|local::at0023|Yes|
+      gt0009|Albumin <3.2 g/dL (32 g/L) Score: 1|local::at0017|Yes|
+      gt0003|PaO₂ <59.3 mmHg (7.9 kPa) Score: 0|local::at0028|No|
+      gt0029|Age: 53,a
+- id: Decimal albumin (does not work in execution tab)
+  input:
+    1:
+      gt0027|Birthdate: 1966-03-01T15:07Z
+      gt0048|Event time: 2019-03-27T15:07Z
+      gt0026|PaO2: 60,mm[Hg]
+      gt0049|Event time: 2019-03-27T15:08Z
+      gt0025|White cell count: 15,10*9/l
+      gt0050|Event time: 2019-03-27T15:09Z
+      gt0024|Serum Calcium: 9,mg/dl
+      gt0051|Event time: 2019-03-27T15:10Z
+      gt0023|Urea: 47,mg/dl
+      gt0052|Event time: 2019-03-26T15:10Z
+      gt0022|LDH: 620,u/l
+      gt0053|Event time: 2019-03-27T15:11Z
+      gt0021|Serum albumin: 3.3,gm/dl
+      gt0054|Event time: 2019-03-27T15:11Z
+      gt0020|Glucose result: 150,mg/dl
+      gt0055|Event time: 2019-03-27T15:12Z
+  expected_output:
+    1:
+      gt0004|Age >55 years Score: 0|local::at0026|No|
+      gt0007|Urea >44.8 mg/dL (16 mmol/L) Score: 1|local::at0021|Yes|
+      gt0011|Total score: 2
+      gt0010|Glucose >180 mg/dL (10 mmol/L) Score: 0|local::at0014|No|
+      gt0005|WBC >15 x 10³/µL (10⁹/L) Score: 0|local::at0024|No|
+      gt0008|LDH >600 IU/L Score: 1|local::at0019|Yes|
+      gt0006|Calcium <8 mg/dL (2 mmol/L) Score: 0|local::at0022|No|
+      gt0009|Albumin <3.2 g/dL (32 g/L) Score: 0|local::at0016|No|
+      gt0003|PaO₂ <59.3 mmHg (7.9 kPa) Score: 0|local::at0028|No|
+      gt0029|Age: 53,a
+- id: Urea, LDH risk factors
+  input:
+    1:
+      gt0027|Birthdate: 1966-03-01T15:07Z
+      gt0048|Event time: 2019-03-27T15:07Z
+      gt0026|PaO2: 60,mm[Hg]
+      gt0049|Event time: 2019-03-27T15:08Z
+      gt0025|White cell count: 15,10*9/l
+      gt0050|Event time: 2019-03-27T15:09Z
+      gt0024|Serum Calcium: 9,mg/dl
+      gt0051|Event time: 2019-03-27T15:10Z
+      gt0023|Urea: 47,mg/dl
+      gt0052|Event time: 2019-03-26T15:10Z
+      gt0022|LDH: 620,u/l
+      gt0053|Event time: 2019-03-27T15:11Z
+      gt0021|Serum albumin: 4,gm/dl
+      gt0054|Event time: 2019-03-27T15:11Z
+      gt0020|Glucose result: 150,mg/dl
+      gt0055|Event time: 2019-03-27T15:12Z
+  expected_output:
+    1:
+      gt0004|Age >55 years Score: 0|local::at0026|No|
+      gt0007|Urea >44.8 mg/dL (16 mmol/L) Score: 1|local::at0021|Yes|
+      gt0011|Total score: 2
+      gt0010|Glucose >180 mg/dL (10 mmol/L) Score: 0|local::at0014|No|
+      gt0005|WBC >15 x 10³/µL (10⁹/L) Score: 0|local::at0024|No|
+      gt0008|LDH >600 IU/L Score: 1|local::at0019|Yes|
+      gt0006|Calcium <8 mg/dL (2 mmol/L) Score: 0|local::at0022|No|
+      gt0009|Albumin <3.2 g/dL (32 g/L) Score: 0|local::at0016|No|
+      gt0003|PaO₂ <59.3 mmHg (7.9 kPa) Score: 0|local::at0028|No|
+      gt0029|Age: 53,a
+- id: Glucose, WBC
+  input:
+    1:
+      gt0027|Birthdate: 1966-03-01T15:07Z
+      gt0048|Event time: 2019-03-27T15:07Z
+      gt0026|PaO2: 60,mm[Hg]
+      gt0049|Event time: 2019-03-27T15:08Z
+      gt0025|White cell count: 17,10*9/l
+      gt0050|Event time: 2019-03-27T15:09Z
+      gt0024|Serum Calcium: 11,mg/dl
+      gt0051|Event time: 2019-03-27T15:10Z
+      gt0023|Urea: 41,mg/dl
+      gt0052|Event time: 2019-03-26T15:10Z
+      gt0022|LDH: 510,u/l
+      gt0053|Event time: 2019-03-27T15:11Z
+      gt0021|Serum albumin: 4,gm/dl
+      gt0054|Event time: 2019-03-27T15:11Z
+      gt0020|Glucose result: 190,mg/dl
+      gt0055|Event time: 2019-03-27T15:12Z
+  expected_output:
+    1:
+      gt0004|Age >55 years Score: 0|local::at0026|No|
+      gt0007|Urea >44.8 mg/dL (16 mmol/L) Score: 0|local::at0020|No|
+      gt0011|Total score: 2
+      gt0010|Glucose >180 mg/dL (10 mmol/L) Score: 1|local::at0015|Yes|
+      gt0005|WBC >15 x 10³/µL (10⁹/L) Score: 1|local::at0025|Yes|
+      gt0008|LDH >600 IU/L Score: 0|local::at0018|No|
+      gt0006|Calcium <8 mg/dL (2 mmol/L) Score: 0|local::at0022|No|
+      gt0009|Albumin <3.2 g/dL (32 g/L) Score: 0|local::at0016|No|
+      gt0003|PaO₂ <59.3 mmHg (7.9 kPa) Score: 0|local::at0028|No|
+      gt0029|Age: 53,a
+- id: Glucose, PaO2
+  input:
+    1:
+      gt0027|Birthdate: 1966-03-01T15:07Z
+      gt0048|Event time: 2019-03-27T15:07Z
+      gt0026|PaO2: 57,mm[Hg]
+      gt0049|Event time: 2019-03-27T15:08Z
+      gt0025|White cell count: 14,10*9/l
+      gt0050|Event time: 2019-03-27T15:09Z
+      gt0024|Serum Calcium: 11,mg/dl
+      gt0051|Event time: 2019-03-27T15:10Z
+      gt0023|Urea: 41,mg/dl
+      gt0052|Event time: 2019-03-26T15:10Z
+      gt0022|LDH: 510,u/l
+      gt0053|Event time: 2019-03-27T15:11Z
+      gt0021|Serum albumin: 4,gm/dl
+      gt0054|Event time: 2019-03-27T15:11Z
+      gt0020|Glucose result: 190,mg/dl
+      gt0055|Event time: 2019-03-27T15:12Z
+  expected_output:
+    1:
+      gt0004|Age >55 years Score: 0|local::at0026|No|
+      gt0007|Urea >44.8 mg/dL (16 mmol/L) Score: 0|local::at0020|No|
+      gt0011|Total score: 2
+      gt0010|Glucose >180 mg/dL (10 mmol/L) Score: 1|local::at0015|Yes|
+      gt0005|WBC >15 x 10³/µL (10⁹/L) Score: 0|local::at0024|No|
+      gt0008|LDH >600 IU/L Score: 0|local::at0018|No|
+      gt0006|Calcium <8 mg/dL (2 mmol/L) Score: 0|local::at0022|No|
+      gt0009|Albumin <3.2 g/dL (32 g/L) Score: 0|local::at0016|No|
+      gt0003|PaO₂ <59.3 mmHg (7.9 kPa) Score: 1|local::at0029|Yes|
+      gt0029|Age: 53,a
+- id: Higher score
+  input:
+    1:
+      gt0027|Birthdate: 1966-03-01T15:07Z
+      gt0048|Event time: 2019-03-27T15:07Z
+      gt0026|PaO2: 57,mm[Hg]
+      gt0049|Event time: 2019-03-27T15:08Z
+      gt0025|White cell count: 14,10*9/l
+      gt0050|Event time: 2019-03-27T15:09Z
+      gt0024|Serum Calcium: 7,mg/dl
+      gt0051|Event time: 2019-03-27T15:10Z
+      gt0023|Urea: 41,mg/dl
+      gt0052|Event time: 2019-03-26T15:10Z
+      gt0022|LDH: 510,u/l
+      gt0053|Event time: 2019-03-27T15:11Z
+      gt0021|Serum albumin: 3,gm/dl
+      gt0054|Event time: 2019-03-27T15:11Z
+      gt0020|Glucose result: 190,mg/dl
+      gt0055|Event time: 2019-03-27T15:12Z
+  expected_output:
+    1:
+      gt0004|Age >55 years Score: 0|local::at0026|No|
+      gt0007|Urea >44.8 mg/dL (16 mmol/L) Score: 0|local::at0020|No|
+      gt0011|Total score: 4
+      gt0010|Glucose >180 mg/dL (10 mmol/L) Score: 1|local::at0015|Yes|
+      gt0005|WBC >15 x 10³/µL (10⁹/L) Score: 0|local::at0024|No|
+      gt0008|LDH >600 IU/L Score: 0|local::at0018|No|
+      gt0006|Calcium <8 mg/dL (2 mmol/L) Score: 1|local::at0023|Yes|
+      gt0009|Albumin <3.2 g/dL (32 g/L) Score: 1|local::at0017|Yes|
+      gt0003|PaO₂ <59.3 mmHg (7.9 kPa) Score: 1|local::at0029|Yes|
+      gt0029|Age: 53,a
+- id: Very high score
+  input:
+    1:
+      gt0027|Birthdate: 1966-03-01T15:07Z
+      gt0048|Event time: 2019-03-27T15:07Z
+      gt0026|PaO2: 57,mm[Hg]
+      gt0049|Event time: 2019-03-27T15:08Z
+      gt0025|White cell count: 16,10*9/l
+      gt0050|Event time: 2019-03-27T15:09Z
+      gt0024|Serum Calcium: 7,mg/dl
+      gt0051|Event time: 2019-03-27T15:10Z
+      gt0023|Urea: 45,mg/dl
+      gt0052|Event time: 2019-03-26T15:10Z
+      gt0022|LDH: 620,u/l
+      gt0053|Event time: 2019-03-27T15:11Z
+      gt0021|Serum albumin: 3,gm/dl
+      gt0054|Event time: 2019-03-27T15:11Z
+      gt0020|Glucose result: 190,mg/dl
+      gt0055|Event time: 2019-03-27T15:12Z
+  expected_output:
+    1:
+      gt0004|Age >55 years Score: 0|local::at0026|No|
+      gt0007|Urea >44.8 mg/dL (16 mmol/L) Score: 1|local::at0021|Yes|
+      gt0011|Total score: 7
+      gt0010|Glucose >180 mg/dL (10 mmol/L) Score: 1|local::at0015|Yes|
+      gt0005|WBC >15 x 10³/µL (10⁹/L) Score: 1|local::at0025|Yes|
+      gt0008|LDH >600 IU/L Score: 1|local::at0019|Yes|
+      gt0006|Calcium <8 mg/dL (2 mmol/L) Score: 1|local::at0023|Yes|
+      gt0009|Albumin <3.2 g/dL (32 g/L) Score: 1|local::at0017|Yes|
+      gt0003|PaO₂ <59.3 mmHg (7.9 kPa) Score: 1|local::at0029|Yes|
+      gt0029|Age: 53,a
+

--- a/gdl2/Glasgow_Imrie_Evaluation.v1.gdl2.json
+++ b/gdl2/Glasgow_Imrie_Evaluation.v1.gdl2.json
@@ -1,0 +1,287 @@
+{
+  "id": "Glasgow_Imrie_Evaluation.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2017-11-03",
+      "name": "Syeeda S Farruque",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "other_contributors": [
+      "Dennis Forslund, Cambio Healthcare Systems"
+    ],
+    "lifecycle_state": "Author draft",
+    "details": {
+      "sv": {
+        "id": "sv",
+        "purpose": "Att i enlighet med Glasgow-Imries kriterier utvärdera svårighetsgrad av akut pankreatit baserat på åtta laborationsparametrar.",
+        "keywords": [
+          "Glasgow Imrie",
+          "pankreatit",
+          "akut pankreatit"
+        ],
+        "use": "Metoden baseras på åtta provsvar vilka poängsätts med 0-1p, vilket ger en maximal poängsumma om 8p:\r\n\r\n    PaO2< 7.9kPa\r\n    Ålder > 55 år\r\n    Neutrofiler (LPK > 15 x 10⁹/L)\r\n    Kalcium < 2 mmol/L\r\n    Njurfunktion: Urea > 16 mmol/L\r\n    LDH > 600 IU/L\r\n    Albumin < 32 g/L (serum)\r\n    B-glukos > 10 mmol/L\r\n \r\n\r\nResultatet tolkas enligt: \r\n\r\n* ≥3p indikerar förhöjd risk för svår pankretatit\r\n* <3p indikerar lägre sannolikhet för svår pankreatit\r\n\r\nPoäng\tSvår pankreatit*\r\n0 \t7%\r\n1 \t6%\r\n2 \t16%\r\n3 \t20%\r\n4 \t61%\r\n5 \t55%\r\n6 \t100%\r\n7 \t0%\r\n8 \t100%",
+        "misuse": "Endast tillämpbar först 48h efter initial bedömning.",
+        "copyright": "© Cambio Healthcare Systems"
+      },
+      "en": {
+        "id": "en",
+        "purpose": "The Glasgow-Imrie Criteria for Severity of Acute Pancreatitis provides an assessment of the severity of pancreatitis using 8 laboratory values",
+        "keywords": [
+          "Glasgow-Imrie Criteria for Severity of Acute Pancreatiti"
+        ],
+        "use": "This tool provides an assessment of the severity of acute pancreatitis.\n\nScores ≥3 suggest increased likelihood of severe pancreatitis\nScores < 3 suggest decreased likelihood of severe pancreatitis\n\nScore interpretation:\n\nScore \t\tSevere Pancreatitis*\n0 \t\t7%\n1 \t\t6%\n2 \t\t16%\n3 \t \t20%\n4 \t \t61%\n5 \t \t55%\n6 \t\t100%\n7 \t\t0%\n8 \t \t100%\n",
+        "misuse": "Do not use sooner than 48 hours from presentation",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Ref. 1: Blamey SL, Imrie CW, O'Neill J, Gilmour WH, Carter DC. Prognostic factors in acute pancreatitis. Gut. 1984 Dec;25(12):1340-6."
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0002": {
+        "id": "gt0002",
+        "model_id": "openEHR-EHR-EVALUATION.glasgow_imrie_for_acute_pancreatitis_evaluation.v1",
+        "template_id": "openEHR-EHR-EVALUATION.glasgow_imrie_for_acute_pancreatitis_evaluation.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0007": {
+            "id": "gt0007",
+            "path": "/data[at0001]/items[at0002]"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "path": "/data[at0001]/items[at0005]"
+          }
+        }
+      },
+      "gt0003": {
+        "id": "gt0003",
+        "model_id": "openEHR-EHR-OBSERVATION.glasgow_imrie_criteria_for_severity_of_acute_pancreatitis.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.glasgow_imrie_criteria_for_severity_of_acute_pancreatitis.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0006": {
+            "id": "gt0006",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0012]"
+          }
+        }
+      }
+    },
+    "rules": {
+      "gt0010": {
+        "id": "gt0010",
+        "priority": 7,
+        "when": [
+          "$gt0006|Total score|==7"
+        ],
+        "then": [
+          "$gt0008|Score interpretation: Percent likelihood of severe pancreatitis|=0|local::at0006|0 %|",
+          "$gt0007|Likelihood of severe pancreatitis|=0|local::at0003|Scores ≥3 suggest increased likelihood of severe pancreatitis|"
+        ]
+      },
+      "gt0011": {
+        "id": "gt0011",
+        "priority": 6,
+        "when": [
+          "$gt0006|Total score|==1"
+        ],
+        "then": [
+          "$gt0007|Likelihood of severe pancreatitis|=1|local::at0004|Scores < 3 suggest decreased likelihood of severe pancreatitis|",
+          "$gt0008|Score interpretation: Percent likelihood of severe pancreatitis|=1|local::at0007|6%|"
+        ]
+      },
+      "gt0012": {
+        "id": "gt0012",
+        "priority": 5,
+        "when": [
+          "$gt0006|Total score|==2"
+        ],
+        "then": [
+          "$gt0007|Likelihood of severe pancreatitis|=1|local::at0004|Scores < 3 suggest decreased likelihood of severe pancreatitis|",
+          "$gt0008|Score interpretation: Percent likelihood of severe pancreatitis|=2|local::at0008|16%|"
+        ]
+      },
+      "gt0013": {
+        "id": "gt0013",
+        "priority": 4,
+        "when": [
+          "$gt0006|Total score|==3"
+        ],
+        "then": [
+          "$gt0007|Likelihood of severe pancreatitis|=0|local::at0003|Scores ≥3 suggest increased likelihood of severe pancreatitis|",
+          "$gt0008|Score interpretation: Percent likelihood of severe pancreatitis|=3|local::at0009|20%|"
+        ]
+      },
+      "gt0014": {
+        "id": "gt0014",
+        "priority": 3,
+        "when": [
+          "$gt0006|Total score|==5"
+        ],
+        "then": [
+          "$gt0007|Likelihood of severe pancreatitis|=0|local::at0003|Scores ≥3 suggest increased likelihood of severe pancreatitis|",
+          "$gt0008|Score interpretation: Percent likelihood of severe pancreatitis|=4|local::at0010|55%|"
+        ]
+      },
+      "gt0015": {
+        "id": "gt0015",
+        "priority": 2,
+        "when": [
+          "$gt0006|Total score|==4"
+        ],
+        "then": [
+          "$gt0007|Likelihood of severe pancreatitis|=0|local::at0003|Scores ≥3 suggest increased likelihood of severe pancreatitis|",
+          "$gt0008|Score interpretation: Percent likelihood of severe pancreatitis|=5|local::at0011|61%|"
+        ]
+      },
+      "gt0016": {
+        "id": "gt0016",
+        "priority": 1,
+        "when": [
+          "($gt0006|Total score|==6)||($gt0006|Total score|==8)"
+        ],
+        "then": [
+          "$gt0007|Likelihood of severe pancreatitis|=0|local::at0003|Scores ≥3 suggest increased likelihood of severe pancreatitis|",
+          "$gt0008|Score interpretation: Percent likelihood of severe pancreatitis|=6|local::at0012|100%|"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "sv": {
+        "id": "sv",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Glasgow Imries kriterier för bedömning av akut pankreatit - utvärdering",
+            "description": "Utvärdering av poäng erhållen i enlighet med Glasgow-Imries kriterier, vilka används för att bedöma svårighetsgrad av akut pankreatit med hjälp av åtta laborationsparametrar."
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Poängsumma",
+            "description": ""
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Poängsumma",
+            "description": ""
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Resultat",
+            "description": ""
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Akut pankreatit - sannolikhet (%)",
+            "description": ""
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "*(en) score",
+            "description": ""
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Akut pankreatit - sannolikhet (%): 0%"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Akut pankreatit - sannolikhet (%): 6%"
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "Akut pankreatit - sannolikhet (%): 16%"
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "Akut pankreatit - sannolikhet (%): 20%"
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "Akut pankreatit - sannolikhet (%): 55%"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "Akut pankreatit - sannolikhet (%): 61%"
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "Akut pankreatit - sannolikhet (%): 100%"
+          }
+        }
+      },
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Glasgow Imrie Evaluation",
+            "description": "The Glasgow-Imrie Criteria for Severity of Acute Pancreatitis provides an assessment of the severity of pancreatitis using 8 laboratory values"
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Total score",
+            "description": "Sum of the individual scores. Range 0 to 8"
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Total score",
+            "description": "Sum of the individual scores. Range 0 to 8"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Likelihood of severe pancreatitis",
+            "description": "Scores that increase or decrease the likelihood of severe pancreatitis"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Score interpretation: Percent likelihood of severe pancreatitis",
+            "description": "Score interpretation: Percent likelihood of severe pancreatitis"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "score"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Percent likelihood of severe pancreatitis: 0%"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Percent likelihood of severe pancreatitis: 6%"
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "Percent likelihood of severe pancreatitis: 16%"
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "Percent likelihood of severe pancreatitis: 20%"
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "Percent likelihood of severe pancreatitis: 55%"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "Percent likelihood of severe pancreatitis: 61%"
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "Percent likelihood of severe pancreatitis: 100%"
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/Glasgow_Imrie_Evaluation.v1.test.yml
+++ b/gdl2/Glasgow_Imrie_Evaluation.v1.test.yml
@@ -1,0 +1,67 @@
+guidelines:
+  1: Glasgow_Imrie_Evaluation.v1
+test_cases:
+- id: 1
+  input:
+    1:
+      gt0006|Total score: 1
+  expected_output:
+    1:
+      'gt0008|Score interpretation: Percent likelihood of severe pancreatitis': 1|local::at0007|6%|
+      gt0007|Likelihood of severe pancreatitis: 1|local::at0004|Scores < 3 suggest decreased likelihood of severe pancreatitis|
+- id: 2
+  input:
+    1:
+      gt0006|Total score: 2
+  expected_output:
+    1:
+      'gt0008|Score interpretation: Percent likelihood of severe pancreatitis': 2|local::at0008|16%|
+      gt0007|Likelihood of severe pancreatitis: 1|local::at0004|Scores < 3 suggest decreased likelihood of severe pancreatitis|
+- id: 3
+  input:
+    1:
+      gt0006|Total score: 3
+  expected_output:
+    1:
+      'gt0008|Score interpretation: Percent likelihood of severe pancreatitis': 3|local::at0009|20%|
+      gt0007|Likelihood of severe pancreatitis: 0|local::at0003|Scores ≥3 suggest increased likelihood of severe pancreatitis|
+- id: 4
+  input:
+    1:
+      gt0006|Total score: 4
+  expected_output:
+    1:
+      'gt0008|Score interpretation: Percent likelihood of severe pancreatitis': 5|local::at0011|61%|
+      gt0007|Likelihood of severe pancreatitis: 0|local::at0003|Scores ≥3 suggest increased likelihood of severe pancreatitis|
+- id: 5
+  input:
+    1:
+      gt0006|Total score: 5
+  expected_output:
+    1:
+      'gt0008|Score interpretation: Percent likelihood of severe pancreatitis': 4|local::at0010|55%|
+      gt0007|Likelihood of severe pancreatitis: 0|local::at0003|Scores ≥3 suggest increased likelihood of severe pancreatitis|
+- id: 6
+  input:
+    1:
+      gt0006|Total score: 6
+  expected_output:
+    1:
+      'gt0008|Score interpretation: Percent likelihood of severe pancreatitis': 6|local::at0012|100%|
+      gt0007|Likelihood of severe pancreatitis: 0|local::at0003|Scores ≥3 suggest increased likelihood of severe pancreatitis|
+- id: 7
+  input:
+    1:
+      gt0006|Total score: 7
+  expected_output:
+    1:
+      'gt0008|Score interpretation: Percent likelihood of severe pancreatitis': 0|local::at0006|0 %|
+      gt0007|Likelihood of severe pancreatitis: 0|local::at0003|Scores ≥3 suggest increased likelihood of severe pancreatitis|
+- id: 8
+  input:
+    1:
+      gt0006|Total score: 8
+  expected_output:
+    1:
+      'gt0008|Score interpretation: Percent likelihood of severe pancreatitis': 6|local::at0012|100%|
+      gt0007|Likelihood of severe pancreatitis: 0|local::at0003|Scores ≥3 suggest increased likelihood of severe pancreatitis|


### PR DESCRIPTION
Dear Isabelle,
Two new guidelines migrated. Only small changes were needed (output -> itput, event time)
Note 1:
The guideline does what it is in description, but the shown probabilities are strange (in fact they are the  same in the referenced article, but for example for score 7, there is only 1 case). I would suggest to remove probability information, because it might be missleading, having a 54-years old patient with all the lab values wrong, and saying 0% chance of pancreatis. Even if there is a note that score >3 indicates high risk.
Note 2:
Guideline accepts only specific units for eaach value (although in the architypes there might be more). This is not specified in the description.
Note 3:
Decimals don't work in the execution tab (but does in the test tab), but I think this is a known issue.