### PR TITLE
Migrated DAS-28 CRP Calculation

### DIFF
--- a/gdl2/DAS28-CRP_Calculation.v1.gdl2.json
+++ b/gdl2/DAS28-CRP_Calculation.v1.gdl2.json
@@ -1,0 +1,268 @@
+{
+  "id": "DAS28-CRP_Calculation.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2016-11-07",
+      "name": "Eneimi Allwell-Brown",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "other_contributors": [
+      "Dennis Forslund",
+      "Jimmy Axelsson"
+    ],
+    "lifecycle_state": "Author draft",
+    "details": {
+      "sv": {
+        "id": "sv",
+        "purpose": "Denna modell beräknar värdet av DAS28-CRP vilket kan användas som mått på sjukdomsaktivitet och behandlingseffekt hos patienter med reumatoid artrit.\n",
+        "keywords": [
+          "reumatoid artrit",
+          "PtGDA",
+          "RA",
+          "DAS28",
+          "DAS28-CRP"
+        ],
+        "use": "Använd för att beräkna värdet av DAS28-CRP baserat på fyra parametrar: antal ömma (TJC) och svullna (SJC) leder, sjukdomskänsla enligt VAS (PtGDA - Patient Global Assessment of Disease Activity), provresultat för CRP (angivet i mg/dl). Dessa parametrar återfinns samtliga i separata arketyper. (PtGDA anges i \\\"mm\\\")\n\nFormel: DAS28-CRP = (0.56*√(TJC)+0.28*√(SJC)+0.36*ln(CRP + 1)+0.014*PtGDA +0.96)\n",
+        "copyright": "© Cambio Healthcare Systems"
+      },
+      "en": {
+        "id": "en",
+        "purpose": "This guide calculates the disesase activity score 28-CRP (DAS28-CRP) which is a measure of disease activity and treatment response in individuals with rheumatoid arthritis.",
+        "keywords": [
+          "rheumatoid arthritis",
+          "PaGDA",
+          "tender joint count",
+          "swollen joint count",
+          "DAS28-CRP"
+        ],
+        "use": "Use to calculate DAS28-CRP, based on four input parameters: tender joint count (TJC), swollen joint count (SJC), patient global assessment of disease activity (PtGDA), and level of C-reactive protein (in mg/dl). PtGDA uses the unit 'mm'.\n\nDAS28-CRP = (0.56*√(TJC)+0.28*√(SJC)+0.36*ln(CRP + 1)+0.014*PtGDA +0.96).\n\nThe assessment of DAS28-CRP is performed by a separate application: DAS28-CRP_Assessment.v1",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Anderson J, Caplan L, Yazdany J, Robbins ML, Neogi T, Michaud K, Saag KG, O'dell JR, Kazi S. Rheumatoid arthritis disease activity measures: American College of Rheumatology recommendations for use in clinical practice. Arthritis care & research. 2012 May 1;64(5):640-7.\n\nWells G, Becker JC, Teng J, Dougados M, Schiff M, Smolen J, Aletaha D, Van Riel PL. Validation of the 28-joint Disease Activity Score (DAS28) and European League Against Rheumatism response criteria based on C-reactive protein against disease progression in patients with rheumatoid arthritis, and comparison with the DAS28 based on erythrocyte sedimentation rate. Annals of the rheumatic diseases. 2009 Jun 1;68(6):954-60."
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0003": {
+        "id": "gt0003",
+        "model_id": "openEHR-EHR-OBSERVATION.disease_activity_score_28_crp.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.disease_activity_score_28_crp.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0004": {
+            "id": "gt0004",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0004]"
+          }
+        }
+      },
+      "gt0005": {
+        "id": "gt0005",
+        "model_id": "openEHR-EHR-OBSERVATION.disease_activity_index_joint_score.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.disease_activity_index_joint_score.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0006": {
+            "id": "gt0006",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0043]"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0044]"
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0008": {
+        "id": "gt0008",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test_c_reactive_protein.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test_c_reactive_protein.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0009": {
+            "id": "gt0009",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0006]"
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0011": {
+        "id": "gt0011",
+        "model_id": "openEHR-EHR-OBSERVATION.patient_global_assessment_arthritis_activity.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.patient_global_assessment_arthritis_activity.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0012": {
+            "id": "gt0012",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0004]"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      }
+    },
+    "rules": {
+      "gt0002": {
+        "id": "gt0002",
+        "priority": 1,
+        "when": [
+          "$gt0012|PtGDA score|.unit=='mm'",
+          "$gt0009|C-reactive protein|.unit=='mg/dl'"
+        ],
+        "then": [
+          "$gt0004|DAS28-CRP|.unit='1'",
+          "$gt0004|DAS28-CRP|.precision=2",
+          "$gt0004|DAS28-CRP|.magnitude=((((($gt0006^0.5)*0.56)+(($gt0007^0.5)*0.28))+(log(($gt0009*10)+1)*0.36))+($gt0012*0.014))+0.96"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "sv": {
+        "id": "sv",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "DAS28-CRP för Reumatoid Artrit",
+            "description": "Disease Activity Score 28-CRP (DAS28-CRP) är ett poängsystem för utvärdering av sjukdomsaktivitet hos patienter med reumatoid artrit (RA).  Beräkningen görs i enlighet med en formel baserad på fyra parametrar: antalet ömma (0--28) och svullna (0-28) leder, sjukdomskänsla (Visuell Analog Skala 0.0-10-0 i enlighet med PtGDA - Patient Global Assessment of Disease Activity) samt provresultat för CRP."
+          },
+          "gt0002": {
+            "id": "gt0002",
+            "text": "Beräkna DAS28-CRP",
+            "description": "*(en) Contains the application logic for calculating DAS28-CRP."
+          },
+          "gt0004": {
+            "id": "gt0004",
+            "text": "DAS28-CRP",
+            "description": "*(en) Disease activity score 28 (CRP) is calculated from a formula that includes tender joint count (TJC), swollen joint count (SJC), patient assessment of global disease activity (PtGDA) and C-reactive protein (CRP)."
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Antal ömma leder (TJC)",
+            "description": "*(en) Total number of tender joints of the possible 28 (on the left side and right side)."
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Antal svullna leder (SJC)",
+            "description": "*(en) Total number of swollen joints of the possible 28 (on the left side and right side)."
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "C-reaktivt protein",
+            "description": "*(en) Test result - C-reactive protein"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "PtGDA poäng",
+            "description": "*(en) Considering all the ways arthritis affects you, how well are you doing? (0.0 = very well; 100.0 = very poor)"
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      },
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "DAS28-CRP Calculator for Rheumatoid Arthritis",
+            "description": "Disease activity score 28-CRP (DAS28-CRP) is a calculated score for assessing disease activity in individuals with rheumatoid arthritis (RA). It is calculated from a formula using four parameters: the number of tender (0 - 28) and swollen (0 - 28) joints the patient has, the visual analogue scale score (0 - 100) for patient global assessment of the level of disease activity [0.0 = low disease activity/patient doing very well; 100.0 = high disease activity/patient doing very poor], and the patient's circulating level of the inflammatory biomarker C-reactive protein (CRP). The 28 joints assessed are the left and right shoulder, elbow, wrist, metacarpophalangeal, proximal interphalangeal and knee.\nDAS28-CRP is a very strong predictor of disability and radiological progression in RA. A score <2.6 is regarded as RA in remission; 2.6 to <3.2 is low disease activity, 3.2 to <=5.1 is moderate disease activity while >5.1 is high disease activity."
+          },
+          "gt0002": {
+            "id": "gt0002",
+            "text": "Calculate DAS28-CRP",
+            "description": "Contains the application logic for calculating DAS28-CRP."
+          },
+          "gt0004": {
+            "id": "gt0004",
+            "text": "DAS28-CRP",
+            "description": "Disease activity score 28 (CRP) is calculated from a formula that includes tender joint count (TJC), swollen joint count (SJC), patient assessment of global disease activity (PtGDA) and C-reactive protein (CRP)."
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Tender joint count (TJC)",
+            "description": "Total number of tender joints of the possible 28 (on the left side and right side)."
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Swollen joint count (SJC)",
+            "description": "Total number of swollen joints of the possible 28 (on the left side and right side)."
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "C-reactive protein",
+            "description": "Test result - C-reactive protein"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "PtGDA score",
+            "description": "Considering all the ways arthritis affects you, how well are you doing? (0.0 = very well; 100.0 = very poor)"
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/DAS28-CRP_Calculation.v1.test.yml
+++ b/gdl2/DAS28-CRP_Calculation.v1.test.yml
@@ -1,0 +1,117 @@
+guidelines:
+  1: DAS28-CRP_Calculation.v1
+test_cases:
+- id: TJC(0)-SJC(0)-CRP(0)-PtGDA(0)
+  input:
+    1:
+      gt0006|Tender joint count (TJC): 0
+      gt0007|Swollen joint count (SJC): 0
+      gt0013|Event time: 2019-04-30T12:50Z
+      gt0009|C-reactive protein: 0,mg/dl
+      gt0014|Event time: 2019-04-30T12:50Z
+      gt0012|PtGDA score: 0,mm
+      gt0015|Event time: 2019-04-30T12:50Z
+  expected_output:
+    1:
+      gt0004|DAS28-CRP: 0.96,1
+
+- id: TJC(1)-SJC(0)-CRP(0)-PtGDA(0)
+  input:
+    1:
+      gt0006|Tender joint count (TJC): 1
+      gt0007|Swollen joint count (SJC): 0
+      gt0013|Event time: 2019-04-30T12:50Z
+      gt0009|C-reactive protein: 0,mg/dl
+      gt0014|Event time: 2019-04-30T12:50Z
+      gt0012|PtGDA score: 0,mm
+      gt0015|Event time: 2019-04-30T12:50Z
+  expected_output:
+    1:
+      gt0004|DAS28-CRP: 1.52,1
+
+- id: TJC(1)-SJC(1)-CRP(0)-PtGDA(0)
+  input:
+    1:
+      gt0006|Tender joint count (TJC): 1
+      gt0007|Swollen joint count (SJC): 1
+      gt0013|Event time: 2019-04-30T12:50Z
+      gt0009|C-reactive protein: 0,mg/dl
+      gt0014|Event time: 2019-04-30T12:50Z
+      gt0012|PtGDA score: 0,mm
+      gt0015|Event time: 2019-04-30T12:50Z
+  expected_output:
+    1:
+      gt0004|DAS28-CRP: 1.80,1
+
+- id: TJC(1)-SJC(1)-CRP(10)-PtGDA(0)
+  input:
+    1:
+      gt0006|Tender joint count (TJC): 1
+      gt0007|Swollen joint count (SJC): 1
+      gt0013|Event time: 2019-04-30T12:50Z
+      gt0009|C-reactive protein: 10,mg/dl
+      gt0014|Event time: 2019-04-30T12:50Z
+      gt0012|PtGDA score: 0,mm
+      gt0015|Event time: 2019-04-30T12:50Z
+  expected_output:
+    1:
+      gt0004|DAS28-CRP: 3.46,1
+
+
+- id: TJC(1)-SJC(1)-CRP(10)-PtGDA(10)
+  input:
+    1:
+      gt0006|Tender joint count (TJC): 1
+      gt0007|Swollen joint count (SJC): 1
+      gt0013|Event time: 2019-04-30T12:50Z
+      gt0009|C-reactive protein: 10,mg/dl
+      gt0014|Event time: 2019-04-30T12:50Z
+      gt0012|PtGDA score: 10,mm
+      gt0015|Event time: 2019-04-30T12:50Z
+  expected_output:
+    1:
+      gt0004|DAS28-CRP: 3.60,1
+
+
+- id: TJC(2)-SJC(2)-CRP(15)-PtGDA(2)
+  input:
+    1:
+      gt0006|Tender joint count (TJC): 2
+      gt0007|Swollen joint count (SJC): 2
+      gt0013|Event time: 2019-04-30T12:50Z
+      gt0009|C-reactive protein: 15,mg/dl
+      gt0014|Event time: 2019-04-30T12:50Z
+      gt0012|PtGDA score: 2,mm
+      gt0015|Event time: 2019-04-30T12:50Z
+  expected_output:
+    1:
+      gt0004|DAS28-CRP: 3.98,1
+
+- id: TJC(2)-SJC(2)-CRP(25)-PtGDA(15)
+  input:
+    1:
+      gt0006|Tender joint count (TJC): 2
+      gt0007|Swollen joint count (SJC): 2
+      gt0013|Event time: 2019-04-30T12:50Z
+      gt0009|C-reactive protein: 25,mg/dl
+      gt0014|Event time: 2019-04-30T12:50Z
+      gt0012|PtGDA score: 15,mm
+      gt0015|Event time: 2019-04-30T12:50Z
+  expected_output:
+    1:
+      gt0004|DAS28-CRP: 4.35,1
+
+- id: TJC(2)-SJC(2)-CRP(40)-PtGDA(30)
+  input:
+    1:
+      gt0006|Tender joint count (TJC): 2
+      gt0007|Swollen joint count (SJC): 2
+      gt0013|Event time: 2019-04-30T12:50Z
+      gt0009|C-reactive protein: 40,mg/dl
+      gt0014|Event time: 2019-04-30T12:50Z
+      gt0012|PtGDA score: 30,mm
+      gt0015|Event time: 2019-04-30T12:50Z
+  expected_output:
+    1:
+      gt0004|DAS28-CRP: 4.73,1
+


### PR DESCRIPTION
Dear Isabelle, this branch contains the migrated DAS-28 CRP Calculation along with its test fixtures. The DAS-28 CRP Assessment can't be migrated yet because there was an error with the archetype. Kindly please check and review it. Thank you.