### PR TITLE
Migration of Manchester guidelines and test fixtures

### DIFF
--- a/gdl2/Manchester_Score_SCC_lung.v1.gdl2.json
+++ b/gdl2/Manchester_Score_SCC_lung.v1.gdl2.json
@@ -1,0 +1,578 @@
+{
+  "id": "Manchester_Score_SCC_lung.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2017-08-17",
+      "name": "Syeeda S Farruque",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "other_contributors": [
+      "Dennis Forslund, Cambio Healthcare Systems"
+    ],
+    "lifecycle_state": "Author draft",
+    "details": {
+      "sv": {
+        "id": "sv",
+        "purpose": "Att uppskatta prognos på två års sikt bland patienter med småcellig lungcancer.  Metoden kan användas för att följa nya behandlingsprotokoll och jämföra behandlingseffekt.",
+        "keywords": [
+          "Manchester score",
+          "lungcancer",
+          "småcellig lungcancer",
+          "onkologi"
+        ],
+        "use": "Metoden baseras på provresultat, tumörstadium och resultat av Karnofsky Performance Status Score. Dessa genererar en poängsumma om 0-6p, och resultatet tolkas enligt:\n\n2-årsöverlevnad (%)\n≤1p:16,2%                \n2-3p:  2.5%\n≥4p: 0%",
+        "misuse": "Endast avsedd att utgöra understöd till bedömning av prognos, tillsammans med annan relevant information och klinisk bedömning.",
+        "copyright": "© Cambio Healthcare Systems"
+      },
+      "en": {
+        "id": "en",
+        "purpose": "The Manchester score for prognosis in small cell lung cancer helps to provide a 2 yr prediction of small cell carcinoma of the lung.\n\nThe scoring system may help in tracking new treatment protocols and for the sake of comparing treatment efficacies.",
+        "keywords": [
+          "Manchester score for prognosis in small cell lung cancer",
+          "small cell carcinoma of lung"
+        ],
+        "use": "The score ranges from 0 to 6 with a combination of laboratory test results, one physical finding (that of extensive stage disease)  and a Karnofsky performance status score (< 60 scoring 1 point).\n\nManchester score \t Two year survival (%)\n≤1 \t             16.2\n2 - 3 \t              2.5\n≥4 \t              0",
+        "misuse": "Do not use alone for prognostic purposes without also in combination with other supporting evidence and sound clinical judgement",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Ref. 1: Cerny, T; Blair V, Anderson H et al. Pretreatment prognostic factors and scoring system in 407 small-cell lung cancer patients. International Journal of Cancer. 1987, (2): 146–149.\nValidation"
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0002": {
+        "id": "gt0002",
+        "model_id": "openEHR-EHR-OBSERVATION.manchester_score_for_prognosis_in_small_cell_lung_cancer.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.manchester_score_for_prognosis_in_small_cell_lung_cancer.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0003": {
+            "id": "gt0003",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0008]"
+          },
+          "gt0036": {
+            "id": "gt0036",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0004]"
+          },
+          "gt0037": {
+            "id": "gt0037",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0006]"
+          },
+          "gt0038": {
+            "id": "gt0038",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0004": {
+        "id": "gt0004",
+        "model_id": "openEHR-EHR-OBSERVATION.manchester_score_for_prognosis_in_small_cell_lung_cancer.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.manchester_score_for_prognosis_in_small_cell_lung_cancer.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0005": {
+            "id": "gt0005",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0004]"
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0005]"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0006]"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0007]"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0008]"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0009]"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0022]"
+          }
+        }
+      },
+      "gt0019": {
+        "id": "gt0019",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-urea_and_electrolytes.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-urea_and_electrolytes.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0020": {
+            "id": "gt0020",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.5]"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.2]"
+          },
+          "gt0039": {
+            "id": "gt0039",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0022": {
+        "id": "gt0022",
+        "model_id": "openEHR-EHR-OBSERVATION.karnofsky_performance_status_scale.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.karnofsky_performance_status_scale.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0023": {
+            "id": "gt0023",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0016]"
+          },
+          "gt0040": {
+            "id": "gt0040",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      }
+    },
+    "default_actions": [
+      "$gt0007|Serum alkaline phosphatase score|=0|local::at0014|No|",
+      "$gt0009|Extensive stage disease|=0|local::at0018|No|",
+      "$gt0005|Serum LDH score|=0|local::at0010|No|"
+    ],
+    "rules": {
+      "gt0024": {
+        "id": "gt0024",
+        "priority": 10,
+        "when": [
+          "$gt0036|Serum LDH score > upper limit of normal?|!=null"
+        ],
+        "then": [
+          "$gt0005|Serum LDH score|=$gt0036|Serum LDH score > upper limit of normal?|"
+        ]
+      },
+      "gt0026": {
+        "id": "gt0026",
+        "priority": 9,
+        "when": [
+          "$gt0020|Sodium|<132,mmol/l"
+        ],
+        "then": [
+          "$gt0006|Serum Na+ score|=1|local::at0013|Yes|"
+        ]
+      },
+      "gt0027": {
+        "id": "gt0027",
+        "priority": 8,
+        "when": [
+          "$gt0020|Sodium|>=132,mmol/l"
+        ],
+        "then": [
+          "$gt0006|Serum Na+ score|=0|local::at0012|No|"
+        ]
+      },
+      "gt0028": {
+        "id": "gt0028",
+        "priority": 7,
+        "when": [
+          "$gt0037|Serum alkaline phosphatase > 1.5x upper limit of normal?|!=null"
+        ],
+        "then": [
+          "$gt0007|Serum alkaline phosphatase score|=$gt0037|Serum alkaline phosphatase > 1.5x upper limit of normal?|"
+        ]
+      },
+      "gt0030": {
+        "id": "gt0030",
+        "priority": 6,
+        "when": [
+          "$gt0021|Bicarbonate|<24,mmol/l"
+        ],
+        "then": [
+          "$gt0008|Serum Bicarb score|=1|local::at0017|Yes|"
+        ]
+      },
+      "gt0031": {
+        "id": "gt0031",
+        "priority": 5,
+        "when": [
+          "$gt0021|Bicarbonate|>=24,mmol/l"
+        ],
+        "then": [
+          "$gt0008|Serum Bicarb score|=0|local::at0016|No|"
+        ]
+      },
+      "gt0032": {
+        "id": "gt0032",
+        "priority": 4,
+        "when": [
+          "$gt0003|Extensive stage disease|!=null"
+        ],
+        "then": [
+          "$gt0009|Extensive stage disease|=$gt0003|Extensive stage disease|"
+        ]
+      },
+      "gt0033": {
+        "id": "gt0033",
+        "priority": 3,
+        "when": [
+          "$gt0023|Karnofksy score|<60"
+        ],
+        "then": [
+          "$gt0010|Karnofsky score|=1|local::at0021|Score < 60|"
+        ]
+      },
+      "gt0034": {
+        "id": "gt0034",
+        "priority": 2,
+        "when": [
+          "$gt0023|Karnofksy score|>=60"
+        ],
+        "then": [
+          "$gt0010|Karnofsky score|=0|local::at0020|SCORE >= 60|"
+        ]
+      },
+      "gt0035": {
+        "id": "gt0035",
+        "priority": 1,
+        "then": [
+          "$gt0011|Total score|.magnitude=(((($gt0010.value+$gt0007.value)+$gt0008.value)+$gt0009.value)+$gt0005.value)+$gt0006.value"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "sv": {
+        "id": "sv",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Manchester Score för prognos vid småcellig lungcancer",
+            "description": "Manchester Score används för prognostisk värdering vid småcellig lungcancer."
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "Omfattande sjukdomsstadium",
+            "description": ""
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Serum-LDH, poäng",
+            "description": "Serum LDH > övre normalgräns"
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Serum-Na+, poäng",
+            "description": "Serum Na < 132 mmol/L"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Serum-ALP, poäng",
+            "description": "Serum-ALP > 1.5x övre normalgräns"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Serum-bikarbonat, poäng",
+            "description": "Serum bicarbonate < 24"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Omfattande sjukdomsstadium",
+            "description": ""
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Karnofsky score",
+            "description": "Karnofsky Performance Status."
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Poängsumma",
+            "description": "Summan av samtliga faktorer."
+          },
+          "gt0013": {
+            "id": "gt0013"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "LFT-ALP",
+            "description": ""
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "LFT-ALP Result",
+            "description": "Provresultat. Normalt intervall för män: 45-115 U/L"
+          },
+          "gt0018": {
+            "id": "gt0018",
+            "text": "LDH",
+            "description": ""
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "Natrium",
+            "description": ""
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "text": "Bikarbonat",
+            "description": ""
+          },
+          "gt0023": {
+            "id": "gt0023",
+            "text": "Karnofksy score",
+            "description": ""
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "text": "CDS Serum-LDH, poäng"
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "text": "CDS LDH score: nej"
+          },
+          "gt0026": {
+            "id": "gt0026",
+            "text": "CDS Na+ score: ja"
+          },
+          "gt0027": {
+            "id": "gt0027",
+            "text": "CDS Na+ score: nej"
+          },
+          "gt0028": {
+            "id": "gt0028",
+            "text": "CDS Serum-ALP, poäng"
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "text": "CDS Serum-ALP, poäng: nej"
+          },
+          "gt0030": {
+            "id": "gt0030",
+            "text": "CDS Serum-bikarbonat, poäng: ja"
+          },
+          "gt0031": {
+            "id": "gt0031",
+            "text": "CDS Serum-bikarbonat, poäng: nej"
+          },
+          "gt0032": {
+            "id": "gt0032",
+            "text": "CDS Omfattande sjukdomsstadium"
+          },
+          "gt0033": {
+            "id": "gt0033",
+            "text": "CDS Karnofsky score: ja"
+          },
+          "gt0034": {
+            "id": "gt0034",
+            "text": "CDS Karnofsky score: nej"
+          },
+          "gt0035": {
+            "id": "gt0035",
+            "text": "Beräkna poängsumma"
+          },
+          "gt0036": {
+            "id": "gt0036",
+            "text": "Serum-ALP > övre normalgräns eller normal",
+            "description": ""
+          },
+          "gt0037": {
+            "id": "gt0037",
+            "text": "Serum-ALP > 1.5x övre normalgräns eller normal",
+            "description": ""
+          },
+          "gt0038": {
+            "id": "gt0038",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0039": {
+            "id": "gt0039",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0040": {
+            "id": "gt0040",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      },
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Manchester score for small cell lung cancer",
+            "description": "The Manchester score for prognosis in small cell lung cancer helps to provide a 2 yr prediction of small cell carcinoma of the lung"
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "Extensive stage disease",
+            "description": "Extensive stage disease"
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Serum LDH score",
+            "description": "Serum LDH > upper limit of normal"
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Serum Na+ score",
+            "description": "Serum Na < 132 mmol/L"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Serum alkaline phosphatase score",
+            "description": "Serum alkaline phosphatase > 1.5x the upper limit of normal"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Serum Bicarb score",
+            "description": "Serum bicarbonate < 24"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Extensive stage disease",
+            "description": "Extensive stage disease"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Karnofsky score",
+            "description": "Karnofsky Performance Status where scores are a score < 60 scores 1 and scores >= 60 scores 0"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Total score",
+            "description": "Sum of the individual scores"
+          },
+          "gt0013": {
+            "id": "gt0013"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "LFT-ALP",
+            "description": "Liver function test component. Alkaline phosphatase (ALP) blood test."
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "LFT-ALP Result",
+            "description": "The result of the test. Normal range for men: 45 to 115 U/L"
+          },
+          "gt0018": {
+            "id": "gt0018",
+            "text": "LDH",
+            "description": "The LDH concentration value in Units/L"
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "Sodium",
+            "description": "Sodium level in this specimen."
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "text": "Bicarbonate",
+            "description": "Bicarbonate level in this specimen."
+          },
+          "gt0023": {
+            "id": "gt0023",
+            "text": "Karnofksy score",
+            "description": "Final score"
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "text": "Set LDH score"
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "text": "Set LDH score: No"
+          },
+          "gt0026": {
+            "id": "gt0026",
+            "text": "Set Na+ score: Yes"
+          },
+          "gt0027": {
+            "id": "gt0027",
+            "text": "Set Na+ score: No"
+          },
+          "gt0028": {
+            "id": "gt0028",
+            "text": "Set ALP score"
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "text": "Set ALP score: No"
+          },
+          "gt0030": {
+            "id": "gt0030",
+            "text": "Set HCO3 score: Yes"
+          },
+          "gt0031": {
+            "id": "gt0031",
+            "text": "Set HCO3 score: No"
+          },
+          "gt0032": {
+            "id": "gt0032",
+            "text": "Set Extensive stage disease"
+          },
+          "gt0033": {
+            "id": "gt0033",
+            "text": "Set Karnofsky score: Yes"
+          },
+          "gt0034": {
+            "id": "gt0034",
+            "text": "Set Karnofsky score: No"
+          },
+          "gt0035": {
+            "id": "gt0035",
+            "text": "Calculate Total Score"
+          },
+          "gt0036": {
+            "id": "gt0036",
+            "text": "Serum LDH score > upper limit of normal?",
+            "description": "Serum LDH > upper limit of normal"
+          },
+          "gt0037": {
+            "id": "gt0037",
+            "text": "Serum alkaline phosphatase > 1.5x upper limit of normal?",
+            "description": "Serum alkaline phosphatase > 1.5x the upper limit of normal"
+          },
+          "gt0038": {
+            "id": "gt0038",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0039": {
+            "id": "gt0039",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0040": {
+            "id": "gt0040",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/Manchester_Score_SCC_lung.v1.test.yml
+++ b/gdl2/Manchester_Score_SCC_lung.v1.test.yml
@@ -1,0 +1,70 @@
+guidelines:
+  1: Manchester_Score_SCC_lung.v1
+test_cases:
+
+- id: case_1:Max score= 6 -  2 year survival 16.2%
+  input:
+    1:
+      gt0003|Extensive stage disease: 1|local::at0019|Yes|
+      gt0036|Serum LDH score > upper limit of normal?: 1|local::at0011|Yes|
+      gt0037|Serum alkaline phosphatase > 1.5x upper limit of normal?: 1|local::at0015|Yes|
+      gt0038|Event time: 2019-04-10T09:26Z
+      gt0020|Sodium: 125,mmol/l
+      gt0021|Bicarbonate: 20,mmol/l
+      gt0039|Event time: 2019-04-10T09:27Z
+      gt0023|Karnofksy score: 50
+      gt0040|Event time: 2019-04-10T09:27Z
+  expected_output:
+    1:
+      gt0005|Serum LDH score: 1|local::at0011|Yes|
+      gt0008|Serum Bicarb score: 1|local::at0017|Yes|
+      gt0011|Total score: 6
+      gt0010|Karnofsky score: 1|local::at0021|Score < 60|
+      gt0006|Serum Na+ score: 1|local::at0013|Yes|
+      gt0007|Serum alkaline phosphatase score: 1|local::at0015|Yes|
+      gt0009|Extensive stage disease: 1|local::at0019|Yes|
+
+- id: case_2:Min score = 0 -  2 year survival 0%
+  input:
+    1:
+      gt0003|Extensive stage disease: 0|local::at0018|No|
+      gt0036|Serum LDH score > upper limit of normal?: 0|local::at0010|No|
+      gt0037|Serum alkaline phosphatase > 1.5x upper limit of normal?: 0|local::at0014|No|
+      gt0038|Event time: 2019-04-10T09:26Z
+      gt0020|Sodium: 135,mmol/l
+      gt0021|Bicarbonate: 25,mmol/l
+      gt0039|Event time: 2019-04-10T09:27Z
+      gt0023|Karnofksy score: 65
+      gt0040|Event time: 2019-04-10T09:27Z
+  expected_output:
+    1:
+      gt0005|Serum LDH score: 0|local::at0010|No|
+      gt0008|Serum Bicarb score: 0|local::at0016|No|
+      gt0011|Total score: 0
+      gt0010|Karnofsky score: 0|local::at0020|SCORE >= 60|
+      gt0006|Serum Na+ score: 0|local::at0012|No|
+      gt0007|Serum alkaline phosphatase score: 0|local::at0014|No|
+      gt0009|Extensive stage disease: 0|local::at0018|No|
+
+- id: case_3:score = 3 -  2 year survival 2.5%
+  input:
+    1:
+      gt0003|Extensive stage disease: 1|local::at0019|Yes|
+      gt0036|Serum LDH score > upper limit of normal?: 1|local::at0011|Yes|
+      gt0037|Serum alkaline phosphatase > 1.5x upper limit of normal?: 1|local::at0015|Yes|
+      gt0038|Event time: 2019-04-10T09:26Z
+      gt0020|Sodium: 135,mmol/l
+      gt0021|Bicarbonate: 25,mmol/l
+      gt0039|Event time: 2019-04-10T09:27Z
+      gt0023|Karnofksy score: 65
+      gt0040|Event time: 2019-04-10T09:27Z
+  expected_output:
+    1:
+      gt0005|Serum LDH score: 1|local::at0011|Yes|
+      gt0008|Serum Bicarb score: 0|local::at0016|No|
+      gt0011|Total score: 3
+      gt0010|Karnofsky score: 0|local::at0020|SCORE >= 60|
+      gt0006|Serum Na+ score: 0|local::at0012|No|
+      gt0007|Serum alkaline phosphatase score: 1|local::at0015|Yes|
+      gt0009|Extensive stage disease: 1|local::at0019|Yes|
+

--- a/gdl2/Manchester_score_assessment.v1.gdl2.json
+++ b/gdl2/Manchester_score_assessment.v1.gdl2.json
@@ -1,0 +1,183 @@
+{
+  "id": "Manchester_score_assessment.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2017-08-19",
+      "name": "Syeeda S Farruque",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "other_contributors": [
+      "Dennis Forslund, Cambio Healthcare Systems"
+    ],
+    "lifecycle_state": "Author draft",
+    "details": {
+      "sv": {
+        "id": "sv",
+        "purpose": "Att uppskatta prognos på två års sikt bland patienter med småcellig lungcancer.  Metoden kan användas för att följa nya behandlingsprotokoll och jämföra behandlingseffekt.",
+        "keywords": [
+          "Manchester score",
+          "sm�cellig lungcancer",
+          "lungcancer",
+          "onkologi"
+        ],
+        "use": "Metoden baseras på provresultat, tumörstadium och resultat av Karnofsky Performance Status Score. Dessa genererar en poängsumma om 0-6p, och resultatet tolkas enligt:\n\n2-årsöverlevnad (%)\n=1p:16,2%                \n2-3p:  2.5%\n=4p: 0%",
+        "misuse": "Endast avsedd att utgöra understöd till bedömning av prognos, tillsammans med annan relevant information och klinisk bedömning.",
+        "copyright": "� Cambio Healthcare Systems"
+      },
+      "en": {
+        "id": "en",
+        "purpose": "The Manchester score for prognosis in small cell lung cancer helps to provide a 2 yr prediction of small cell carcinoma of the lung. This archetype holds the score and allows interpretation in order to ascertain the prognostic group and 2 year survival of patients with SCC (Small Cell Carcinoma) of the lung",
+        "keywords": [
+          "Manchester score for prognosis in small cell lung",
+          "small cell lung carcinoma"
+        ],
+        "use": "The score ranges from 0 to 6 with a combination of laboratory test results, one physical finding (that of extensive stage disease)  and a Karnofsky performance status score (< 60 scoring 1 point).\n\nManchester score \t Two year survival (%)\n=1 \t             16.2\n2 - 3 \t              2.5\n=4 \t              0",
+        "misuse": "Do not use alone for prognostic purposes or without also in combination with other supporting evidence and sound clinical judgement",
+        "copyright": "� Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Ref. 1: Cerny, T; Blair V, Anderson H et al. Pretreatment prognostic factors and scoring system in 407 small-cell lung cancer patients. International Journal of Cancer. 1987, (2): 146-149."
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0002": {
+        "id": "gt0002",
+        "model_id": "openEHR-EHR-EVALUATION.manchester_score_assessment.v1",
+        "template_id": "openEHR-EHR-EVALUATION.manchester_score_assessment.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0005": {
+            "id": "gt0005",
+            "path": "/data[at0001]/items[at0003]"
+          }
+        }
+      },
+      "gt0003": {
+        "id": "gt0003",
+        "model_id": "openEHR-EHR-OBSERVATION.manchester_score_for_prognosis_in_small_cell_lung_cancer.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.manchester_score_for_prognosis_in_small_cell_lung_cancer.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0004": {
+            "id": "gt0004",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0022]"
+          }
+        }
+      }
+    },
+    "rules": {
+      "gt0007": {
+        "id": "gt0007",
+        "priority": 3,
+        "when": [
+          "$gt0004|Total score|<=1"
+        ],
+        "then": [
+          "$gt0005|2-year survival|=0|local::at0007|16.2%|"
+        ]
+      },
+      "gt0008": {
+        "id": "gt0008",
+        "priority": 2,
+        "when": [
+          "($gt0004|Total score|==2)||($gt0004|Total score|==3)"
+        ],
+        "then": [
+          "$gt0005|2-year survival|=1|local::at0008|2.5%|"
+        ]
+      },
+      "gt0009": {
+        "id": "gt0009",
+        "priority": 1,
+        "when": [
+          "$gt0004|Total score|>=4"
+        ],
+        "then": [
+          "$gt0005|2-year survival|=2|local::at0009|0%|"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "sv": {
+        "id": "sv",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Manchester Score - utvärdering",
+            "description": "Utvärdering av poäng genererad i enlighet med Manchester Score, vilken används för prognostisk värdering vid småcellig lungcancer."
+          },
+          "gt0004": {
+            "id": "gt0004",
+            "text": "Po�ngsumma",
+            "description": ""
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "2-�rs�verlevnad",
+            "description": ""
+          },
+          "gt0006": {
+            "id": "gt0006"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "CDS 16,2%"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "CDS 2,5%"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "CDS 0%"
+          }
+        }
+      },
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Manchester score assessment",
+            "description": "The Manchester score for prognosis in small cell lung cancer helps to provide a 2 yr prediction of small cell carcinoma of the lung"
+          },
+          "gt0004": {
+            "id": "gt0004",
+            "text": "Total score",
+            "description": "Sum of the individual scores"
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "2-year survival",
+            "description": "2 Year Survival"
+          },
+          "gt0006": {
+            "id": "gt0006"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "CDS 16,2%"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "CDS 2,5%"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "CDS 0%"
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/Manchester_score_assessment.v1.test.yml
+++ b/gdl2/Manchester_score_assessment.v1.test.yml
@@ -1,0 +1,26 @@
+guidelines:
+  1: Manchester_score_assessment.v1
+test_cases:
+- id: case_1:2 year survival 16.2%
+  input:
+    1:
+      gt0004|Total score: 1
+  expected_output:
+    1:
+      gt0005|2-year survival: 0|local::at0007|16.2%|
+
+- id: case_2:2 year survival 2.5% 
+  input:
+    1:
+      gt0004|Total score: 2
+  expected_output:
+    1:
+      gt0005|2-year survival: 1|local::at0008|2.5%|
+
+- id: case_3:2 year survival 0% 
+  input:
+    1:
+      gt0004|Total score: 5
+  expected_output:
+    1:
+      gt0005|2-year survival: 2|local::at0009|0%|


### PR DESCRIPTION
Manchester_Score_SCC_lung.v1 with test fixture
and 
Manchester_Score_assessment.v1 with test fixture.
 ".magnitude" had to be removed. Rule 2 did not fire, so I had to make some adjustments with the test fixture to solve that problem.  

/Linda 