### PR TITLE
HAT score migrated

### DIFF
--- a/gdl2/HAT_Score_Assessment.v1.gdl2.json
+++ b/gdl2/HAT_Score_Assessment.v1.gdl2.json
@@ -1,0 +1,193 @@
+{
+  "id": "HAT_Score_Assessment.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2017-12-10",
+      "name": "Syeeda S Farruque",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "lifecycle_state": "Author draft",
+    "details": {
+      "en": {
+        "id": "en",
+        "purpose": "HAT (Hemorrhage After Thrombolysis) Score for Predicting Post-tPA Hemorrhage provides an assessment of the risk of hemorrhage after tPA.\r\n\r\nThe tool provides a way to indentify patients that require close monitoring when treated with tPA\r\n",
+        "keywords": [
+          "HAT (Hemorrhage After Thrombolysis) Score for Predicting Post-tPA Hemorrhage"
+        ],
+        "use": "Score interpretation:\r\nHAT Score \tRisk of Any Hemorrhage \tRisk of Symptomatic ICH \tRisk of Fatal Hemorrhage\r\n0 \t                                                         6% \t                                        2% \t                                       0%\r\n1 \t                                                       16% \t                                         5% \t                                       3%\r\n2 \t                                                        23% \t                                       10% \t                                       7%\r\n3 \t                                                        36% \t                                       15% \t                                       6%\r\n>3 \t                                                        78% \t                                       44% \t                                     33%",
+        "misuse": "Do not use the score on its own for diagnostic purposes without supporting evidence",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Ref. 1: Lou M, Safdar A, Selim M, et. al. The HAT Score: A simple grading scale for predicting hemorrhage after thrombolysis. Neurology. 2008; 71(18): 1417–1423. doi: 10.1212/01.wnl.0000330297.58334.dd"
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0002": {
+        "id": "gt0002",
+        "model_id": "openEHR-EHR-EVALUATION.haemorrhage_after_thrombolysis_score_assessment.v1",
+        "template_id": "openEHR-EHR-EVALUATION.haemorrhage_after_thrombolysis_score_assessment.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0007": {
+            "id": "gt0007",
+            "path": "/data[at0001]/items[at0002]"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "path": "/data[at0001]/items[at0008]"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "path": "/data[at0001]/items[at0014]"
+          }
+        }
+      },
+      "gt0003": {
+        "id": "gt0003",
+        "model_id": "openEHR-EHR-OBSERVATION.haemorrhage_after_thrombolysis_score.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.haemorrhage_after_thrombolysis_score.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0006": {
+            "id": "gt0006",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0007]"
+          }
+        }
+      }
+    },
+    "rules": {
+      "gt0010": {
+        "id": "gt0010",
+        "priority": 5,
+        "when": [
+          "$gt0006|Total score|==0"
+        ],
+        "then": [
+          "$gt0007|Risk of any Hemorrhage|=0|local::at0003|2%|",
+          "$gt0008|Risk of symptomatic ICH|=0|local::at0009|6%|",
+          "$gt0009|Risk of Fatal Hemorrhage|=0|local::at0015|0%|"
+        ]
+      },
+      "gt0011": {
+        "id": "gt0011",
+        "priority": 4,
+        "when": [
+          "$gt0006|Total score|==1"
+        ],
+        "then": [
+          "$gt0007|Risk of any Hemorrhage|=1|local::at0004|5%|",
+          "$gt0008|Risk of symptomatic ICH|=1|local::at0010|16%|",
+          "$gt0009|Risk of Fatal Hemorrhage|=1|local::at0016|3%|"
+        ]
+      },
+      "gt0012": {
+        "id": "gt0012",
+        "priority": 3,
+        "when": [
+          "$gt0006|Total score|==2"
+        ],
+        "then": [
+          "$gt0007|Risk of any Hemorrhage|=2|local::at0005|10%|",
+          "$gt0008|Risk of symptomatic ICH|=2|local::at0011|23%|",
+          "$gt0009|Risk of Fatal Hemorrhage|=2|local::at0017|7%|"
+        ]
+      },
+      "gt0013": {
+        "id": "gt0013",
+        "priority": 2,
+        "when": [
+          "$gt0006|Total score|==3"
+        ],
+        "then": [
+          "$gt0007|Risk of any Hemorrhage|=3|local::at0006|15%|",
+          "$gt0008|Risk of symptomatic ICH|=3|local::at0012|36%|",
+          "$gt0009|Risk of Fatal Hemorrhage|=3|local::at0018|6%|"
+        ]
+      },
+      "gt0014": {
+        "id": "gt0014",
+        "priority": 1,
+        "when": [
+          "$gt0006|Total score|>3"
+        ],
+        "then": [
+          "$gt0007|Risk of any Hemorrhage|=4|local::at0007|44%|",
+          "$gt0008|Risk of symptomatic ICH|=4|local::at0013|78%|",
+          "$gt0009|Risk of Fatal Hemorrhage|=4|local::at0019|33%|"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Haemorrhage after thrombolysis score assessment",
+            "description": "HAT (Hemorrhage After Thrombolysis) Score for Predicting Post-tPA Hemorrhage provides an assessment of the risk of hemorrhage after tPA. This tool provides the score interpretation in terms of risk of hemorrhage and symptomatic ICH."
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Total score",
+            "description": "Sum of the individual scores with a range of 0 to 5"
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Total score",
+            "description": "Sum of the individual scores with a range of 0 to 5"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Risk of any Hemorrhage",
+            "description": "Risk of any Hemorrhage"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Risk of symptomatic ICH",
+            "description": "Risk of symptomatic ICH"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Risk of Fatal Hemorrhage",
+            "description": "Risk of Fatal Hemorrhage"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Interpretation for score 0"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Interpretation for score 1"
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "Interpretation for score 2"
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "Interpretation for score 3"
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "Interpretation for score > 3"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "score"
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/HAT_Score_Assessment.v1.test.yml
+++ b/gdl2/HAT_Score_Assessment.v1.test.yml
@@ -1,0 +1,48 @@
+guidelines:
+  1: HAT_Score_Assessment.v1
+test_cases:
+- id: 4
+  input:
+    1:
+      gt0006|Total score: 4
+  expected_output:
+    1:
+      gt0007|Risk of any Hemorrhage: 4|local::at0007|44%|
+      gt0009|Risk of Fatal Hemorrhage: 4|local::at0019|33%|
+      gt0008|Risk of symptomatic ICH: 4|local::at0013|78%|
+- id: 3
+  input:
+    1:
+      gt0006|Total score: 3
+  expected_output:
+    1:
+      gt0007|Risk of any Hemorrhage: 3|local::at0006|15%|
+      gt0009|Risk of Fatal Hemorrhage: 3|local::at0018|6%|
+      gt0008|Risk of symptomatic ICH: 3|local::at0012|36%|
+- id: 2
+  input:
+    1:
+      gt0006|Total score: 2
+  expected_output:
+    1:
+      gt0007|Risk of any Hemorrhage: 2|local::at0005|10%|
+      gt0009|Risk of Fatal Hemorrhage: 2|local::at0017|7%|
+      gt0008|Risk of symptomatic ICH: 2|local::at0011|23%|
+- id: 1
+  input:
+    1:
+      gt0006|Total score: 1
+  expected_output:
+    1:
+      gt0007|Risk of any Hemorrhage: 1|local::at0004|5%|
+      gt0009|Risk of Fatal Hemorrhage: 1|local::at0016|3%|
+      gt0008|Risk of symptomatic ICH: 1|local::at0010|16%|
+- id: 0
+  input:
+    1:
+      gt0006|Total score: 0
+  expected_output:
+    1:
+      gt0007|Risk of any Hemorrhage: 0|local::at0003|2%|
+      gt0009|Risk of Fatal Hemorrhage: 0|local::at0015|0%|
+      gt0008|Risk of symptomatic ICH: 0|local::at0009|6%|

--- a/gdl2/Hemorrhage After Thrombolysis Score.v1.gdl2.json
+++ b/gdl2/Hemorrhage After Thrombolysis Score.v1.gdl2.json
@@ -1,0 +1,300 @@
+{
+  "id": "Hemorrhage After Thrombolysis Score.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2017-12-05",
+      "name": "Syeeda S Farruque",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "lifecycle_state": "Author draft",
+    "details": {
+      "en": {
+        "id": "en",
+        "purpose": "HAT (Hemorrhage After Thrombolysis) Score for Predicting Post-tPA Hemorrhage provides an assessment of the risk of hemorrhage after tPA.\r\n\r\nThe tool provides a way to indentify patients that require close monitoring when treated with tPA\r\n",
+        "keywords": [
+          "HAT (Hemorrhage After Thrombolysis) Score for Predicting Post-tPA Hemorrhage"
+        ],
+        "use": "The total score is made up of the sum of the individual scores with a range of 0 to 5, which is related to 3 scored variables as shown below:\n\n- History of diabetes or initial glucose >200 mg/dL\n- Pre-tPA NIH Stroke Scale\n- Easily visible hypodensity on initial head CT\n\nScore interpretation:\nHAT Score \tRisk of Any Hemorrhage \tRisk of Symptomatic ICH \tRisk of Fatal Hemorrhage\n0 \t                                                         6% \t                                        2% \t                                       0%\n1 \t                                                       16% \t                                         5% \t                                       3%\n2 \t                                                        23% \t                                       10% \t                                       7%\n3 \t                                                        36% \t                                       15% \t                                       6%\n>3 \t                                                        78% \t                                       44% \t                                     33%",
+        "misuse": "Do not use the score on its own for diagnostic purposes without supporting evidence",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Ref. 1: Lou M, Safdar A, Selim M, et. al. The HAT Score: A simple grading scale for predicting hemorrhage after thrombolysis. Neurology. 2008; 71(18): 1417–1423. doi: 10.1212/01.wnl.0000330297.58334.dd"
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0002": {
+        "id": "gt0002",
+        "model_id": "openEHR-EHR-OBSERVATION.nihss.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.nihss.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0005": {
+            "id": "gt0005",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0021]"
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0003": {
+        "id": "gt0003",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test_glucose.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test_glucose.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0004": {
+            "id": "gt0004",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078]"
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0008": {
+        "id": "gt0008",
+        "model_id": "openEHR-EHR-OBSERVATION.haemorrhage_after_thrombolysis_score.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.haemorrhage_after_thrombolysis_score.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0009": {
+            "id": "gt0009",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0004]"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0006]"
+          },
+          "gt0026": {
+            "id": "gt0026",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0011": {
+        "id": "gt0011",
+        "model_id": "openEHR-EHR-OBSERVATION.haemorrhage_after_thrombolysis_score.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.haemorrhage_after_thrombolysis_score.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0012": {
+            "id": "gt0012",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0004]"
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0005]"
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0006]"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0007]"
+          }
+        }
+      }
+    },
+    "rules": {
+      "gt0017": {
+        "id": "gt0017",
+        "priority": 7,
+        "when": [
+          "((($gt0009|History of diabetes|==1|local::at0015|Yes|)&&($gt0004|Initial Glucose|==null))||(($gt0004|Initial Glucose|>200,mg/dl)&&($gt0009|History of diabetes|==null)))||(($gt0009|History of diabetes|==1|local::at0015|Yes|)&&($gt0004|Initial Glucose|>200,mg/dl))"
+        ],
+        "then": [
+          "$gt0012|History of diabetes or initial glucose > 200 mg/dL score|=1|local::at0015|Yes|"
+        ]
+      },
+      "gt0018": {
+        "id": "gt0018",
+        "priority": 6,
+        "when": [
+          "(($gt0009|History of diabetes|==0|local::at0014|No|)&&($gt0004|Initial Glucose|<=200,mg/dl))||((($gt0009|History of diabetes|==0|local::at0014|No|)&&($gt0004|Initial Glucose|==null))||(($gt0004|Initial Glucose|<=200,mg/dl)&&($gt0009|History of diabetes|==null)))"
+        ],
+        "then": [
+          "$gt0012|History of diabetes or initial glucose > 200 mg/dL score|=0|local::at0014|No|"
+        ]
+      },
+      "gt0019": {
+        "id": "gt0019",
+        "priority": 5,
+        "when": [
+          "$gt0005|NIHSS score|<15"
+        ],
+        "then": [
+          "$gt0013|Pre-tPA NIH Stroke Scale|=0|local::at0011|< 15|"
+        ]
+      },
+      "gt0020": {
+        "id": "gt0020",
+        "priority": 4,
+        "when": [
+          "$gt0005|NIHSS score|<=20",
+          "$gt0005|NIHSS score|>=15"
+        ],
+        "then": [
+          "$gt0013|Pre-tPA NIH Stroke Scale|=1|local::at0012|15-20|"
+        ]
+      },
+      "gt0021": {
+        "id": "gt0021",
+        "priority": 3,
+        "when": [
+          "$gt0005|NIHSS score|>=20"
+        ],
+        "then": [
+          "$gt0013|Pre-tPA NIH Stroke Scale|=2|local::at0013|>= 20|"
+        ]
+      },
+      "gt0022": {
+        "id": "gt0022",
+        "priority": 2,
+        "when": [
+          "$gt0010|Easily visible hypodensity on initial head CT|!=null"
+        ],
+        "then": [
+          "$gt0014|Easily visible hypodensity on initial head CT|=$gt0010|Easily visible hypodensity on initial head CT|"
+        ]
+      },
+      "gt0023": {
+        "id": "gt0023",
+        "priority": 1,
+        "then": [
+          "$gt0015|Total score|.magnitude=($gt0012.value+$gt0013.value)+$gt0014.value"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Haemorrhage after thrombolysis score",
+            "description": "HAT (Hemorrhage After Thrombolysis) Score for Predicting Post-tPA Hemorrhage provides an assessment of the risk of hemorrhage after tPA."
+          },
+          "gt0004": {
+            "id": "gt0004",
+            "text": "Initial Glucose",
+            "description": "The result of the test."
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "NIHSS score",
+            "description": "Sum of all factors."
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "History of diabetes",
+            "description": "History of diabetes or initial glucose >200 mg/dL (The latter is calculated directly from the glucose level."
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "History of diabetes",
+            "description": "History of diabetes or initial glucose >200 mg/dL (The latter is calculated directly from the glucose level."
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Easily visible hypodensity on initial head CT",
+            "description": "Easily visible hypodensity on initial head CT"
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "History of diabetes or initial glucose > 200 mg/dL score",
+            "description": "History of diabetes or initial glucose >200 mg/dL (The latter is calculated directly from the glucose level."
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "Pre-tPA NIH Stroke Scale",
+            "description": "Pre-tPA NIH Stroke Scale"
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "Easily visible hypodensity on initial head CT",
+            "description": "Easily visible hypodensity on initial head CT"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "Total score",
+            "description": "Sum of the individual scores with a range of 0 to 5"
+          },
+          "gt0016": {
+            "id": "gt0016"
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "text": "Set History of Diabetes or >200 mg/dL"
+          },
+          "gt0018": {
+            "id": "gt0018",
+            "text": "Set No History of Diabetes or <= 200 mg/dL"
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "text": "Set Pre-tPA NIHSS score 0"
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "Set Pre-tPA NIHSS score 1"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "text": "Set Pre-tPA NIHSS score 2"
+          },
+          "gt0022": {
+            "id": "gt0022",
+            "text": "Set Easily visible hypodensity on initial head CT"
+          },
+          "gt0023": {
+            "id": "gt0023",
+            "text": "Calculate Total Score"
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0026": {
+            "id": "gt0026",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0027": {
+            "id": "gt0027",
+            "text": "new rule"
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/Hemorrhage After Thrombolysis Score.v1.gdl2.json
+++ b/gdl2/Hemorrhage After Thrombolysis Score.v1.gdl2.json
@@ -122,7 +122,7 @@
         "id": "gt0017",
         "priority": 7,
         "when": [
-          "((($gt0009|History of diabetes|==1|local::at0015|Yes|)&&($gt0004|Initial Glucose|==null))||(($gt0004|Initial Glucose|>200,mg/dl)&&($gt0009|History of diabetes|==null)))||(($gt0009|History of diabetes|==1|local::at0015|Yes|)&&($gt0004|Initial Glucose|>200,mg/dl))"
+          "($gt0009|History of diabetes|==1|local::at0015|Yes|)||($gt0004|Initial Glucose|>200,mg/dl)"
         ],
         "then": [
           "$gt0012|History of diabetes or initial glucose > 200 mg/dL score|=1|local::at0015|Yes|"

--- a/gdl2/Hemorrhage After Thrombolysis Score.v1.test.yml
+++ b/gdl2/Hemorrhage After Thrombolysis Score.v1.test.yml
@@ -1,0 +1,128 @@
+guidelines:
+  1: Hemorrhage After Thrombolysis Score.v1
+test_cases:
+- id: Least damage
+  input:
+    1:
+      gt0005|NIHSS score: 13
+      gt0024|Event time: 2019-03-27T21:43Z
+      gt0004|Initial Glucose: 150,mg/dl
+      gt0025|Event time: 2019-03-19T21:43Z
+      gt0009|History of diabetes: 0|local::at0014|No|
+      gt0010|Easily visible hypodensity on initial head CT: 0|local::at0009|No|
+      gt0026|Event time: 2019-03-26T21:43Z
+  expected_output:
+    1:
+      gt0013|Pre-tPA NIH Stroke Scale: 0|local::at0011|< 15|
+      gt0015|Total score: 0
+      gt0012|History of diabetes or initial glucose > 200 mg/dL score: 0|local::at0014|No|
+      gt0014|Easily visible hypodensity on initial head CT: 0|local::at0009|No|
+- id: Diabetic no glucose info
+  input:
+    1:
+      gt0005|NIHSS score: 12
+      gt0024|Event time: 2019-03-26T21:54Z
+      gt0009|History of diabetes: 1|local::at0015|Yes|
+      gt0010|Easily visible hypodensity on initial head CT: 0|local::at0009|No|
+      gt0026|Event time: 2019-03-31T21:55Z
+  expected_output:
+    1:
+      gt0013|Pre-tPA NIH Stroke Scale: 0|local::at0011|< 15|
+      gt0015|Total score: 1
+      gt0012|History of diabetes or initial glucose > 200 mg/dL score: 1|local::at0015|Yes|
+      gt0014|Easily visible hypodensity on initial head CT: 0|local::at0009|No|
+- id: Diabetic normal glucose
+  input:
+    1:
+      gt0005|NIHSS score: 12
+      gt0024|Event time: 2019-03-26T21:54Z
+      gt0004|Initial Glucose: 120,mg/dl
+      gt0025|Event time: 2019-03-24T22:00Z
+      gt0009|History of diabetes: 1|local::at0015|Yes|
+      gt0010|Easily visible hypodensity on initial head CT: 0|local::at0009|No|
+      gt0026|Event time: 2019-03-31T21:55Z
+  expected_output:
+    1:
+      gt0013|Pre-tPA NIH Stroke Scale: 0|local::at0011|< 15|
+      gt0015|Total score: 1
+      gt0012|History of diabetes or initial glucose > 200 mg/dL score: 1|local::at0015|Yes|
+      gt0014|Easily visible hypodensity on initial head CT: 0|local::at0009|No|
+- id: Diabetic high glucose
+  input:
+    1:
+      gt0005|NIHSS score: 12
+      gt0024|Event time: 2019-03-26T21:54Z
+      gt0004|Initial Glucose: 220,mg/dl
+      gt0025|Event time: 2019-03-24T22:00Z
+      gt0009|History of diabetes: 1|local::at0015|Yes|
+      gt0010|Easily visible hypodensity on initial head CT: 0|local::at0009|No|
+      gt0026|Event time: 2019-03-31T21:55Z
+  expected_output:
+    1:
+      gt0013|Pre-tPA NIH Stroke Scale: 0|local::at0011|< 15|
+      gt0015|Total score: 1
+      gt0012|History of diabetes or initial glucose > 200 mg/dL score: 1|local::at0015|Yes|
+      gt0014|Easily visible hypodensity on initial head CT: 0|local::at0009|No|
+- id: Moderate NIHSS and hypodensity
+  input:
+    1:
+      gt0005|NIHSS score: 16
+      gt0024|Event time: 2019-03-25T22:07Z
+      gt0004|Initial Glucose: 220,mg/dl
+      gt0025|Event time: 2019-03-31T22:07Z
+      gt0009|History of diabetes: 1|local::at0015|Yes|
+      gt0010|Easily visible hypodensity on initial head CT: 1|local::at0010|Yes, <1/3 of MCA territory|
+      gt0026|Event time: 2019-03-31T22:08Z
+  expected_output:
+    1:
+      gt0013|Pre-tPA NIH Stroke Scale: 1|local::at0012|15-20|
+      gt0015|Total score: 3
+      gt0012|History of diabetes or initial glucose > 200 mg/dL score: 1|local::at0015|Yes|
+      gt0014|Easily visible hypodensity on initial head CT: 1|local::at0010|Yes, <1/3 of MCA territory|
+- id: Maximal score
+  input:
+    1:
+      gt0005|NIHSS score: 21
+      gt0024|Event time: 2019-03-25T22:07Z
+      gt0004|Initial Glucose: 220,mg/dl
+      gt0025|Event time: 2019-03-31T22:07Z
+      gt0009|History of diabetes: 1|local::at0015|Yes|
+      gt0010|Easily visible hypodensity on initial head CT: 2|local::at0016|Yes, ≥1/3 of MCA territory|
+      gt0026|Event time: 2019-03-31T22:08Z
+  expected_output:
+    1:
+      gt0013|Pre-tPA NIH Stroke Scale: 2|local::at0013|>= 20|
+      gt0015|Total score: 5
+      gt0012|History of diabetes or initial glucose > 200 mg/dL score: 1|local::at0015|Yes|
+      gt0014|Easily visible hypodensity on initial head CT: 2|local::at0016|Yes, ≥1/3 of MCA territory|
+- id: High glucose no diabetic info
+  input:
+    1:
+      gt0005|NIHSS score: 12
+      gt0024|Event time: 2019-03-26T21:54Z
+      gt0004|Initial Glucose: 220,mg/dl
+      gt0025|Event time: 2019-03-24T22:00Z
+      gt0010|Easily visible hypodensity on initial head CT: 0|local::at0009|No|
+      gt0026|Event time: 2019-03-31T21:55Z
+  expected_output:
+    1:
+      gt0013|Pre-tPA NIH Stroke Scale: 0|local::at0011|< 15|
+      gt0015|Total score: 1
+      gt0012|History of diabetes or initial glucose > 200 mg/dL score: 1|local::at0015|Yes|
+      gt0014|Easily visible hypodensity on initial head CT: 0|local::at0009|No|
+- id: High glucose no diabetes diagnosed before
+  input:
+    1:
+      gt0005|NIHSS score: 13
+      gt0024|Event time: 2019-03-25T22:07Z
+      gt0004|Initial Glucose: 220,mg/dl
+      gt0025|Event time: 2019-03-31T22:07Z
+      gt0009|History of diabetes: 0|local::at0014|No|
+      gt0010|Easily visible hypodensity on initial head CT: 0|local::at0009|No|
+      gt0026|Event time: 2019-03-31T22:08Z
+  expected_output:
+    1:
+      gt0013|Pre-tPA NIH Stroke Scale: 0|local::at0011|< 15|
+      gt0015|Total score: 1
+      gt0012|History of diabetes or initial glucose > 200 mg/dL score: 1|local::at0015|Yes|
+      gt0014|Easily visible hypodensity on initial head CT: 0|local::at0009|No|


### PR DESCRIPTION
HAT score migrated, rules works as in the earlier version, but I think they are/were not correct (see below).
Changes: Event time, output->input, instead of Null_Value Comparision Element Existance is used).
Note: If glucose level is high but patient was not diagnosed with diabetes, guideline gives wrong results, it should give 1 point for this part, increasing the total score with this 1 point: See also last test case.