### PR TITLE
Migrated DAS-28 ESR Calculation

### DIFF
--- a/gdl2/DAS28-ESR_Calculation.v1.gdl2.json
+++ b/gdl2/DAS28-ESR_Calculation.v1.gdl2.json
@@ -1,0 +1,268 @@
+{
+  "id": "DAS28-ESR_Calculation.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2016-11-07",
+      "name": "Eneimi Allwell-Brown",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "other_contributors": [
+      "Dennis Forslund",
+      "Jimmy Axelsson"
+    ],
+    "lifecycle_state": "Author draft",
+    "details": {
+      "sv": {
+        "id": "sv",
+        "purpose": "Denna modell beräknar värdet av DAS28-ESR vilket kan användas som mått på sjukdomsaktivitet och behandlingseffekt hos patienter med reumatoid artrit.",
+        "keywords": [
+          "reumatoid artrit",
+          "PtGDA",
+          "RA",
+          "DAS28",
+          "DAS28-ESR"
+        ],
+        "use": "Använd för att beräkna värdet av DAS28-ESR baserat på fyra parametrar: antal ömma (TJC) och svullna (SJC) leder, sjukdomskänsla enligt VAS (PtGDA - Patient Global Assessment of Disease Activity), provresultat för sänkningsreaktion (SR/ESR - angivet i mm/h). Dessa parametrar återfinns samtliga i separata arketyper. (PtGDA anges i \\\"mm\\\")\n\n\nFormel: DAS28-ESR = (0.56*√(TJC)+0.28*√(SJC)+0.7*ln(ESR)+0.014*(PtGDA))\n",
+        "copyright": "© Cambio Healthcare Systems"
+      },
+      "en": {
+        "id": "en",
+        "purpose": "This guide calculates the disesase activity score 28-ESR (DAS28-ESR) which is a measure of disease activity and treatment response in individuals with rheumatoid arthritis.",
+        "keywords": [
+          "rheumatoid arthritis",
+          "PaGDA",
+          "tender joint count",
+          "swollen joint count",
+          "DAS28-ESR"
+        ],
+        "use": "Use to calculate DAS28-ESR, based on four input parameters: tender joint count (TJC), swollen joint count (SJC), patient global assessment of disease activity (PtGDA), and erythrocyte sedimentation rate (in mm/hr). PtGDA uses the unit 'mm'.\n\nDAS28-ESR = (0.56*√(TJC)+0.28*√(SJC)+0.7*ln(ESR)+0.014*(PtGDA)). The score is calculated by a separate application: DAS28-ESR.v1\n\nThe disease is considered to be in remission if the score is between 0 and <2.6., low activity is score  2.6 to <3.2, moderate activity is 3.2 to ≤5.1, while high activity is strictly above 5.1.",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Anderson J, Caplan L, Yazdany J, Robbins ML, Neogi T, Michaud K, Saag KG, O'dell JR, Kazi S. Rheumatoid arthritis disease activity measures: American College of Rheumatology recommendations for use in clinical practice. Arthritis care & research. 2012 May 1;64(5):640-7.\n\nWells G, Becker JC, Teng J, Dougados M, Schiff M, Smolen J, Aletaha D, Van Riel PL. Validation of the 28-joint Disease Activity Score (DAS28) and European League Against Rheumatism response criteria based on C-reactive protein against disease progression in patients with rheumatoid arthritis, and comparison with the DAS28 based on erythrocyte sedimentation rate. Annals of the rheumatic diseases. 2009 Jun 1;68(6):954-60."
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0002": {
+        "id": "gt0002",
+        "model_id": "openEHR-EHR-OBSERVATION.disease_activity_score_28_esr.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.disease_activity_score_28_esr.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0003": {
+            "id": "gt0003",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0004]"
+          }
+        }
+      },
+      "gt0005": {
+        "id": "gt0005",
+        "model_id": "openEHR-EHR-OBSERVATION.disease_activity_index_joint_score.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.disease_activity_index_joint_score.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0006": {
+            "id": "gt0006",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0043]"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0044]"
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0008": {
+        "id": "gt0008",
+        "model_id": "openEHR-EHR-OBSERVATION.patient_global_assessment_arthritis_activity.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.patient_global_assessment_arthritis_activity.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0009": {
+            "id": "gt0009",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0004]"
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0010": {
+        "id": "gt0010",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-esr.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-esr.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0011": {
+            "id": "gt0011",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.1]"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      }
+    },
+    "rules": {
+      "gt0012": {
+        "id": "gt0012",
+        "priority": 1,
+        "when": [
+          "$gt0009|PtGDA score|.unit=='mm'",
+          "$gt0011|Erythrocyte sedimentation rate (ESR)|.unit=='mm/h'"
+        ],
+        "then": [
+          "$gt0003|DAS28-ESR|.unit='1'",
+          "$gt0003|DAS28-ESR|.precision=2",
+          "$gt0003|DAS28-ESR|.magnitude=(((($gt0006^0.5)*0.56)+(($gt0007^0.5)*0.28))+(0.7*log($gt0011.magnitude)))+(0.014*$gt0009)"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "sv": {
+        "id": "sv",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "DAS28-ESR för Reumatoid Artrit",
+            "description": "Disease Activity Score 28-ESR (DAS28-ESR) är ett poängsystem för utvärdering av sjukdomsaktivitet hos patienter med reumatoid artrit (RA).  Beräkningen görs i enlighet med en formel baserad på fyra parametrar: antalet ömma (0--28) och svullna (0-28) leder, sjukdomskänsla (Visuell Analog Skala 0.0-10-0 i enlighet med PtGDA - Patient Global Assessment of Disease Activity) samt provresultat för sänkningsreaktion (SR/ESR)."
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "DAS28-ESR",
+            "description": "*(en) Disease activity score 28 (ESR) is calculated from a formula that includes tender joint count (TJC), swollen joint count (SJC), patient assessment of global disease activity (PtGDA) and erythrocyte sedimentation rate (ESR)."
+          },
+          "gt0004": {
+            "id": "gt0004",
+            "text": "Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Ömma leder (TJC)",
+            "description": "*(en) Total number of tender joints of the possible 28 (on the left side and right side)."
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Svullna leder (SJC)",
+            "description": "*(en) Total number of swollen joints of the possible 28 (on the left side and right side)."
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "PtGDA poäng",
+            "description": "*(en) Considering all the ways arthritis affects you, how well are you doing? (0.0 = very well; 100.0 = very poor)"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Sänkningsreaktion (SR/ESR)",
+            "description": "*(en) The velocity of sedimentation of red cells in the first hour."
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "Beräkna DAS28-ESR",
+            "description": "*(en) Contains the application logic for calculating DAS28-ESR."
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      },
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "DAS28-ESR Calculator for Rheumatoid Arthritis",
+            "description": "Disease activity score 28-ESR (DAS28-ESR) is a calculated score for assessing disease activity in individuals with rheumatoid arthritis (RA). It is calculated from a formula using four parameters: the number of tender (0 - 28) and swollen (0 - 28) joints the patient has, the visual analogue scale score (0 - 100) for patient global assessment of the level of disease activity [0.0 = low disease activity/patient doing very well; 100.0 = high disease activity/patient doing very poor], and the patient's erythrocyte sedimentation rate (ESR).The 28 joints assessed are the left and right shoulder, elbow, wrist, metacarpophalangeal, proximal interphalangeal and knee.\nDAS28-ESR is a very strong predictor of disability and radiological progression in RA. A score <2.6 is regarded as RA in remission; 2.6 to <3.2 is low disease activity, 3.2 to <=5.1 is moderate disease activity while >5.1 is high disease activity."
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "DAS28-ESR",
+            "description": "Disease activity score 28 (ESR) is calculated from a formula that includes tender joint count (TJC), swollen joint count (SJC), patient assessment of global disease activity (PtGDA) and erythrocyte sedimentation rate (ESR)."
+          },
+          "gt0004": {
+            "id": "gt0004",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Tender joint count (TJC)",
+            "description": "Total number of tender joints of the possible 28 (on the left side and right side)."
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Swollen joint count (SJC)",
+            "description": "Total number of swollen joints of the possible 28 (on the left side and right side)."
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "PtGDA score",
+            "description": "Considering all the ways arthritis affects you, how well are you doing? (0.0 = very well; 100.0 = very poor)"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Erythrocyte sedimentation rate (ESR)",
+            "description": "The velocity of sedimentation of red cells in the first hour."
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "Calculate DAS28-ESR",
+            "description": "Contains the application logic for calculating DAS28-ESR."
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/DAS28-ESR_Calculation.v1.test.yml
+++ b/gdl2/DAS28-ESR_Calculation.v1.test.yml
@@ -1,0 +1,90 @@
+guidelines:
+  1: DAS28-ESR_Calculation.v1
+test_cases:
+- id: TJC(0)-SJC(0)-PtGDA(0)-ESR(0)
+  input:
+    1:
+      gt0006|Tender joint count (TJC): 0
+      gt0007|Swollen joint count (SJC): 0
+      gt0013|Event time: 2019-04-30T13:01Z
+      gt0009|PtGDA score: 0,mm
+      gt0014|Event time: 2019-04-30T13:01Z
+      gt0011|Erythrocyte sedimentation rate (ESR): 0,mm/h
+      gt0015|Event time: 2019-04-30T13:02Z
+  expected_output:
+    1:
+      gt0003|DAS28-ESR: -∞,1
+
+
+- id: TJC(1)-SJC(1)-PtGDA(1)-ESR(1)
+  input:
+    1:
+      gt0006|Tender joint count (TJC): 1
+      gt0007|Swollen joint count (SJC): 1
+      gt0013|Event time: 2019-04-30T13:01Z
+      gt0009|PtGDA score: 1,mm
+      gt0014|Event time: 2019-04-30T13:01Z
+      gt0011|Erythrocyte sedimentation rate (ESR): 1,mm/h
+      gt0015|Event time: 2019-04-30T13:02Z
+  expected_output:
+    1:
+      gt0003|DAS28-ESR: 0.85,1
+
+- id: TJC(2)-SJC(2)-PtGDA(10)-ESR(10)
+  input:
+    1:
+      gt0006|Tender joint count (TJC): 2
+      gt0007|Swollen joint count (SJC): 2
+      gt0013|Event time: 2019-04-30T13:01Z
+      gt0009|PtGDA score: 10,mm
+      gt0014|Event time: 2019-04-30T13:01Z
+      gt0011|Erythrocyte sedimentation rate (ESR): 10,mm/h
+      gt0015|Event time: 2019-04-30T13:02Z
+  expected_output:
+    1:
+      gt0003|DAS28-ESR: 2.94,1
+
+
+- id: TJC(2)-SJC(2)-PtGDA(20)-ESR(20)
+  input:
+    1:
+      gt0006|Tender joint count (TJC): 2
+      gt0007|Swollen joint count (SJC): 2
+      gt0013|Event time: 2019-04-30T13:01Z
+      gt0009|PtGDA score: 20,mm
+      gt0014|Event time: 2019-04-30T13:01Z
+      gt0011|Erythrocyte sedimentation rate (ESR): 20,mm/h
+      gt0015|Event time: 2019-04-30T13:02Z
+  expected_output:
+    1:
+      gt0003|DAS28-ESR: 3.56,1
+
+
+- id: TJC(2)-SJC(2)-PtGDA(30)-ESR(30)
+  input:
+    1:
+      gt0006|Tender joint count (TJC): 2
+      gt0007|Swollen joint count (SJC): 2
+      gt0013|Event time: 2019-04-30T13:01Z
+      gt0009|PtGDA score: 30,mm
+      gt0014|Event time: 2019-04-30T13:01Z
+      gt0011|Erythrocyte sedimentation rate (ESR): 30,mm/h
+      gt0015|Event time: 2019-04-30T13:02Z
+  expected_output:
+    1:
+      gt0003|DAS28-ESR: 3.99,1
+
+
+- id: TJC(2)-SJC(2)-PtGDA(30)-ESR(40)
+  input:
+    1:
+      gt0006|Tender joint count (TJC): 2
+      gt0007|Swollen joint count (SJC): 2
+      gt0013|Event time: 2019-04-30T13:01Z
+      gt0009|PtGDA score: 30,mm
+      gt0014|Event time: 2019-04-30T13:01Z
+      gt0011|Erythrocyte sedimentation rate (ESR): 40,mm/h
+      gt0015|Event time: 2019-04-30T13:02Z
+  expected_output:
+    1:
+      gt0003|DAS28-ESR: 4.19,1


### PR DESCRIPTION
Dear Isabelle, this branch contains the migrated DAS-28 ESR Calculation along with its test fixtures. The DAS-28 ESR Assessment has not yet been migrated because there's an issue with the quantity unit in the archetype. Kindly please check and review it. Thank you.