### PR TITLE
Migrated EDACS-ADP

### DIFF
--- a/gdl2/EDACS-ADP.v1.gdl2.json
+++ b/gdl2/EDACS-ADP.v1.gdl2.json
@@ -1,0 +1,273 @@
+{
+  "id": "EDACS-ADP.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2017-08-04",
+      "name": "Syeeda S Farruque",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "other_contributors": [
+      "Dennis Forslund, Cambio Healthcare Systems"
+    ],
+    "lifecycle_state": "Author draft",
+    "details": {
+      "sv": {
+        "id": "sv",
+        "purpose": "Emergency Department Assessment of Chest Pain Score (EDACS) är en metod för att identifiera individer med låg risk för akut allvarlig hjärtsjukdom, inklusive akut koronart syndrom, i syfte att i kombination med EDACS-ADP (Accelerated Diagnostic Protocol) bedöma vilka som säkert kan skrivas ut för poliklinisk uppföljning.",
+        "keywords": [
+          "bröstsmärta",
+          "EDACS-ADP"
+        ],
+        "use": "EDACS-ADP är ett tillägg till EDACS, och används som stöd till klinisk bedömning av vilka patienter som kan kategoriseras ha låg risk för akut allvarlig hjärtsjukdom inklusive akut koronart syndrom. \n\nResultatet tolkas enligt:\n\n* Låg risk\nEDACS < 16 och\nIngen nytillkommen ischemi på EKG samt negativa troponinprover vid 0h och 2h\n\nRekommendation: säkert att skriva ut med poliklinisk uppföljning (alternativt att gå vidare med tidig provtagning på sjukhuset).\n\n* Allvarlig akut hjärtsjukdom kan ej uteslutas\nEDACS ≥16, eller\nNytillkommen ischemi på EKG/positivt troponinprov vid 0h och 2h\n\nRekommendation: gå vidare i enlighet med sjukhusets protokoll för vidare observation och troponinprovtagning\n\nHandläggning\n\n    Lågriskpatienter: överväg annat fokus för genes innan utskrivning, såsom aorta, esofagus, lungor, hjärta, buk och muskuloskeletal.\n    Allvarlig akut hjärtsjukdom kan ej uteslutas: gå vidare i enlighet med sjukhusets protokoll för vidare observation, överväg administrering av nitroglycering och smärtstillande, uppföljande EKG och troponinprovtagning",
+        "misuse": "Ej tillämpbar på patienter under 18 års ålder, patienter med bröstsmärta ej förenlig med akut koronart syndrom, eller vid pågående bröstsmärta eller instabil angina.",
+        "copyright": "© Cambio Healthcare Systems"
+      },
+      "en": {
+        "id": "en",
+        "purpose": "Pain Score (EDACS) provides a method to identify patients with a low risk of a major cardiac adverse event or possible acute coronary syndrom (ACS). The addition of a couple of variables, the extended EDACS, EDACS-ADP (accelerated diagnostic protocol) helps to ascertain whether they might be suitable for early discharge.",
+        "keywords": [
+          "chest pain",
+          "EDACS-ADP"
+        ],
+        "use": "The EDACS- ADP extends on the EDAC score to provide  a fast evaluation of the risk a major cardiac adverse event or possible acute coronary syndrom (ACS). This uses the EDACS score and requires the additonal ADP elements to stratify the risk between low and not low risk: \n\nLow Risk Cohort:\n\nEDACS < 16 and\nIf EKG shows no new ischemia and 0h and 2h troponin both negative\n\nRecommendation: safe for discharge to early outpatient follow-up investigation (or proceed to earlier inpatient testing).\n\nNot Low Risk Cohort:\n\nEDACS ≥16 or EKG shows new ischemia 0h or 2h troponin positive\n\nRecommendation: Proceed with usual care with further observation and delayed troponin.\n\nManagement\n\n    For low-risk patients: consider other causes of chest pain due to aortic, esophageal, pulmonary, cardiac, and abdominal, and muskuloskeletal sources prior to discharge.\n    For non-low-risk patients: Treat as per usual chest pain protocols, including but not limited to consideration of aspirin, nitroglycerin, and serial EKGs and biomarkers at minimum.\n",
+        "misuse": "Not to be used with patients below 18 years of age or with chest pain not consistent with ACS or if there is ongoing chest pain or crescendo angina.",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Ref. 1: Than M, et al. Emerg Med Australas. Development and validation of the Emergency Department Assessment of Chest pain Score and 2 h accelerated diagnostic protocol. 2014 Feb;26(1):34-44. doi: 10.1111/1742-6723.12164."
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0002": {
+        "id": "gt0002",
+        "model_id": "openEHR-EHR-EVALUATION.edacs_adp_evaluation.v1",
+        "template_id": "openEHR-EHR-EVALUATION.edacs_adp_evaluation.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0011": {
+            "id": "gt0011",
+            "path": "/data[at0001]/items[at0002]"
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "path": "/data[at0001]/items[at0005]"
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "path": "/data[at0001]/items[at0008]"
+          }
+        }
+      },
+      "gt0003": {
+        "id": "gt0003",
+        "model_id": "openEHR-EHR-OBSERVATION.emergency_department_assessment_of_chest_pain_score.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.emergency_department_assessment_of_chest_pain_score.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0008": {
+            "id": "gt0008",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0037]/items[at0038]"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0037]/items[at0039]"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0042]"
+          }
+        }
+      }
+    },
+    "rules": {
+      "gt0017": {
+        "id": "gt0017",
+        "priority": 2,
+        "when": [
+          "$gt0008|Was there new ischemia on ECG?|==0|local::at0044|No|",
+          "$gt0009|Was both 0hr and 2hr troponin negative?|==0|local::at0040|Both 0hr and 2hr Troponin was negative|",
+          "$gt0010|Total score|<16"
+        ],
+        "then": [
+          "$gt0011|Cohort Risk Level|=0|local::at0003|Low Risk|",
+          "$gt0012|Recommendation|=0|local::at0006|Recommendation: safe for discharge to early outpatient follow-up investigation (or proceed to earlier inpatient testing).|",
+          "$gt0013|Management|=0|local::at0009|For low-risk patients: consider other causes of chest pain due to aortic, esophageal, pulmonary, cardiac, and abdominal, and muskuloskeletal sources prior to discharge.|"
+        ]
+      },
+      "gt0018": {
+        "id": "gt0018",
+        "priority": 1,
+        "when": [
+          "($gt0010|Total score|>=16)||(($gt0009|Was both 0hr and 2hr troponin negative?|==1|local::at0041|Either 0hr or 2hr Troponin was positive|)||($gt0008|Was there new ischemia on ECG?|==1|local::at0045|Yes|))"
+        ],
+        "then": [
+          "$gt0011|Cohort Risk Level|=1|local::at0004|Not Low Risk|",
+          "$gt0012|Recommendation|=1|local::at0007|Recommendation: Proceed with usual care with further observation and delayed troponin.|",
+          "$gt0013|Management|=1|local::at0010|For non-low-risk patients: Treat as per usual chest pain protocols, including but not limited to consideration of aspirin, nitroglycerin, and serial EKGs and biomarkers at minimum.|"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "sv": {
+        "id": "sv",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "EDACS-ADP",
+            "description": "Emergency Department Assessment of Chest Pain Score (EDACS) är en metod för att identifiera individer med låg risk för akut allvarlig hjärtsjukdom."
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Nytillkommen ischemi på EKG?",
+            "description": "EDACS-ADP används för att utvärdering i enlighet med EDACS - Accelerated Diagnostic Protocol för snabb bedömning. Måste kombineras med EDACS Score för komplett bedömning, men är separata."
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Negativt troponin vid 0h och 2h?",
+            "description": "EDACS-ADP används för att utvärdering i enlighet med EDACS - Accelerated Diagnostic Protocol för snabb bedömning. Måste kombineras med EDACS Score för komplett bedömning, men är separata."
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Resultat",
+            "description": "Summan av samtliga faktorer. EDACS-ADP inkluderas ej."
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Nytillkommen ischemi på EKG?",
+            "description": "EDACS-ADP används för att utvärdering i enlighet med EDACS - Accelerated Diagnostic Protocol för snabb bedömning. Måste kombineras med EDACS Score för komplett bedömning, men är separata."
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Negativt troponin vid 0h och 2h?",
+            "description": "EDACS-ADP används för att utvärdering i enlighet med EDACS - Accelerated Diagnostic Protocol för snabb bedömning. Måste kombineras med EDACS Score för komplett bedömning, men är separata."
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Resultat",
+            "description": "Summan av samtliga faktorer. EDACS-ADP inkluderas ej."
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Risknivå",
+            "description": "Risknivå baserad på poäng."
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "Rekommendation",
+            "description": "Rekommendation baserad på risknivå."
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "Handläggning",
+            "description": ""
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "*(en) score"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "Q1"
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "Q2"
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "text": "CDS Låg risk - rekommendation och handläggning"
+          },
+          "gt0018": {
+            "id": "gt0018",
+            "text": "CDS Allvarlig akut hjärtsjukdom kan ej uteslutas  - rekommendation och handläggning"
+          }
+        }
+      },
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "EDACS-ADP",
+            "description": "Emergency Department Assessment of Chest Pain Score (EDACS) provides a method to identify patients with a low risk of a major cardiac adverse event"
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Was there new ischemia on ECG?",
+            "description": "Was there new ischemia on ECG?"
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Was both 0hr and 2hr troponin negative?",
+            "description": "These EDACS-ADP questions help to evaluate for the purposes of the EDACS - Accelerated Diagnostic Protocol for fast evaluation. These questions must be combined with the EDACS score for the evaluation to be completed. These questions  are not added to the score for EDACS however."
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Total score",
+            "description": "Sum of the individual EDACS scores (not including the ADP section)"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Was there new ischemia on ECG?",
+            "description": "Was there new ischemia on ECG?"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Was both 0hr and 2hr troponin negative?",
+            "description": "These EDACS-ADP questions help to evaluate for the purposes of the EDACS - Accelerated Diagnostic Protocol for fast evaluation. These questions must be combined with the EDACS score for the evaluation to be completed. These questions  are not added to the score for EDACS however."
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Total score",
+            "description": "Sum of the individual EDACS scores (not including the ADP section)"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Cohort Risk Level",
+            "description": "Low Risk Cohort: EDACS < 16 and\nIf EKG shows no new ischemia and 0h and 2h troponin both negative \nNot Low Risk Cohort: EDACS ≥16 or EKG shows new ischemia 0h or 2h troponin positive"
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "Recommendation",
+            "description": "Recommendation dependant upon cohort risk level."
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "Management",
+            "description": "For low-risk patients: consider other causes of chest pain due to aortic, esophageal, pulmonary, cardiac, and abdominal, and muskuloskeletal sources prior to discharge. For non-low-risk patients: Treat as per usual chest pain protocols, including but not limited to consideration of aspirin, nitroglycerin, and serial EKGs and biomarkers at minimum.\n"
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "score"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "q1"
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "q2"
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "text": "Set Low risk level, recommendation and management"
+          },
+          "gt0018": {
+            "id": "gt0018",
+            "text": "Set Not Low risk level, recommendation and management"
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/EDACS-ADP.v1.test.yml
+++ b/gdl2/EDACS-ADP.v1.test.yml
@@ -10,8 +10,8 @@ test_cases:
   expected_output:
     1:
       gt0011|Cohort Risk Level: 0|local::at0003|Low Risk|
-      gt0013|Management: 0|local::at0009|For low-risk patients: consider other causes of chest pain due to aortic, esophageal, pulmonary, cardiac, and abdominal, and muskuloskeletal sources prior to discharge.|
-      gt0012|Recommendation: 0|local::at0006|Recommendation: safe for discharge to early outpatient follow-up investigation (or proceed to earlier inpatient testing).|
+      gt0013|Management: 0|local::at0009|For low-risk patients - consider other causes of chest pain due to aortic, esophageal, pulmonary, cardiac, and abdominal, and muskuloskeletal sources prior to discharge.|
+      gt0012|Recommendation: 0|local::at0006|Recommendation - safe for discharge to early outpatient follow-up investigation (or proceed to earlier inpatient testing).|
 
 - id: not_low_risk(ischemia)
   input:
@@ -22,8 +22,8 @@ test_cases:
   expected_output:
     1:
       gt0011|Cohort Risk Level: 1|local::at0004|Not Low Risk|
-      gt0013|Management: 1|local::at0010|For non-low-risk patients: Treat as per usual chest pain protocols, including but not limited to consideration of aspirin, nitroglycerin, and serial EKGs and biomarkers at minimum.|
-      gt0012|Recommendation: 1|local::at0007|Recommendation: Proceed with usual care with further observation and delayed troponin.|
+      gt0013|Management: 1|local::at0010|For non-low-risk patients - Treat as per usual chest pain protocols, including but not limited to consideration of aspirin, nitroglycerin, and serial EKGs and biomarkers at minimum.|
+      gt0012|Recommendation: 1|local::at0007|Recommendation - Proceed with usual care with further observation and delayed troponin.|
 
 - id: not_low_risk(troponin)
   input:
@@ -34,8 +34,8 @@ test_cases:
   expected_output:
     1:
       gt0011|Cohort Risk Level: 1|local::at0004|Not Low Risk|
-      gt0013|Management: 1|local::at0010|For non-low-risk patients: Treat as per usual chest pain protocols, including but not limited to consideration of aspirin, nitroglycerin, and serial EKGs and biomarkers at minimum.|
-      gt0012|Recommendation: 1|local::at0007|Recommendation: Proceed with usual care with further observation and delayed troponin.|
+      gt0013|Management: 1|local::at0010|For non-low-risk patients - Treat as per usual chest pain protocols, including but not limited to consideration of aspirin, nitroglycerin, and serial EKGs and biomarkers at minimum.|
+      gt0012|Recommendation: 1|local::at0007|Recommendation - Proceed with usual care with further observation and delayed troponin.|
 
 - id: not_low_risk(total_score>=16)
   input:
@@ -46,8 +46,8 @@ test_cases:
   expected_output:
     1:
       gt0011|Cohort Risk Level: 1|local::at0004|Not Low Risk|
-      gt0013|Management: 1|local::at0010|For non-low-risk patients: Treat as per usual chest pain protocols, including but not limited to consideration of aspirin, nitroglycerin, and serial EKGs and biomarkers at minimum.|
-      gt0012|Recommendation: 1|local::at0007|Recommendation: Proceed with usual care with further observation and delayed troponin.|
+      gt0013|Management: 1|local::at0010|For non-low-risk patients - Treat as per usual chest pain protocols, including but not limited to consideration of aspirin, nitroglycerin, and serial EKGs and biomarkers at minimum.|
+      gt0012|Recommendation: 1|local::at0007|Recommendation - Proceed with usual care with further observation and delayed troponin.|
 
 - id: not_low_risk(all_indicators)
   input:
@@ -58,5 +58,5 @@ test_cases:
   expected_output:
     1:
       gt0011|Cohort Risk Level: 1|local::at0004|Not Low Risk|
-      gt0013|Management: 1|local::at0010|For non-low-risk patients: Treat as per usual chest pain protocols, including but not limited to consideration of aspirin, nitroglycerin, and serial EKGs and biomarkers at minimum.|
-      gt0012|Recommendation: 1|local::at0007|Recommendation: Proceed with usual care with further observation and delayed troponin.|
+      gt0013|Management: 1|local::at0010|For non-low-risk patients - Treat as per usual chest pain protocols, including but not limited to consideration of aspirin, nitroglycerin, and serial EKGs and biomarkers at minimum.|
+      gt0012|Recommendation: 1|local::at0007|Recommendation - Proceed with usual care with further observation and delayed troponin.|

--- a/gdl2/EDACS-ADP.v1.test.yml
+++ b/gdl2/EDACS-ADP.v1.test.yml
@@ -1,0 +1,62 @@
+guidelines:
+  1: EDACS-ADP.v1
+test_cases:
+- id: low_risk
+  input:
+    1:
+      gt0008|Was there new ischemia on ECG?: 0|local::at0044|No|
+      gt0009|Was both 0hr and 2hr troponin negative?: 0|local::at0040|Both 0hr and 2hr Troponin was negative|
+      gt0010|Total score: 0
+  expected_output:
+    1:
+      gt0011|Cohort Risk Level: 0|local::at0003|Low Risk|
+      gt0013|Management: 0|local::at0009|For low-risk patients: consider other causes of chest pain due to aortic, esophageal, pulmonary, cardiac, and abdominal, and muskuloskeletal sources prior to discharge.|
+      gt0012|Recommendation: 0|local::at0006|Recommendation: safe for discharge to early outpatient follow-up investigation (or proceed to earlier inpatient testing).|
+
+- id: not_low_risk(ischemia)
+  input:
+    1:
+      gt0008|Was there new ischemia on ECG?: 1|local::at0045|Yes|
+      gt0009|Was both 0hr and 2hr troponin negative?: 0|local::at0040|Both 0hr and 2hr Troponin was negative|
+      gt0010|Total score: 0
+  expected_output:
+    1:
+      gt0011|Cohort Risk Level: 1|local::at0004|Not Low Risk|
+      gt0013|Management: 1|local::at0010|For non-low-risk patients: Treat as per usual chest pain protocols, including but not limited to consideration of aspirin, nitroglycerin, and serial EKGs and biomarkers at minimum.|
+      gt0012|Recommendation: 1|local::at0007|Recommendation: Proceed with usual care with further observation and delayed troponin.|
+
+- id: not_low_risk(troponin)
+  input:
+    1:
+      gt0008|Was there new ischemia on ECG?: 0|local::at0044|No|
+      gt0009|Was both 0hr and 2hr troponin negative?: 1|local::at0041|Either 0hr or 2hr Troponin was positive|
+      gt0010|Total score: 0
+  expected_output:
+    1:
+      gt0011|Cohort Risk Level: 1|local::at0004|Not Low Risk|
+      gt0013|Management: 1|local::at0010|For non-low-risk patients: Treat as per usual chest pain protocols, including but not limited to consideration of aspirin, nitroglycerin, and serial EKGs and biomarkers at minimum.|
+      gt0012|Recommendation: 1|local::at0007|Recommendation: Proceed with usual care with further observation and delayed troponin.|
+
+- id: not_low_risk(total_score>=16)
+  input:
+    1:
+      gt0008|Was there new ischemia on ECG?: 0|local::at0044|No|
+      gt0009|Was both 0hr and 2hr troponin negative?: 0|local::at0040|Both 0hr and 2hr Troponin was negative|
+      gt0010|Total score: 16
+  expected_output:
+    1:
+      gt0011|Cohort Risk Level: 1|local::at0004|Not Low Risk|
+      gt0013|Management: 1|local::at0010|For non-low-risk patients: Treat as per usual chest pain protocols, including but not limited to consideration of aspirin, nitroglycerin, and serial EKGs and biomarkers at minimum.|
+      gt0012|Recommendation: 1|local::at0007|Recommendation: Proceed with usual care with further observation and delayed troponin.|
+
+- id: not_low_risk(all_indicators)
+  input:
+    1:
+      gt0008|Was there new ischemia on ECG?: 1|local::at0045|Yes|
+      gt0009|Was both 0hr and 2hr troponin negative?: 1|local::at0041|Either 0hr or 2hr Troponin was positive|
+      gt0010|Total score: 16
+  expected_output:
+    1:
+      gt0011|Cohort Risk Level: 1|local::at0004|Not Low Risk|
+      gt0013|Management: 1|local::at0010|For non-low-risk patients: Treat as per usual chest pain protocols, including but not limited to consideration of aspirin, nitroglycerin, and serial EKGs and biomarkers at minimum.|
+      gt0012|Recommendation: 1|local::at0007|Recommendation: Proceed with usual care with further observation and delayed troponin.|


### PR DESCRIPTION
Dear Isabelle, this branch contains the migrated EDACS-ADP along with its test fixtures. The guideline works well, however I was unable to execute the test fixtures due to "mapping values are not allowed here in 'reader'". I'm thinking it is caused by character ':' that was contained in the guideline output. Kindly please check and review it. Thank you.  