### PR TITLE
ABG migrated

### DIFF
--- a/gdl2/ABG.v1.gdl2.json
+++ b/gdl2/ABG.v1.gdl2.json
@@ -1,0 +1,1110 @@
+{
+  "id": "ABG.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2016-01-13",
+      "name": "Syeeda S Farruque",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "other_contributors": [
+      "Dennis Forslund",
+      "Jimmy Axelsson"
+    ],
+    "lifecycle_state": "Not set",
+    "details": {
+      "sv": {
+        "id": "sv",
+        "purpose": "Instrumentet beräknar anjongap, korrigerat anjongap, metabol rubbning samt, om föreliggande, kompensatorisk reaktion.\r\n",
+        "keywords": [
+          "arterial blood gas analyzer",
+          "acidos",
+          "alkalos",
+          "anjongap",
+          "pH",
+          "ABG ",
+          "pH",
+          "arteriell blodgas",
+          "blodgas"
+        ],
+        "use": "Med hjälp av instrumentet bedöms patientens blodgas med avseende på eventuell förekomst av metabol eller respiratorisk acidos eller alkalos samt eventuell kompensatorisk reaktion.\r\n\r\n1 - är pH inom normalintervall?\r\n2 - är  PaCO2 inom normalintervall?\r\n3 - är HCO3 inom normalintervall?\r\n4 - information från 1-3 bearbetas\r\n5 - bedömning av PaCO2 och HCO3 \r\n\r\nNormalintervall:\r\nPH: 7.35-7.45\r\nPaCO2: 35-45mmHg (4.7-KPa)\r\nHCO3-: 22-29mmol/l\r\nNa: 135-145mmol/l\r\nCl: 95-105mmol/l",
+        "misuse": "Ej avsedd att användas isolerat utan endast för att stödja klinisk bedömning.",
+        "copyright": "© Cambio Healthcare Systems"
+      },
+      "en": {
+        "id": "en",
+        "purpose": "This tool calculates the AG (Anion gap) the corrected Anion Gap (cAG), the primary acid/base disturbance of blood PH and the compensatory - if any - reaction by utilising the various blood gas/electrolytes values found in a patient's record.\n\nIncreased Anion gap is measured in the presence of a metabolic acidosis with a corrected gap in the presence of albumin values.",
+        "keywords": [
+          "arterial blood gas analyser",
+          "acidosis",
+          "alkalosis",
+          "Anion gap"
+        ],
+        "use": "According to the US National Library of Medicine (NIH) on their MedlinePlus health information platform (3) reference ranges at sea level used are:\n\nArterial PH normal range: 7.38-7.42 PH (but with an extreme deviation in either bicarb or PaCO2 if the Ph is between above or below 7.4, even if the value is within this normal range, it will be moving in the direction of the disturbance).\n\nBicarb (HCO3-) normal range: 22-28 mmol/L\n (mEq/L)\nPaCO2: 38-42mmHg\n (5.1-5.6kPa)\nNa: 136-145mmol/L\nCl: 98-107mmol/L\nAlbumin: 40 g/L\nThe picture is also contextualised in terms of acute or chronic.\n\nTo ascertain whether the picture represents a metabolic or respiratory acidosis or alkalosis, the PH, PaCO2 and bicarbonate are looked at:\n\n1-Is the PH normal?\n2-Is the PaCO2 normal?\n3-Is the HCO3 normal?\n4-Match the direction of difference of the PaCO2 or HCO3 with the PH\n5-Does the PaCO2 or the HCO3 move in the opposite direction to the PH?",
+        "misuse": "Do not use in isolation of a thorough clinical evaluation of the patient's state",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Ref. 1: Baillie JK. Simple, easily memorised 'rules of thumb' for the rapid assessment of physiological compensation for respiratory acid-base disorders. Thorax 2008;63:289-290 doi:10.1136/thx.2007.091223\n\nRef. 2: Kaufman DA. Interpretation of Arterial Blood Gases (ABGs). Written for Thoracic.org. Retrieved 12/9/2014.\n\nRef. 3: NIH: US National Library of Medicine: Accessed at: https://medlineplus.gov/ency/article/003855.htm\n"
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0002": {
+        "id": "gt0002",
+        "model_id": "openEHR-EHR-OBSERVATION.abg_analyser.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.abg_analyser.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0004": {
+            "id": "gt0004",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0014]"
+          },
+          "gt0074": {
+            "id": "gt0074",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0006": {
+        "id": "gt0006",
+        "model_id": "openEHR-EHR-OBSERVATION.abg_analyser.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.abg_analyser.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0007": {
+            "id": "gt0007",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0004]"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0017]"
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0014]"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0006]"
+          },
+          "gt0040": {
+            "id": "gt0040",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0025]"
+          },
+          "gt0041": {
+            "id": "gt0041",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0026]"
+          },
+          "gt0042": {
+            "id": "gt0042",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0027]"
+          },
+          "gt0043": {
+            "id": "gt0043",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0028]"
+          },
+          "gt0044": {
+            "id": "gt0044",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0018]"
+          },
+          "gt0050": {
+            "id": "gt0050",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0045]"
+          },
+          "gt0066": {
+            "id": "gt0066",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0049]"
+          },
+          "gt0067": {
+            "id": "gt0067",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0050]"
+          }
+        }
+      },
+      "gt0010": {
+        "id": "gt0010",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-blood_gases.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-blood_gases.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0011": {
+            "id": "gt0011",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.12]"
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.10]"
+          },
+          "gt0073": {
+            "id": "gt0073",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0013": {
+        "id": "gt0013",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-urea_and_electrolytes.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-urea_and_electrolytes.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0014": {
+            "id": "gt0014",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.5]"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.3]"
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.2]"
+          },
+          "gt0072": {
+            "id": "gt0072",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0030": {
+        "id": "gt0030",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-serum_albumin.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-serum_albumin.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0031": {
+            "id": "gt0031",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.3]"
+          },
+          "gt0071": {
+            "id": "gt0071",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      }
+    },
+    "rules": {
+      "gt0058": {
+        "id": "gt0058",
+        "priority": 24,
+        "when": [
+          "$gt0067|Delta ratio assessment|==null",
+          "$gt0050|Associated Anion Gap?|==null",
+          "$gt0040|Respiratory acidosis|==null",
+          "$gt0021|PH acidotic?|==null",
+          "$gt0042|Metabolic acidosis|==null",
+          "$gt0041|Respiratory alkalosis|==null",
+          "$gt0044|Final analysis|==null",
+          "$gt0019|Acute/chronic|==null",
+          "$gt0043|Metabolic alkalosis|==null"
+        ],
+        "then": [
+          "$gt0067|Delta ratio assessment|=0|local::at0051|NA|",
+          "$gt0050|Associated Anion Gap?|=0|local::at0046|No AG|",
+          "$gt0040|Respiratory acidosis|=0|local::at0029|No|",
+          "$gt0021|PH acidotic?|=0|local::at0007|No - normal |",
+          "$gt0042|Metabolic acidosis|=0|local::at0033|No|",
+          "$gt0041|Respiratory alkalosis|=0|local::at0031|No|",
+          "$gt0044|Final analysis|=0|local::at0039|N/A|",
+          "$gt0043|Metabolic alkalosis|=0|local::at0035|No|",
+          "$gt0019|Acute/chronic|=0|local::at0015|Acute|"
+        ]
+      },
+      "gt0018": {
+        "id": "gt0018",
+        "priority": 23,
+        "when": [
+          "$gt0004|Acute/chronic|!=null"
+        ],
+        "then": [
+          "$gt0019|Acute/chronic|=$gt0004|Acute/chronic|"
+        ]
+      },
+      "gt0020": {
+        "id": "gt0020",
+        "priority": 22,
+        "when": [
+          "$gt0012|Arterial pH|<7.38,[pH]"
+        ],
+        "then": [
+          "$gt0021|PH acidotic?|=2|local::at0009|Yes|"
+        ]
+      },
+      "gt0022": {
+        "id": "gt0022",
+        "priority": 21,
+        "when": [
+          "$gt0012|Arterial pH|!=null",
+          "$gt0012|Arterial pH|>7.42,[pH]"
+        ],
+        "then": [
+          "$gt0021|PH acidotic?|=1|local::at0008|No - alkalotic|"
+        ]
+      },
+      "gt0023": {
+        "id": "gt0023",
+        "priority": 20,
+        "when": [
+          "$gt0012|Arterial pH|!=null",
+          "$gt0012|Arterial pH|<=7.42,[pH]",
+          "$gt0012|Arterial pH|>=7.38,[pH]"
+        ],
+        "then": [
+          "$gt0021|PH acidotic?|=0|local::at0007|No - normal |"
+        ]
+      },
+      "gt0024": {
+        "id": "gt0024",
+        "priority": 19,
+        "when": [
+          "$gt0016|Bicarbonate|.unit=='mmol/l'",
+          "$gt0015|Chloride|.unit=='mmol/l'",
+          "$gt0014|Sodium|.unit=='mmol/l'",
+          "$gt0016|Bicarbonate|!=null",
+          "$gt0015|Chloride|!=null",
+          "$gt0014|Sodium|!=null"
+        ],
+        "then": [
+          "$gt0007|Anion gap|.unit='mmol/l'",
+          "$gt0007|Anion gap|.magnitude=$gt0014.magnitude-($gt0015.magnitude+$gt0016.magnitude)"
+        ]
+      },
+      "gt0033": {
+        "id": "gt0033",
+        "priority": 18,
+        "when": [
+          "$gt0031|Serum albumin in g/L|.unit=='gm/l'",
+          "$gt0031|Serum albumin in g/L|!=null",
+          "$gt0007|Anion gap|!=null"
+        ],
+        "then": [
+          "$gt0008|Corrected AG|.magnitude=$gt0007.magnitude+(2.5*(40-$gt0031.magnitude))"
+        ]
+      },
+      "gt0035": {
+        "id": "gt0035",
+        "priority": 17,
+        "when": [
+          "$gt0016|Bicarbonate|<22,mmol/l",
+          "$gt0021|PH acidotic?|==2|local::at0009|Yes|"
+        ],
+        "then": [
+          "$gt0042|Metabolic acidosis|=1|local::at0034|Primary Metabolic acidosis|"
+        ]
+      },
+      "gt0036": {
+        "id": "gt0036",
+        "priority": 16,
+        "when": [
+          "$gt0016|Bicarbonate|>28,mmol/l",
+          "$gt0021|PH acidotic?|==1|local::at0008|No - alkalotic|"
+        ],
+        "then": [
+          "$gt0043|Metabolic alkalosis|=1|local::at0036|Primary Metabolic alkalosis|"
+        ]
+      },
+      "gt0037": {
+        "id": "gt0037",
+        "priority": 15,
+        "when": [
+          "$gt0011|PaCO2 in mmHg|>42,mm[Hg]",
+          "$gt0021|PH acidotic?|==2|local::at0009|Yes|"
+        ],
+        "then": [
+          "$gt0040|Respiratory acidosis|=1|local::at0030|Primary Respiratory acidosis|"
+        ]
+      },
+      "gt0038": {
+        "id": "gt0038",
+        "priority": 14,
+        "when": [
+          "$gt0011|PaCO2 in mmHg|<38,mm[Hg]",
+          "$gt0021|PH acidotic?|==1|local::at0008|No - alkalotic|"
+        ],
+        "then": [
+          "$gt0041|Respiratory alkalosis|=1|local::at0032|Primary Respiratory alkalosis|"
+        ]
+      },
+      "gt0039": {
+        "id": "gt0039",
+        "priority": 13,
+        "when": [
+          "$gt0040|Respiratory acidosis|==1|local::at0030|Primary Respiratory acidosis|",
+          "$gt0016|Bicarbonate|>28,mmol/l"
+        ],
+        "then": [
+          "$gt0044|Final analysis|=4|local::at0043|Compensatory metabolic alkalosis|"
+        ]
+      },
+      "gt0046": {
+        "id": "gt0046",
+        "priority": 12,
+        "when": [
+          "$gt0041|Respiratory alkalosis|==1|local::at0032|Primary Respiratory alkalosis|",
+          "$gt0016|Bicarbonate|<22,mmol/l"
+        ],
+        "then": [
+          "$gt0044|Final analysis|=3|local::at0042|Compensatory metabolic acidosis|"
+        ]
+      },
+      "gt0052": {
+        "id": "gt0052",
+        "priority": 11,
+        "when": [
+          "$gt0042|Metabolic acidosis|==1|local::at0034|Primary Metabolic acidosis|",
+          "$gt0011|PaCO2 in mmHg|<38,mm[Hg]"
+        ],
+        "then": [
+          "$gt0044|Final analysis|=2|local::at0041|Compensatory respiratory alkalosis|"
+        ]
+      },
+      "gt0053": {
+        "id": "gt0053",
+        "priority": 10,
+        "when": [
+          "$gt0043|Metabolic alkalosis|==1|local::at0036|Primary Metabolic alkalosis|",
+          "$gt0011|PaCO2 in mmHg|>42,mm[Hg]"
+        ],
+        "then": [
+          "$gt0044|Final analysis|=1|local::at0040|Compenatory respiratory acidosis|"
+        ]
+      },
+      "gt0063": {
+        "id": "gt0063",
+        "priority": 9,
+        "when": [
+          "$gt0042|Metabolic acidosis|==1|local::at0034|Primary Metabolic acidosis|",
+          "$gt0011|PaCO2 in mmHg|>=38,mm[Hg]",
+          "$gt0011|PaCO2 in mmHg|<=42,mm[Hg]"
+        ],
+        "then": [
+          "$gt0044|Final analysis|=5|local::at0044|Uncompensated|"
+        ]
+      },
+      "gt0048": {
+        "id": "gt0048",
+        "priority": 8,
+        "when": [
+          "$gt0040|Respiratory acidosis|==1|local::at0030|Primary Respiratory acidosis|",
+          "$gt0016|Bicarbonate|<=28,mmol/l",
+          "$gt0016|Bicarbonate|>=22,mmol/l"
+        ],
+        "then": [
+          "$gt0044|Final analysis|=5|local::at0044|Uncompensated|"
+        ]
+      },
+      "gt0049": {
+        "id": "gt0049",
+        "priority": 7,
+        "when": [
+          "$gt0043|Metabolic alkalosis|==1|local::at0036|Primary Metabolic alkalosis|",
+          "$gt0011|PaCO2 in mmHg|>=38,mm[Hg]",
+          "$gt0011|PaCO2 in mmHg|<=42,mm[Hg]"
+        ],
+        "then": [
+          "$gt0044|Final analysis|=5|local::at0044|Uncompensated|"
+        ]
+      },
+      "gt0064": {
+        "id": "gt0064",
+        "priority": 6,
+        "when": [
+          "$gt0041|Respiratory alkalosis|==1|local::at0032|Primary Respiratory alkalosis|",
+          "$gt0016|Bicarbonate|<=28,mmol/l",
+          "$gt0016|Bicarbonate|>=22,mmol/l"
+        ],
+        "then": [
+          "$gt0044|Final analysis|=5|local::at0044|Uncompensated|"
+        ]
+      },
+      "gt0060": {
+        "id": "gt0060",
+        "priority": 5,
+        "when": [
+          "$gt0042|Metabolic acidosis|==1|local::at0034|Primary Metabolic acidosis|",
+          "$gt0007|Anion gap|.magnitude>14",
+          "$gt0007|Anion gap|.unit=='mmol/l'"
+        ],
+        "then": [
+          "$gt0050|Associated Anion Gap?|=1|local::at0047|AG present|"
+        ]
+      },
+      "gt0059": {
+        "id": "gt0059",
+        "priority": 4,
+        "when": [
+          "$gt0042|Metabolic acidosis|==1|local::at0034|Primary Metabolic acidosis|",
+          "$gt0007|Anion gap|.magnitude>=10",
+          "$gt0007|Anion gap|.magnitude<=14",
+          "$gt0007|Anion gap|.unit=='mmol/l'"
+        ],
+        "then": [
+          "$gt0050|Associated Anion Gap?|=0|local::at0046|No AG|"
+        ]
+      },
+      "gt0069": {
+        "id": "gt0069",
+        "priority": 3,
+        "when": [
+          "(($gt0041|Respiratory alkalosis|==1|local::at0032|Primary Respiratory alkalosis|)&&($gt0043|Metabolic alkalosis|==1|local::at0036|Primary Metabolic alkalosis|))||(($gt0040|Respiratory acidosis|==1|local::at0030|Primary Respiratory acidosis|)&&($gt0042|Metabolic acidosis|==1|local::at0034|Primary Metabolic acidosis|))"
+        ],
+        "then": [
+          "$gt0044|Final analysis|=6|local::at0048|Mixed disturbance|"
+        ]
+      },
+      "gt0065": {
+        "id": "gt0065",
+        "priority": 2,
+        "when": [
+          "$gt0050|Associated Anion Gap?|==1|local::at0047|AG present|"
+        ],
+        "then": [
+          "$gt0066|Delta gap if AG present|.magnitude=($gt0007.magnitude-12)/(24-$gt0016.magnitude)"
+        ]
+      },
+      "gt0068": {
+        "id": "gt0068",
+        "priority": 1,
+        "when": [
+          "$gt0066|Delta gap if AG present|.magnitude<0.4",
+          "$gt0066|Delta gap if AG present|!=null"
+        ],
+        "then": [
+          "$gt0067|Delta ratio assessment|=1|local::at0052|<0.4|"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "sv": {
+        "id": "sv",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Arterial Blood Gas analyzer",
+            "description": "Instrumentet beräknar anjongap, korrigerat anjongap, metabol rubbning samt, om föreliggande, kompensatorisk reaktion.\r\n"
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "pH <7,35?",
+            "description": "*(en) If PH is <7.35, register as acidotic. If between 7.35 and 7.45 - normal and alkalotic if > 7.45"
+          },
+          "gt0004": {
+            "id": "gt0004",
+            "text": "Akut/kronisk",
+            "description": "*(en) If respiratory process present, chronicity"
+          },
+          "gt0005": {
+            "id": "gt0005"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Anjongap",
+            "description": "*(en) AG = Na - [Cl - HCO3-]"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Korrigerat anjongap",
+            "description": "*(en) cAG = AG + (2.5*(4-albumin)) where albumin is = 4 g/dL or 40 g/L"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Delta ratio",
+            "description": "*(en) (AG - [HCO3-])/(24 - [HCO3-]) where AG = anion gap"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "PaCO2",
+            "description": "*(en) The carbon dioxide pressure in the arterial blood."
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "Arteriellt pH",
+            "description": "*(en) The negative logarithm of the hydrogen ion concentration in blood."
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "Natrium",
+            "description": "*(en) Sodium level in this specimen."
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "Klorid",
+            "description": "*(en) Chloride level in this specimen."
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "Bikarbonat",
+            "description": "*(en) Bicarbonate level in this specimen."
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "text": "Standard"
+          },
+          "gt0018": {
+            "id": "gt0018",
+            "text": "CDS akut/kronisk"
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "text": "Akut/kronisk",
+            "description": "*(en) If respiratory process present, chronicity"
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "CDS pH - acidos"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "text": "pH <7,35?",
+            "description": "*(en) If PH is <7.35, register as acidotic. If between 7.35 and 7.45 - normal and alkalotic if > 7.45"
+          },
+          "gt0022": {
+            "id": "gt0022",
+            "text": "CDS pH - alkalos"
+          },
+          "gt0023": {
+            "id": "gt0023",
+            "text": "CDS pH - normal"
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "text": "CDS anjongap"
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "text": "CDS korrigerat anjongap"
+          },
+          "gt0026": {
+            "id": "gt0026",
+            "text": "Delta ratio"
+          },
+          "gt0027": {
+            "id": "gt0027",
+            "text": "Analys"
+          },
+          "gt0028": {
+            "id": "gt0028",
+            "text": "Slutgiltig analys",
+            "description": "*(en) Type of analysis"
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "text": "Slutgiltig analys: metabol acidos resp metabol alkalos"
+          },
+          "gt0031": {
+            "id": "gt0031",
+            "text": "S-albumin",
+            "description": "*(en) Serum albumin level in this specimen."
+          },
+          "gt0032": {
+            "id": "gt0032",
+            "text": "CDS albumin"
+          },
+          "gt0033": {
+            "id": "gt0033",
+            "text": "CDS korrigerat anjongap"
+          },
+          "gt0034": {
+            "id": "gt0034",
+            "text": "CDS Delta ratio"
+          },
+          "gt0035": {
+            "id": "gt0035",
+            "text": "CDS metabol acidos"
+          },
+          "gt0036": {
+            "id": "gt0036",
+            "text": "CDS metabol alkalos"
+          },
+          "gt0037": {
+            "id": "gt0037",
+            "text": "CDS respiratorisk acidos"
+          },
+          "gt0038": {
+            "id": "gt0038",
+            "text": "CDS respiratorisk alkalos "
+          },
+          "gt0039": {
+            "id": "gt0039",
+            "text": "CDS kompenserad metabol alkalos"
+          },
+          "gt0040": {
+            "id": "gt0040",
+            "text": "Respiratorisk acidos",
+            "description": "*(en) *"
+          },
+          "gt0041": {
+            "id": "gt0041",
+            "text": "Respiratorisk alkalos",
+            "description": "*(en) *"
+          },
+          "gt0042": {
+            "id": "gt0042",
+            "text": "Metabol acidos",
+            "description": "*(en) *"
+          },
+          "gt0043": {
+            "id": "gt0043",
+            "text": "Metabol alkalos",
+            "description": "*(en) *"
+          },
+          "gt0044": {
+            "id": "gt0044",
+            "text": "Slutgiltig analys",
+            "description": "*(en) Type of analysis"
+          },
+          "gt0045": {
+            "id": "gt0045",
+            "text": "Standrad"
+          },
+          "gt0046": {
+            "id": "gt0046",
+            "text": "CDS kompenserad metabol acidos"
+          },
+          "gt0047": {
+            "id": "gt0047"
+          },
+          "gt0048": {
+            "id": "gt0048",
+            "text": "CDS okompenserad respiratorisk acidos"
+          },
+          "gt0049": {
+            "id": "gt0049",
+            "text": "CDS okompenserad metabol alkalos"
+          },
+          "gt0050": {
+            "id": "gt0050",
+            "text": "Associerat anjongap?",
+            "description": "*(en) Anion Gap presence or absence associated with acid-base disturbance"
+          },
+          "gt0051": {
+            "id": "gt0051"
+          },
+          "gt0052": {
+            "id": "gt0052",
+            "text": "CDS kompenserad respiratorisk alkalos"
+          },
+          "gt0053": {
+            "id": "gt0053",
+            "text": "CDS kompenserad respiratorisk acidos"
+          },
+          "gt0054": {
+            "id": "gt0054",
+            "text": "CDS: No associerat anjongap"
+          },
+          "gt0055": {
+            "id": "gt0055",
+            "text": "CDS associerat anjongap"
+          },
+          "gt0056": {
+            "id": "gt0056",
+            "text": "CDS inget korrigerat anjongap"
+          },
+          "gt0057": {
+            "id": "gt0057",
+            "text": "CDS korrigerat anjongap"
+          },
+          "gt0058": {
+            "id": "gt0058",
+            "text": "CDS Standard"
+          },
+          "gt0059": {
+            "id": "gt0059",
+            "text": "CDS anjongap om metabol acidos - nej"
+          },
+          "gt0060": {
+            "id": "gt0060",
+            "text": "CDS anjongap om metabol acidos - ja"
+          },
+          "gt0061": {
+            "id": "gt0061",
+            "text": "CDS mixed: alkalos"
+          },
+          "gt0062": {
+            "id": "gt0062",
+            "text": "CDS mixed: acidos"
+          },
+          "gt0063": {
+            "id": "gt0063",
+            "text": "CDS okompenserad metabol acidos"
+          },
+          "gt0064": {
+            "id": "gt0064",
+            "text": "CDS okompenserad respiratorisk alkalos"
+          },
+          "gt0065": {
+            "id": "gt0065",
+            "text": "Beräkna delta ratio"
+          },
+          "gt0066": {
+            "id": "gt0066",
+            "text": "Delta gap om föreliggande anjongap",
+            "description": "*(en) If an AG is present,the delta ratio is used to determine if a mixed acid base disorder is present. "
+          },
+          "gt0067": {
+            "id": "gt0067",
+            "text": "Delta ratio - utvärdering",
+            "description": "*(en) Delta ratio assessment"
+          },
+          "gt0068": {
+            "id": "gt0068",
+            "text": "Delta ratio - utvärdering"
+          },
+          "gt0069": {
+            "id": "gt0069",
+            "text": "CDS Oklar blandad bild"
+          },
+          "gt0070": {
+            "id": "gt0070",
+            "text": "*(en) Unclassifiable or complicated disturbance"
+          },
+          "gt0071": {
+            "id": "gt0071",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0072": {
+            "id": "gt0072",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0073": {
+            "id": "gt0073",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0074": {
+            "id": "gt0074",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      },
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Arterial Blood Gas Analyser",
+            "description": "Arterial Blood Gas Analyser (ABG) helps to calculate the acid/base disturbances that can be ascertained from a patient's arterial blood gases/electrolytes and albumin.\r\n"
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "PH acidotic?",
+            "description": "If PH is <7.35, register as acidotic. If between 7.35 and 7.45 - normal and alkalotic if > 7.45"
+          },
+          "gt0004": {
+            "id": "gt0004",
+            "text": "Acute/chronic",
+            "description": "If respiratory process present, chronicity"
+          },
+          "gt0005": {
+            "id": "gt0005"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Anion gap",
+            "description": "AG = Na - [Cl - HCO3-]"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Corrected AG",
+            "description": "cAG = AG + (2.5*(4-albumin)) where albumin is = 4 g/dL or 40 g/L"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Delta ratio",
+            "description": "(AG - [HCO3-])/(24 - [HCO3-]) where AG = anion gap"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "PaCO2 in mmHg",
+            "description": "The carbon dioxide pressure in the arterial blood."
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "Arterial pH",
+            "description": "The negative logarithm of the hydrogen ion concentration in blood."
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "Sodium",
+            "description": "Sodium level in this specimen."
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "Chloride",
+            "description": "Chloride level in this specimen."
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "Bicarbonate",
+            "description": "Bicarbonate level in this specimen."
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "text": "Default"
+          },
+          "gt0018": {
+            "id": "gt0018",
+            "text": "Set acute/chronic"
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "text": "Acute/chronic",
+            "description": "If respiratory process present, chronicity"
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "Set PH: acidotic"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "text": "PH acidotic?",
+            "description": "If PH is <7.35, register as acidotic. If between 7.35 and 7.45 - normal and alkalotic if > 7.45"
+          },
+          "gt0022": {
+            "id": "gt0022",
+            "text": "Set PH: alkalotic"
+          },
+          "gt0023": {
+            "id": "gt0023",
+            "text": "Set PH: normal"
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "text": "Set AG"
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "text": "Set corrected AG"
+          },
+          "gt0026": {
+            "id": "gt0026",
+            "text": "Delta ratio"
+          },
+          "gt0027": {
+            "id": "gt0027",
+            "text": "set analysis"
+          },
+          "gt0028": {
+            "id": "gt0028",
+            "text": "Final analysis",
+            "description": "Type of analysis"
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "text": "Final analysis: met aci/resp alki"
+          },
+          "gt0031": {
+            "id": "gt0031",
+            "text": "Serum albumin in g/L",
+            "description": "Serum albumin level in this specimen."
+          },
+          "gt0032": {
+            "id": "gt0032",
+            "text": "Set albumin"
+          },
+          "gt0033": {
+            "id": "gt0033",
+            "text": "Set cAG"
+          },
+          "gt0034": {
+            "id": "gt0034",
+            "text": "Set Delta ratio"
+          },
+          "gt0035": {
+            "id": "gt0035",
+            "text": "Set metabolic acidosis"
+          },
+          "gt0036": {
+            "id": "gt0036",
+            "text": "Set metabolic alkalosis"
+          },
+          "gt0037": {
+            "id": "gt0037",
+            "text": "Set respiratory acidosis"
+          },
+          "gt0038": {
+            "id": "gt0038",
+            "text": "Set respiratory alkalosis"
+          },
+          "gt0039": {
+            "id": "gt0039",
+            "text": "Set Renal compensatory alkalosis for respiratory acidosis"
+          },
+          "gt0040": {
+            "id": "gt0040",
+            "text": "Respiratory acidosis",
+            "description": "*"
+          },
+          "gt0041": {
+            "id": "gt0041",
+            "text": "Respiratory alkalosis",
+            "description": "*"
+          },
+          "gt0042": {
+            "id": "gt0042",
+            "text": "Metabolic acidosis",
+            "description": "*"
+          },
+          "gt0043": {
+            "id": "gt0043",
+            "text": "Metabolic alkalosis",
+            "description": "*"
+          },
+          "gt0044": {
+            "id": "gt0044",
+            "text": "Final analysis",
+            "description": "Type of analysis"
+          },
+          "gt0045": {
+            "id": "gt0045",
+            "text": "Default"
+          },
+          "gt0046": {
+            "id": "gt0046",
+            "text": "Set Renal compensatory acidosis for respiratory alkalosis"
+          },
+          "gt0047": {
+            "id": "gt0047"
+          },
+          "gt0048": {
+            "id": "gt0048",
+            "text": "Set uncompensated respiratory acidosis"
+          },
+          "gt0049": {
+            "id": "gt0049",
+            "text": "Set uncompensated metabolic alkalosis"
+          },
+          "gt0050": {
+            "id": "gt0050",
+            "text": "Associated Anion Gap?",
+            "description": "Anion Gap presence or absence associated with acid-base disturbance"
+          },
+          "gt0051": {
+            "id": "gt0051"
+          },
+          "gt0052": {
+            "id": "gt0052",
+            "text": "Set compensatory respiratory alkalosis for metabolic acidosis"
+          },
+          "gt0053": {
+            "id": "gt0053",
+            "text": "Set compensatory respiratory acidosis for metabolic alkalosis"
+          },
+          "gt0054": {
+            "id": "gt0054",
+            "text": "Set: No AG associated"
+          },
+          "gt0055": {
+            "id": "gt0055",
+            "text": "Set: AG associated"
+          },
+          "gt0056": {
+            "id": "gt0056",
+            "text": "Set: No cAG"
+          },
+          "gt0057": {
+            "id": "gt0057",
+            "text": "Set: cAG present"
+          },
+          "gt0058": {
+            "id": "gt0058",
+            "text": "Set default"
+          },
+          "gt0059": {
+            "id": "gt0059",
+            "text": "Set AG if metabolic acidosis: No AG"
+          },
+          "gt0060": {
+            "id": "gt0060",
+            "text": "Set AG if metab acidosis: AG present"
+          },
+          "gt0061": {
+            "id": "gt0061",
+            "text": "Set mixed disturbance"
+          },
+          "gt0062": {
+            "id": "gt0062",
+            "text": "Set mixed: acidosis"
+          },
+          "gt0063": {
+            "id": "gt0063",
+            "text": "Set uncompensated metabolic acidosis"
+          },
+          "gt0064": {
+            "id": "gt0064",
+            "text": "Set uncompensated respiratory alkalosis"
+          },
+          "gt0065": {
+            "id": "gt0065",
+            "text": "Calc delta ratio"
+          },
+          "gt0066": {
+            "id": "gt0066",
+            "text": "Delta gap if AG present",
+            "description": "If an AG is present,the delta ratio is used to determine if a mixed acid base disorder is present. "
+          },
+          "gt0067": {
+            "id": "gt0067",
+            "text": "Delta ratio assessment",
+            "description": "Delta ratio assessment"
+          },
+          "gt0068": {
+            "id": "gt0068",
+            "text": "Delta ratio assessment"
+          },
+          "gt0069": {
+            "id": "gt0069",
+            "text": "Mixed disturbance"
+          },
+          "gt0070": {
+            "id": "gt0070",
+            "text": "Unclassifiable or complicated disturbance"
+          },
+          "gt0071": {
+            "id": "gt0071",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0072": {
+            "id": "gt0072",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0073": {
+            "id": "gt0073",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0074": {
+            "id": "gt0074",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/ABG.v1.test.yml
+++ b/gdl2/ABG.v1.test.yml
@@ -1,0 +1,361 @@
+guidelines:
+  1: ABG.v1
+test_cases:
+- id: Acute metabolic acidosis, with delta <0.4
+  input:
+    1:
+      gt0004|Acute/chronic: 0|local::at0015|Acute|
+      gt0074|Event time: 2019-04-29T20:22Z
+      gt0011|PaCO2 in mmHg: 42,mm[Hg]
+      gt0012|Arterial pH: 7,[pH]
+      gt0073|Event time: 2019-04-28T20:27Z
+      gt0014|Sodium: 136,mmol/l
+      gt0015|Chloride: 106,mmol/l
+      gt0016|Bicarbonate: 15,mmol/l
+      gt0072|Event time: 2019-04-28T20:27Z
+      gt0031|Serum albumin in g/L: 40,gm/l
+      gt0071|Event time: 2019-04-28T20:27Z
+  expected_output:
+    1:
+      gt0067|Delta ratio assessment: 1|local::at0052|<0.4|
+      gt0066|Delta gap if AG present: 0
+      gt0019|Acute/chronic: 0|local::at0015|Acute|
+      gt0007|Anion gap: 15,mmol/l
+      gt0021|PH acidotic?: 2|local::at0009|Yes|
+      gt0042|Metabolic acidosis: 1|local::at0034|Primary Metabolic acidosis|
+      gt0044|Final analysis: 5|local::at0044|Uncompensated|
+      gt0008|Corrected AG: 15
+      gt0050|Associated Anion Gap?: 1|local::at0047|AG present|
+
+- id: Acute metabolic acidosis, normal anion gap
+  input:
+    1:
+      gt0004|Acute/chronic: 0|local::at0015|Acute|
+      gt0074|Event time: 2019-04-29T20:22Z
+      gt0011|PaCO2 in mmHg: 42,mm[Hg]
+      gt0012|Arterial pH: 7,[pH]
+      gt0073|Event time: 2019-04-28T20:27Z
+      gt0014|Sodium: 136,mmol/l
+      gt0015|Chloride: 104,mmol/l
+      gt0016|Bicarbonate: 19,mmol/l
+      gt0072|Event time: 2019-04-28T20:27Z
+      gt0031|Serum albumin in g/L: 40,gm/l
+      gt0071|Event time: 2019-04-28T20:27Z
+  expected_output:
+    1:
+      gt0019|Acute/chronic: 0|local::at0015|Acute|
+      gt0007|Anion gap: 13,mmol/l
+      gt0021|PH acidotic?: 2|local::at0009|Yes|
+      gt0042|Metabolic acidosis: 1|local::at0034|Primary Metabolic acidosis|
+      gt0044|Final analysis: 5|local::at0044|Uncompensated|
+      gt0008|Corrected AG: 13
+      gt0050|Associated Anion Gap?: 0|local::at0046|No AG|
+
+- id:  Acute metabolic acidosis, normal anion gap case 2
+  input:
+    1:
+      gt0004|Acute/chronic: 0|local::at0015|Acute|
+      gt0074|Event time: 2019-04-29T20:22Z
+      gt0011|PaCO2 in mmHg: 42,mm[Hg]
+      gt0012|Arterial pH: 7,[pH]
+      gt0073|Event time: 2019-04-28T20:27Z
+      gt0014|Sodium: 136,mmol/l
+      gt0015|Chloride: 106,mmol/l
+      gt0016|Bicarbonate: 21,mmol/l
+      gt0072|Event time: 2019-04-28T20:27Z
+      gt0031|Serum albumin in g/L: 40,gm/l
+      gt0071|Event time: 2019-04-28T20:27Z
+  expected_output:
+    1:
+      gt0019|Acute/chronic: 0|local::at0015|Acute|
+      gt0007|Anion gap: 9,mmol/l
+      gt0021|PH acidotic?: 2|local::at0009|Yes|
+      gt0042|Metabolic acidosis: 1|local::at0034|Primary Metabolic acidosis|
+      gt0044|Final analysis: 5|local::at0044|Uncompensated|
+      gt0008|Corrected AG: 9
+
+- id: Chronic, lower albumin, AG - cAG different
+  input:
+    1:
+      gt0004|Acute/chronic: 1|local::at0016|Chronic|
+      gt0074|Event time: 2019-04-29T20:22Z
+      gt0011|PaCO2 in mmHg: 42,mm[Hg]
+      gt0012|Arterial pH: 7,[pH]
+      gt0073|Event time: 2019-04-28T20:27Z
+      gt0014|Sodium: 136,mmol/l
+      gt0015|Chloride: 104,mmol/l
+      gt0016|Bicarbonate: 19,mmol/l
+      gt0072|Event time: 2019-04-28T20:27Z
+      gt0031|Serum albumin in g/L: 32,gm/l
+      gt0071|Event time: 2019-04-28T20:27Z
+  expected_output:
+    1:
+      gt0019|Acute/chronic: 1|local::at0016|Chronic|
+      gt0007|Anion gap: 13,mmol/l
+      gt0021|PH acidotic?: 2|local::at0009|Yes|
+      gt0042|Metabolic acidosis: 1|local::at0034|Primary Metabolic acidosis|
+      gt0044|Final analysis: 5|local::at0044|Uncompensated|
+      gt0008|Corrected AG: 33
+      gt0050|Associated Anion Gap?: 0|local::at0046|No AG|
+
+- id: Uncompensated Metabolic Acidosis
+  input:
+    1:
+      gt0004|Acute/chronic: 1|local::at0016|Chronic|
+      gt0074|Event time: 2019-04-29T20:22Z
+      gt0011|PaCO2 in mmHg: 40,mm[Hg]
+      gt0012|Arterial pH: 7,[pH]
+      gt0073|Event time: 2019-04-28T20:27Z
+      gt0014|Sodium: 136,mmol/l
+      gt0015|Chloride: 104,mmol/l
+      gt0016|Bicarbonate: 19,mmol/l
+      gt0072|Event time: 2019-04-28T20:27Z
+      gt0031|Serum albumin in g/L: 37,gm/l
+      gt0071|Event time: 2019-04-28T20:27Z
+  expected_output:
+    1:
+      gt0019|Acute/chronic: 1|local::at0016|Chronic|
+      gt0007|Anion gap: 13,mmol/l
+      gt0021|PH acidotic?: 2|local::at0009|Yes|
+      gt0042|Metabolic acidosis: 1|local::at0034|Primary Metabolic acidosis|
+      gt0044|Final analysis: 5|local::at0044|Uncompensated|
+      gt0008|Corrected AG: 20
+      gt0050|Associated Anion Gap?: 0|local::at0046|No AG|
+
+- id: Mixed disturbance acidosis
+  input:
+    1:
+      gt0004|Acute/chronic: 1|local::at0016|Chronic|
+      gt0074|Event time: 2019-04-29T20:22Z
+      gt0011|PaCO2 in mmHg: 43,mm[Hg]
+      gt0012|Arterial pH: 7,[pH]
+      gt0073|Event time: 2019-04-28T20:27Z
+      gt0014|Sodium: 136,mmol/l
+      gt0015|Chloride: 104,mmol/l
+      gt0016|Bicarbonate: 19,mmol/l
+      gt0072|Event time: 2019-04-28T20:27Z
+      gt0031|Serum albumin in g/L: 37,gm/l
+      gt0071|Event time: 2019-04-28T20:27Z
+  expected_output:
+    1:
+      gt0019|Acute/chronic: 1|local::at0016|Chronic|
+      gt0007|Anion gap: 13,mmol/l
+      gt0021|PH acidotic?: 2|local::at0009|Yes|
+      gt0042|Metabolic acidosis: 1|local::at0034|Primary Metabolic acidosis|
+      gt0044|Final analysis: 6|local::at0048|Mixed disturbance|
+      gt0008|Corrected AG: 20
+      gt0050|Associated Anion Gap?: 0|local::at0046|No AG|
+      gt0040|Respiratory acidosis: 1|local::at0030|Primary Respiratory acidosis|
+
+- id: Compensatory metabolic acidosis
+  input:
+    1:
+      gt0004|Acute/chronic: 1|local::at0016|Chronic|
+      gt0074|Event time: 2019-04-29T20:22Z
+      gt0011|PaCO2 in mmHg: 36,mm[Hg]
+      gt0012|Arterial pH: 7,[pH]
+      gt0073|Event time: 2019-04-28T20:27Z
+      gt0014|Sodium: 136,mmol/l
+      gt0015|Chloride: 104,mmol/l
+      gt0016|Bicarbonate: 19,mmol/l
+      gt0072|Event time: 2019-04-28T20:27Z
+      gt0031|Serum albumin in g/L: 37,gm/l
+      gt0071|Event time: 2019-04-28T20:27Z
+  expected_output:
+    1:
+      gt0019|Acute/chronic: 1|local::at0016|Chronic|
+      gt0007|Anion gap: 13,mmol/l
+      gt0021|PH acidotic?: 2|local::at0009|Yes|
+      gt0042|Metabolic acidosis: 1|local::at0034|Primary Metabolic acidosis|
+      gt0044|Final analysis: 2|local::at0041|Compensatory respiratory alkalosis|
+      gt0008|Corrected AG: 20
+      gt0050|Associated Anion Gap?: 0|local::at0046|No AG|
+
+- id: Respiratory acidosis, uncompensated
+  input:
+    1:
+      gt0004|Acute/chronic: 0|local::at0015|Acute|
+      gt0074|Event time: 2019-04-29T20:22Z
+      gt0011|PaCO2 in mmHg: 44,mm[Hg]
+      gt0012|Arterial pH: 7,[pH]
+      gt0073|Event time: 2019-04-28T20:27Z
+      gt0014|Sodium: 136,mmol/l
+      gt0015|Chloride: 104,mmol/l
+      gt0016|Bicarbonate: 25,mmol/l
+      gt0072|Event time: 2019-04-28T20:27Z
+      gt0031|Serum albumin in g/L: 37,gm/l
+      gt0071|Event time: 2019-04-28T20:27Z
+  expected_output:
+    1:
+      gt0019|Acute/chronic: 0|local::at0015|Acute|
+      gt0007|Anion gap: 7,mmol/l
+      gt0021|PH acidotic?: 2|local::at0009|Yes|
+      gt0044|Final analysis: 5|local::at0044|Uncompensated|
+      gt0008|Corrected AG: 14
+      gt0040|Respiratory acidosis: 1|local::at0030|Primary Respiratory acidosis|
+
+
+
+- id: Compensatory respiratory alkalosis
+  input:
+    1:
+      gt0004|Acute/chronic: 0|local::at0015|Acute|
+      gt0074|Event time: 2019-04-29T20:22Z
+      gt0011|PaCO2 in mmHg: 44,mm[Hg]
+      gt0012|Arterial pH: 7,[pH]
+      gt0073|Event time: 2019-04-28T20:27Z
+      gt0014|Sodium: 136,mmol/l
+      gt0015|Chloride: 104,mmol/l
+      gt0016|Bicarbonate: 29,mmol/l
+      gt0072|Event time: 2019-04-28T20:27Z
+      gt0031|Serum albumin in g/L: 37,gm/l
+      gt0071|Event time: 2019-04-28T20:27Z
+  expected_output:
+    1:
+      gt0019|Acute/chronic: 0|local::at0015|Acute|
+      gt0007|Anion gap: 3,mmol/l
+      gt0021|PH acidotic?: 2|local::at0009|Yes|
+      gt0044|Final analysis: 4|local::at0043|Compensatory metabolic alkalosis|
+      gt0008|Corrected AG: 10
+      gt0040|Respiratory acidosis: 1|local::at0030|Primary Respiratory acidosis|
+
+- id: Compenatory respiratory acidosis
+  input:
+    1:
+      gt0004|Acute/chronic: 1|local::at0016|Chronic|
+      gt0074|Event time: 2019-04-29T20:22Z
+      gt0011|PaCO2 in mmHg: 44,mm[Hg]
+      gt0012|Arterial pH: 7.6,[pH]
+      gt0073|Event time: 2019-04-28T20:27Z
+      gt0014|Sodium: 136,mmol/l
+      gt0015|Chloride: 104,mmol/l
+      gt0016|Bicarbonate: 29,mmol/l
+      gt0072|Event time: 2019-04-28T20:27Z
+      gt0031|Serum albumin in g/L: 37,gm/l
+      gt0071|Event time: 2019-04-28T20:27Z
+  expected_output:
+    1:
+      gt0043|Metabolic alkalosis: 1|local::at0036|Primary Metabolic alkalosis|
+      gt0019|Acute/chronic: 1|local::at0016|Chronic|
+      gt0007|Anion gap: 3,mmol/l
+      gt0021|PH acidotic?: 1|local::at0008|No - alkalotic|
+      gt0044|Final analysis: 1|local::at0040|Compenatory respiratory acidosis|
+      gt0008|Corrected AG: 10
+
+- id: Uncompensated respiratory alkalosis
+  input:
+    1:
+      gt0004|Acute/chronic: 1|local::at0016|Chronic|
+      gt0074|Event time: 2019-04-29T20:22Z
+      gt0011|PaCO2 in mmHg: 34,mm[Hg]
+      gt0012|Arterial pH: 7.6,[pH]
+      gt0073|Event time: 2019-04-28T20:27Z
+      gt0014|Sodium: 136,mmol/l
+      gt0015|Chloride: 104,mmol/l
+      gt0016|Bicarbonate: 26,mmol/l
+      gt0072|Event time: 2019-04-28T20:27Z
+      gt0031|Serum albumin in g/L: 37,gm/l
+      gt0071|Event time: 2019-04-28T20:27Z
+  expected_output:
+    1:
+      gt0019|Acute/chronic: 1|local::at0016|Chronic|
+      gt0007|Anion gap: 6,mmol/l
+      gt0041|Respiratory alkalosis: 1|local::at0032|Primary Respiratory alkalosis|
+      gt0021|PH acidotic?: 1|local::at0008|No - alkalotic|
+      gt0044|Final analysis: 5|local::at0044|Uncompensated|
+      gt0008|Corrected AG: 13
+
+- id: metabolic alkalosis
+  input:
+    1:
+      gt0004|Acute/chronic: 1|local::at0016|Chronic|
+      gt0074|Event time: 2019-04-29T20:22Z
+      gt0011|PaCO2 in mmHg: 39,mm[Hg]
+      gt0012|Arterial pH: 8,[pH]
+      gt0073|Event time: 2019-04-28T20:27Z
+      gt0014|Sodium: 136,mmol/l
+      gt0015|Chloride: 104,mmol/l
+      gt0016|Bicarbonate: 29,mmol/l
+      gt0072|Event time: 2019-04-28T20:27Z
+      gt0031|Serum albumin in g/L: 37,gm/l
+      gt0071|Event time: 2019-04-28T20:27Z
+  expected_output:
+    1:
+      gt0043|Metabolic alkalosis: 1|local::at0036|Primary Metabolic alkalosis|
+      gt0019|Acute/chronic: 1|local::at0016|Chronic|
+      gt0007|Anion gap: 3,mmol/l
+      gt0021|PH acidotic?: 1|local::at0008|No - alkalotic|
+      gt0044|Final analysis: 5|local::at0044|Uncompensated|
+      gt0008|Corrected AG: 10
+
+
+- id: Mixed alkalosis
+  input:
+    1:
+      gt0004|Acute/chronic: 1|local::at0016|Chronic|
+      gt0074|Event time: 2019-04-29T20:22Z
+      gt0011|PaCO2 in mmHg: 37,mm[Hg]
+      gt0012|Arterial pH: 8,[pH]
+      gt0073|Event time: 2019-04-28T20:27Z
+      gt0014|Sodium: 136,mmol/l
+      gt0015|Chloride: 104,mmol/l
+      gt0016|Bicarbonate: 29,mmol/l
+      gt0072|Event time: 2019-04-28T20:27Z
+      gt0031|Serum albumin in g/L: 37,gm/l
+      gt0071|Event time: 2019-04-28T20:27Z
+  expected_output:
+    1:
+      gt0043|Metabolic alkalosis: 1|local::at0036|Primary Metabolic alkalosis|
+      gt0019|Acute/chronic: 1|local::at0016|Chronic|
+      gt0007|Anion gap: 3,mmol/l
+      gt0041|Respiratory alkalosis: 1|local::at0032|Primary Respiratory alkalosis|
+      gt0021|PH acidotic?: 1|local::at0008|No - alkalotic|
+      gt0044|Final analysis: 6|local::at0048|Mixed disturbance|
+      gt0008|Corrected AG: 10
+
+- id: normal pH
+  input:
+    1:
+      gt0004|Acute/chronic: 1|local::at0016|Chronic|
+      gt0074|Event time: 2019-04-29T20:22Z
+      gt0011|PaCO2 in mmHg: 39,mm[Hg]
+      gt0012|Arterial pH: 7.4,[pH]
+      gt0073|Event time: 2019-04-28T20:27Z
+      gt0014|Sodium: 136,mmol/l
+      gt0015|Chloride: 104,mmol/l
+      gt0016|Bicarbonate: 20,mmol/l
+      gt0072|Event time: 2019-04-28T20:27Z
+      gt0031|Serum albumin in g/L: 40,gm/l
+      gt0071|Event time: 2019-04-28T20:27Z
+  expected_output:
+    1:
+      gt0019|Acute/chronic: 1|local::at0016|Chronic|
+      gt0007|Anion gap: 12,mmol/l
+      gt0021|PH acidotic?: 0|local::at0007|No - normal |
+      gt0008|Corrected AG: 12
+
+- id: Renal compensatory metabolic acidosis
+  input:
+    1:
+      gt0004|Acute/chronic: 1|local::at0016|Chronic|
+      gt0074|Event time: 2019-04-29T20:22Z
+      gt0011|PaCO2 in mmHg: 37,mm[Hg]
+      gt0012|Arterial pH: 8,[pH]
+      gt0073|Event time: 2019-04-28T20:27Z
+      gt0014|Sodium: 136,mmol/l
+      gt0015|Chloride: 104,mmol/l
+      gt0016|Bicarbonate: 20,mmol/l
+      gt0072|Event time: 2019-04-28T20:27Z
+      gt0031|Serum albumin in g/L: 37,gm/l
+      gt0071|Event time: 2019-04-28T20:27Z
+  expected_output:
+    1:
+      gt0019|Acute/chronic: 1|local::at0016|Chronic|
+      gt0007|Anion gap: 12,mmol/l
+      gt0041|Respiratory alkalosis: 1|local::at0032|Primary Respiratory alkalosis|
+      gt0021|PH acidotic?: 1|local::at0008|No - alkalotic|
+      gt0044|Final analysis: 3|local::at0042|Compensatory metabolic acidosis|
+      gt0008|Corrected AG: 19
+
+
+


### PR DESCRIPTION
Changes:
(1)Event time,
(2)in delta ratio assessment rule, unit comparison was removed (as it was not set before, therefore making no sense, and it hindered the rule to run; in addition, the correct unit would not be "1");
(3)in set cAG rule a new precondition: "anion gap" exists is added; the guideline runs without it, but can very easily to run to problem, if one of the ions are not set.

Further comments:
(1) in "Set AG if metabolic acidosis: No AG" rule, I see no reason, why AG is limited to 11-14 interval, instead of just keeping the upper bound (14), and allowing everything below. I didn't find anything in the reference literature either.
(2) Misspelling: "compensatory respiratory acidosis"

All rules are tested.