### PR TITLE
Asthma predictive score migrated

### DIFF
--- a/gdl2/Asthma_predictive_index_Assessment.v1.gdl2.json
+++ b/gdl2/Asthma_predictive_index_Assessment.v1.gdl2.json
@@ -1,0 +1,158 @@
+{
+  "id": "Asthma_predictive_index_Assessment.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2017-03-17",
+      "name": "Eneimi Allwell-Brown",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "other_contributors": [
+      "Dennis Forslund",
+      "Jimmy Axelsson"
+    ],
+    "lifecycle_state": "Author draft",
+    "details": {
+      "sv": {
+        "id": "sv",
+        "purpose": "Utvärdering av poäng genererad i enlighet med Asthma Predictive Index (API), som används för att hos barn skatta sannolikhet för utveckling av astma (generellt före 15 års ålder).\r\n",
+        "keywords": [
+          "astma",
+          "pediatrik"
+        ],
+        "use": "Använd för utvärdering av poäng genererad i enlighet med Asthma Predictive Index (API), som används för att hos barn skatta sannolikhet för utveckling av astma (generellt före 15 års ålder). Verktyget baseras på förekomst av minst 1/2 huvudkriterier i kombination med minst 2/3 underkriterier, samt eventuellt föreliggande episoder av pipande, väsande andning. Huvudkriterierna är 1) förälder med astma och 2) patient med eksem. Underkriterierna är 1) patient med allergisk rinit, 2) pipande, väsande andning utöver vid förkylning och 3) eosinofili (≥ 4%). \r\n\r\nPositivt resultat uppnås via uppfyllda kriterier enligt Strict index eller Loose index, vilka medger 95% respektive 80% specificitet. \r\n\r\nStrict index:\r\n≥3 episoder av pipande, väsande andning/år OCH \r\n≥1 huvudkriterium ELLER ≥2 underkriterier\r\n\r\nLoose index:\r\n<3 episoder av pipande, väsande andning/år OCH \r\n≥1 huvudkriterium ELLER ≥2 underkriterier\r\n\r\nInstrumentet kan även användas för att avgöra vilka patienter som är lämpliga för aggressiv behandlingsprövning baserat på sannolikhet för utveckling av astma under senare skede. ",
+        "copyright": "© Cambio Healthcare Systems"
+      },
+      "en": {
+        "id": "en",
+        "purpose": "To determine specificity of the API and likelihood of developing childhood asthma (generally before age 15 years).",
+        "keywords": [
+          "asthma",
+          "wheezing",
+          "respiratory illness",
+          "atopy"
+        ],
+        "use": "To assess specificity of API for children/infants ≤3 years old. It is based on the presence of at least one of 2 major criteria and at least two of 3 minor criteria, plus the number of wheezing episodes per year. Major criteria are: parent with asthma/patient with eczema; minor criteria are: patient with allergic rhinitis/wheezing apart from colds/eosinophilia (≥ 4% on FBC). A positive API is fulfilled by either 'strict index' or 'loose index' which provide >95% specificity, and 80% specificity respectively.\r\nStrict index (>95% API specificity):\r\n     ≥3 episodes of wheezing per year, AND\r\n     ≥1 major criteria OR ≥2 minor criteria\r\nLoose index (80% API specificity):\r\n     <3 episodes of wheezing per year, AND\r\n     ≥1 major criteria OR ≥2 minor criteria\r\nIt may also be used by clinicians to detemine which patients are suitable for more aggressive trials of asthma medications because of the likelihood of being diagnosed with asthma later in life.\r\nA corresponding application: Asthma_predictive_index_Calculation.v1 is used to determine the asthma predictive index.",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Castro-Rodríguez JA, Holberg CJ, Wright AL, Martinez FD. A clinical index to define risk of asthma in young children with recurrent wheezing. American journal of respiratory and critical care medicine. 2000 Oct 1;162(4):1403-6.\r\n\r\nLeonardi NA, Spycher BD, Strippoli MP, Frey U, Silverman M, Kuehni CE. Validation of the Asthma Predictive Index and comparison with simpler clinical prediction rules. Journal of allergy and clinical immunology. 2011 Jun 30;127(6):1466-72."
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0035": {
+        "id": "gt0035",
+        "model_id": "openEHR-EHR-OBSERVATION.asthma_predictive_index.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.asthma_predictive_index.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0036": {
+            "id": "gt0036",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0027]"
+          }
+        }
+      },
+      "gt0037": {
+        "id": "gt0037",
+        "model_id": "openEHR-EHR-EVALUATION.asthma_predictive_index.v1",
+        "template_id": "openEHR-EHR-EVALUATION.asthma_predictive_index.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0038": {
+            "id": "gt0038",
+            "path": "/data[at0001]/items[at0002]"
+          }
+        }
+      }
+    },
+    "rules": {
+      "gt0039": {
+        "id": "gt0039",
+        "priority": 2,
+        "when": [
+          "$gt0036|Asthma predictive index|==3|local::at0031|Positive by strict criteria|"
+        ],
+        "then": [
+          "$gt0038|Specificity of API|='> 95%'"
+        ]
+      },
+      "gt0040": {
+        "id": "gt0040",
+        "priority": 1,
+        "when": [
+          "$gt0036|Asthma predictive index|==2|local::at0030|Positive by loose criteria|"
+        ],
+        "then": [
+          "$gt0038|Specificity of API|='80%'"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "sv": {
+        "id": "sv",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Asthma predictive index (API) - utvärdering",
+            "description": "Asthma Predictive Index (API) kan tillämpas på barn ≤3 års ålder och är ett instrument för riskskattning av sannolikhet för framtida diagnosticering av astma. Det baseras på förekomst av minst 1/2 huvudkriterier i kombination med minst 2/3 underkriterier, samt eventuellt föreliggande episoder av pipande, väsande andning. Huvudkriterierna är 1) förälder med astma och 2) patient med eksem. Underkriterierna är 1) patient med allergisk rinit, 2) pipande, väsande andning utöver vid förkylning och 3) eosinofili (≥ 4%). Positivt resultat uppnås via uppfyllda kriterier enligt Strict index (≥3 episoder av pipande, väsande andning/år OCH ≥1 huvudkriterium ELLER ≥2 underkriterier) eller Loose index (<3 episoder av pipande, väsande andning/år OCH ≥1 huvudkriterium ELLER ≥2 underkriterier). Dessa definitioner medger 95% respektive 80% specificitet. "
+          },
+          "gt0036": {
+            "id": "gt0036",
+            "text": "Asthma predictive index",
+            "description": "*(en) Whether the individual meets any of the criteria for likelihood of developing asthma later in childhood."
+          },
+          "gt0038": {
+            "id": "gt0038",
+            "text": "API - specificitet",
+            "description": "*(en) Likelihood of a diagnosis of asthma later in childhood, based on major and minor API criteria."
+          },
+          "gt0039": {
+            "id": "gt0039",
+            "text": "CDS positiv strict index"
+          },
+          "gt0040": {
+            "id": "gt0040",
+            "text": "CDS positiv loose index"
+          }
+        }
+      },
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Asthma Predictive Index Assessment",
+            "description": "Asthma predictive index (API) appplies to children/infants ≤3 years old and is a method for predicting likelihood of a later diagnosis of childhood asthma. It is based on the presence of at least one of 2 major criteria and at least two of 3 minor criteria, plus the number of wheezing episodes per year. Major criteria are: parent with asthma/patient with eczema; minor criteria are: patient with allergic rhinitis/wheezing apart from colds/eosinophilia (≥ 4% on FBC). A positive API is fulfilled by either 'strict index' (≥3 episodes of wheezing per year, AND ≥1 major criteria OR ≥2 minor criteria) or 'loose index' (<3 episodes of wheezing per year, AND ≥1 major criteria OR ≥2 minor criteria), and they each provide >95% specificity, and 80% specificity respectively. It has good specificity but is not a good screening tool and does not detect many patients who will later be diagnosed with asthma. It allows for more aggressive trials of asthma medications in patients who are likely to be diagnosed with asthma later in life."
+          },
+          "gt0036": {
+            "id": "gt0036",
+            "text": "Asthma predictive index",
+            "description": "Whether the individual meets any of the criteria for likelihood of developing asthma later in childhood."
+          },
+          "gt0038": {
+            "id": "gt0038",
+            "text": "Specificity of API",
+            "description": "Likelihood of a diagnosis of asthma later in childhood, based on major and minor API criteria."
+          },
+          "gt0039": {
+            "id": "gt0039",
+            "text": "Set positive strict specificity"
+          },
+          "gt0040": {
+            "id": "gt0040",
+            "text": "Set positive loose specificity"
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/Asthma_predictive_index_Assessment.v1.test.yml
+++ b/gdl2/Asthma_predictive_index_Assessment.v1.test.yml
@@ -1,0 +1,17 @@
+guidelines:
+  1: Asthma_predictive_index_Assessment.v1
+test_cases:
+- id: positive loose
+  input:
+    1:
+      gt0036|Asthma predictive index: 2|local::at0030|Positive by loose criteria|
+  expected_output:
+    1:
+      gt0038|Specificity of API: 80%
+- id: positive strict
+  input:
+    1:
+      gt0036|Asthma predictive index: 3|local::at0031|Positive by strict criteria|
+  expected_output:
+    1:
+      gt0038|Specificity of API: > 95%

--- a/gdl2/Asthma_predictive_index_Calculation.v1.gdl2.json
+++ b/gdl2/Asthma_predictive_index_Calculation.v1.gdl2.json
@@ -1,0 +1,473 @@
+{
+  "id": "Asthma_predictive_index_Calculation.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2017-03-17",
+      "name": "Eneimi Allwell-Brown",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "other_contributors": [
+      "Dennis Forslund",
+      "Jimmy Axelsson"
+    ],
+    "lifecycle_state": "Author draft",
+    "details": {
+      "en": {
+        "id": "en",
+        "purpose": "To determine the likelihood of developing childhood asthma (generally before age 15 years).",
+        "keywords": [
+          "asthma",
+          "wheezing",
+          "respiratory illness",
+          "atopy"
+        ],
+        "use": "To calculate the API for children/infants ≤3 years old. It is based on the presence of at least one of 2 major criteria and at least two of 3 minor criteria, plus the number of wheezing episodes per year. Major criteria are: parent with asthma/patient with eczema; minor criteria are: patient with allergic rhinitis/wheezing apart from colds/eosinophilia (≥ 4% on FBC). A positive API is fulfilled by either 'strict index' or 'loose index' which provide >95% specificity, and 80% specificity respectively.\nStrict index:\n     ≥3 episodes of wheezing per year, AND\n     ≥1 major criteria OR ≥2 minor criteria\nLoose index:\n     <3 episodes of wheezing per year, AND\n     ≥1 major criteria OR ≥2 minor criteria\nIt may also be used by clinicians to detemine which patients are suitable for more aggressive trials of asthma medications because of the likelihood of being diagnosed with asthma later in life.\nA corresponding application: Asthma_predictive_index_Assessment.v1 is used to evaluate the asthma predictive index.",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Castro-Rodríguez JA, Holberg CJ, Wright AL, Martinez FD. A clinical index to define risk of asthma in young children with recurrent wheezing. American journal of respiratory and critical care medicine. 2000 Oct 1;162(4):1403-6.\r\n\r\nLeonardi NA, Spycher BD, Strippoli MP, Frey U, Silverman M, Kuehni CE. Validation of the Asthma Predictive Index and comparison with simpler clinical prediction rules. Journal of allergy and clinical immunology. 2011 Jun 30;127(6):1466-72."
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0002": {
+        "id": "gt0002",
+        "model_id": "openEHR-EHR-OBSERVATION.asthma_predictive_index.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.asthma_predictive_index.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0003": {
+            "id": "gt0003",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0004]"
+          },
+          "gt0004": {
+            "id": "gt0004",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0005]/items[at0006]"
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0008]/items[at0010]"
+          },
+          "gt0035": {
+            "id": "gt0035",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0006": {
+        "id": "gt0006",
+        "model_id": "openEHR-EHR-OBSERVATION.history_prior_medical_diagnosis.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.history_prior_medical_diagnosis.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0007": {
+            "id": "gt0007",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0068]/items[at0089]"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0020]/items[at0088]"
+          },
+          "gt0036": {
+            "id": "gt0036",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0009": {
+        "id": "gt0009",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-full_blood_count.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-full_blood_count.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0010": {
+            "id": "gt0010",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.14]/items[at0078.19]"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.13]"
+          },
+          "gt0037": {
+            "id": "gt0037",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0012": {
+        "id": "gt0012",
+        "model_id": "openEHR-EHR-OBSERVATION.asthma_predictive_index.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.asthma_predictive_index.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0013": {
+            "id": "gt0013",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0004]"
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0005]/items[at0007]"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0005]/items[at0006]"
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0008]/items[at0011]"
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0008]/items[at0010]"
+          },
+          "gt0018": {
+            "id": "gt0018",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0008]/items[at0009]"
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0027]"
+          },
+          "gt0031": {
+            "id": "gt0031",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0005]/items[at0032]"
+          },
+          "gt0032": {
+            "id": "gt0032",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0008]/items[at0033]"
+          }
+        }
+      }
+    },
+    "rules": {
+      "gt0024": {
+        "id": "gt0024",
+        "priority": 13,
+        "when": [
+          "$gt0017|Wheezing apart from colds|==null",
+          "$gt0016|Eosinophilia (≥4% on FBC)|==null",
+          "$gt0015|Parent with asthma|==null",
+          "$gt0014|Patient with eczema|==null",
+          "$gt0018|Patient with allergic rhinitis|==null",
+          "$gt0013|Wheezing episodes/year|==null"
+        ],
+        "then": [
+          "$gt0017|Wheezing apart from colds|=0|local::at0014|No|",
+          "$gt0016|Eosinophilia (≥4% on FBC)|=0|local::at0016|No|",
+          "$gt0015|Parent with asthma|=0|local::at0018|No|",
+          "$gt0014|Patient with eczema|=0|local::at0020|No|",
+          "$gt0018|Patient with allergic rhinitis|=0|local::at0012|No|",
+          "$gt0013|Wheezing episodes/year|=0|local::at0024|<3|"
+        ]
+      },
+      "gt0025": {
+        "id": "gt0025",
+        "priority": 12,
+        "when": [
+          "$gt0003|Wheezing episodes/year|!=null"
+        ],
+        "then": [
+          "$gt0013|Wheezing episodes/year|=$gt0003|Wheezing episodes/year|"
+        ]
+      },
+      "gt0026": {
+        "id": "gt0026",
+        "priority": 11,
+        "when": [
+          "$gt0004|Parent with asthma|!=null"
+        ],
+        "then": [
+          "$gt0015|Parent with asthma|=$gt0004|Parent with asthma|"
+        ]
+      },
+      "gt0028": {
+        "id": "gt0028",
+        "priority": 10,
+        "when": [
+          "$gt0007|Eczema|!=null"
+        ],
+        "then": [
+          "$gt0014|Patient with eczema|=$gt0007|Eczema|"
+        ]
+      },
+      "gt0027": {
+        "id": "gt0027",
+        "priority": 9,
+        "when": [
+          "$gt0008|Allergic rhinitis|!=null"
+        ],
+        "then": [
+          "$gt0018|Patient with allergic rhinitis|=$gt0008|Allergic rhinitis|"
+        ]
+      },
+      "gt0029": {
+        "id": "gt0029",
+        "priority": 8,
+        "when": [
+          "$gt0005|Wheezing apart from colds|!=null"
+        ],
+        "then": [
+          "$gt0017|Wheezing apart from colds|=$gt0005|Wheezing apart from colds|"
+        ]
+      },
+      "gt0030": {
+        "id": "gt0030",
+        "priority": 7,
+        "when": [
+          "$gt0010|Eosinophils|!=null",
+          "$gt0011|White cell count|!=null",
+          "$gt0011|White cell count|.unit=='10*9/l'",
+          "$gt0010|Eosinophils|.unit=='10*9/l'",
+          "$gt0010|Eosinophils|.magnitude>=((4/100)*$gt0011.magnitude)"
+        ],
+        "then": [
+          "$gt0016|Eosinophilia (≥4% on FBC)|=1|local::at0017|Yes|"
+        ]
+      },
+      "gt0033": {
+        "id": "gt0033",
+        "priority": 6,
+        "then": [
+          "$gt0031|Major criteria count|.magnitude=$gt0014.value+$gt0015.value"
+        ]
+      },
+      "gt0034": {
+        "id": "gt0034",
+        "priority": 5,
+        "when": [
+          "$gt0016|Eosinophilia (≥4% on FBC)|!=null"
+        ],
+        "then": [
+          "$gt0032|Minor criteria count|.magnitude=($gt0018.value+$gt0016.value)+$gt0017.value"
+        ]
+      },
+      "gt0023": {
+        "id": "gt0023",
+        "priority": 4,
+        "when": [
+          "($gt0031|Major criteria count|>=1)||($gt0032|Minor criteria count|>=2)",
+          "$gt0013|Wheezing episodes/year|==1|local::at0025|≥3|"
+        ],
+        "then": [
+          "$gt0019|Asthma predictive index|=3|local::at0031|Positive by strict criteria|"
+        ]
+      },
+      "gt0022": {
+        "id": "gt0022",
+        "priority": 3,
+        "when": [
+          "!fired($gt0023)",
+          "($gt0031|Major criteria count|>=1)||($gt0032|Minor criteria count|>=2)",
+          "$gt0013|Wheezing episodes/year|==0|local::at0024|<3|"
+        ],
+        "then": [
+          "$gt0019|Asthma predictive index|=2|local::at0030|Positive by loose criteria|"
+        ]
+      },
+      "gt0021": {
+        "id": "gt0021",
+        "priority": 2,
+        "when": [
+          "!fired($gt0022)",
+          "!fired($gt0023)",
+          "($gt0031|Major criteria count|<1)||($gt0032|Minor criteria count|<2)",
+          "$gt0013|Wheezing episodes/year|==1|local::at0025|≥3|"
+        ],
+        "then": [
+          "$gt0019|Asthma predictive index|=1|local::at0029|Negative by strict criteria|"
+        ]
+      },
+      "gt0020": {
+        "id": "gt0020",
+        "priority": 1,
+        "when": [
+          "!fired($gt0023)",
+          "!fired($gt0022)",
+          "!fired($gt0021)",
+          "($gt0031|Major criteria count|<1)||($gt0032|Minor criteria count|<2)",
+          "$gt0013|Wheezing episodes/year|==0|local::at0024|<3|"
+        ],
+        "then": [
+          "$gt0019|Asthma predictive index|=0|local::at0028|Negative by loose criteria|"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Asthma Predictive Index Calculator",
+            "description": "Asthma predictive index (API) appplies to children/infants ≤3 years old and is a method for predicting likelihood of a later diagnosis of childhood asthma. It is based on the presence of at least one of 2 major criteria and at least two of 3 minor criteria, plus the number of wheezing episodes per year. Major criteria are: parent with asthma/patient with eczema; minor criteria are: patient with allergic rhinitis/wheezing apart from colds/eosinophilia (≥ 4% on FBC). A positive API is fulfilled by either 'strict index' (≥3 episodes of wheezing per year, AND ≥1 major criteria OR ≥2 minor criteria) or 'loose index' (<3 episodes of wheezing per year, AND ≥1 major criteria OR ≥2 minor criteria), and they each provide >95% specificity, and 80% specificity respectively. It has good specificity but is not a good screening tool and does not detect many patients who will later be diagnosed with asthma. It allows for more aggressive trials of asthma medications in patients who are likely to be diagnosed with asthma later in life."
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "Wheezing episodes/year",
+            "description": "Number of wheezing episode experienced per year."
+          },
+          "gt0004": {
+            "id": "gt0004",
+            "text": "Parent with asthma",
+            "description": "Does any of the individual's parents suffer from asthma?"
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Wheezing apart from colds",
+            "description": "Does the individual experience wheezing apart from having colds?"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Eczema",
+            "description": "Has the individual ever been diagnosed with tendon xanthoma?"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Allergic rhinitis",
+            "description": "Has the individual ever been diagnosed with allergic rhinitis?"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Eosinophils",
+            "description": "The number of eosinophils per litre"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "White cell count",
+            "description": "The number of white cells per litre"
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "Wheezing episodes/year",
+            "description": "Number of wheezing episode experienced per year."
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "Patient with eczema",
+            "description": "Does the individual suffer from eczema?"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "Parent with asthma",
+            "description": "Does any of the individual's parents suffer from asthma?"
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "Eosinophilia (≥4% on FBC)",
+            "description": "Does the full blood count show eosinophilia?"
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "text": "Wheezing apart from colds",
+            "description": "Does the individual experience wheezing apart from having colds?"
+          },
+          "gt0018": {
+            "id": "gt0018",
+            "text": "Patient with allergic rhinitis",
+            "description": "Does the individual suffer from allergic rhinitis?"
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "text": "Asthma predictive index",
+            "description": "Whether the individual meets any of the criteria for likelihood of developing asthma later in childhood."
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "Set negative loose criteria"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "text": "Set negative strict criteria"
+          },
+          "gt0022": {
+            "id": "gt0022",
+            "text": "Set positive loose criteria"
+          },
+          "gt0023": {
+            "id": "gt0023",
+            "text": "Set positive strict criteria"
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "text": "Set defaults"
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "text": "Set wheezing episodes per year"
+          },
+          "gt0026": {
+            "id": "gt0026",
+            "text": "Set parent with asthma"
+          },
+          "gt0027": {
+            "id": "gt0027",
+            "text": "Set patient with allergic rhinitis"
+          },
+          "gt0028": {
+            "id": "gt0028",
+            "text": "Set patient with eczema"
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "text": "Set wheezing episodes apart from colds"
+          },
+          "gt0030": {
+            "id": "gt0030",
+            "text": "Set eosinophilia"
+          },
+          "gt0031": {
+            "id": "gt0031",
+            "text": "Major criteria count",
+            "description": "Sum of ordinal values for the major criteria."
+          },
+          "gt0032": {
+            "id": "gt0032",
+            "text": "Minor criteria count",
+            "description": "Sum of ordinal values for the minor criteria."
+          },
+          "gt0033": {
+            "id": "gt0033",
+            "text": "Set major criteria count"
+          },
+          "gt0034": {
+            "id": "gt0034",
+            "text": "Set minor criteria count"
+          },
+          "gt0035": {
+            "id": "gt0035",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0036": {
+            "id": "gt0036",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0037": {
+            "id": "gt0037",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/Asthma_predictive_index_Calculation.v1.test.yml
+++ b/gdl2/Asthma_predictive_index_Calculation.v1.test.yml
@@ -1,0 +1,208 @@
+guidelines:
+  1: Asthma_predictive_index_Calculation.v1
+test_cases:
+- id: Default
+  input:
+    1: {}
+  expected_output:
+    1:
+      gt0032|Minor criteria count: 0
+      gt0016|Eosinophilia (≥4% on FBC): 0|local::at0016|No|
+      gt0014|Patient with eczema: 0|local::at0020|No|
+      gt0019|Asthma predictive index: 0|local::at0028|Negative by loose criteria|
+      gt0018|Patient with allergic rhinitis: 0|local::at0012|No|
+      gt0015|Parent with asthma: 0|local::at0018|No|
+      gt0017|Wheezing apart from colds: 0|local::at0014|No|
+      gt0013|Wheezing episodes/year: 0|local::at0024|<3|
+      gt0031|Major criteria count: 0
+- id: Eosinophilia and allergic rhinitis
+  input:
+    1:
+      gt0003|Wheezing episodes/year: 0|local::at0024|<3|
+      gt0004|Parent with asthma: 0|local::at0018|No|
+      gt0005|Wheezing apart from colds: 0|local::at0014|No|
+      gt0035|Event time: 2019-04-29T22:12Z
+      gt0007|Eczema: 0|local::at0090|No|
+      gt0008|Allergic rhinitis: 1|local::at0093|Yes|
+      gt0036|Event time: 2019-04-28T22:12Z
+      gt0010|Eosinophils: 0.6,10*9/l
+      gt0011|White cell count: 7,10*9/l
+      gt0037|Event time: 2019-04-29T22:18Z
+  expected_output:
+    1:
+      gt0032|Minor criteria count: 2
+      gt0016|Eosinophilia (≥4% on FBC): 1|local::at0017|Yes|
+      gt0014|Patient with eczema: 0|local::at0090|No|
+      gt0019|Asthma predictive index: 2|local::at0030|Positive by loose criteria|
+      gt0018|Patient with allergic rhinitis: 1|local::at0093|Yes|
+      gt0015|Parent with asthma: 0|local::at0018|No|
+      gt0017|Wheezing apart from colds: 0|local::at0014|No|
+      gt0013|Wheezing episodes/year: 0|local::at0024|<3|
+      gt0031|Major criteria count: 0
+
+
+- id: Positve by strict, minor criteria
+  input:
+    1:
+      gt0003|Wheezing episodes/year: 1|local::at0025|≥3|
+      gt0004|Parent with asthma: 0|local::at0018|No|
+      gt0005|Wheezing apart from colds: 0|local::at0014|No|
+      gt0035|Event time: 2019-04-29T22:12Z
+      gt0007|Eczema: 0|local::at0090|No|
+      gt0008|Allergic rhinitis: 1|local::at0093|Yes|
+      gt0036|Event time: 2019-04-28T22:12Z
+      gt0010|Eosinophils: 1,10*9/l
+      gt0011|White cell count: 7,10*9/l
+      gt0037|Event time: 2019-04-29T22:18Z
+  expected_output:
+    1:
+      gt0032|Minor criteria count: 2
+      gt0016|Eosinophilia (≥4% on FBC): 1|local::at0017|Yes|
+      gt0014|Patient with eczema: 0|local::at0090|No|
+      gt0019|Asthma predictive index: 3|local::at0031|Positive by strict criteria|
+      gt0018|Patient with allergic rhinitis: 1|local::at0093|Yes|
+      gt0015|Parent with asthma: 0|local::at0018|No|
+      gt0017|Wheezing apart from colds: 0|local::at0014|No|
+      gt0013|Wheezing episodes/year: 1|local::at0025|≥3|
+      gt0031|Major criteria count: 0
+
+- id: Healthy 1
+  input:
+    1:
+      gt0003|Wheezing episodes/year: 1|local::at0025|≥3|
+      gt0004|Parent with asthma: 0|local::at0018|No|
+      gt0005|Wheezing apart from colds: 0|local::at0014|No|
+      gt0035|Event time: 2019-04-29T22:12Z
+      gt0007|Eczema: 0|local::at0090|No|
+      gt0008|Allergic rhinitis: 1|local::at0093|Yes|
+      gt0036|Event time: 2019-04-28T22:12Z
+      gt0010|Eosinophils: 1,10*9/l
+      gt0011|White cell count: 26,10*9/l
+      gt0037|Event time: 2019-04-29T22:18Z
+  expected_output:
+    1:
+      gt0014|Patient with eczema: 0|local::at0090|No|
+      gt0019|Asthma predictive index: 1|local::at0029|Negative by strict criteria|
+      gt0018|Patient with allergic rhinitis: 1|local::at0093|Yes|
+      gt0015|Parent with asthma: 0|local::at0018|No|
+      gt0017|Wheezing apart from colds: 0|local::at0014|No|
+      gt0013|Wheezing episodes/year: 1|local::at0025|≥3|
+      gt0031|Major criteria count: 0
+
+
+- id: Negative by strict
+  input:
+    1:
+      gt0003|Wheezing episodes/year: 1|local::at0025|≥3|
+      gt0004|Parent with asthma: 0|local::at0018|No|
+      gt0005|Wheezing apart from colds: 0|local::at0014|No|
+      gt0035|Event time: 2019-04-29T22:12Z
+      gt0007|Eczema: 0|local::at0090|No|
+      gt0008|Allergic rhinitis: 1|local::at0093|Yes|
+      gt0036|Event time: 2019-04-28T22:12Z
+      gt0010|Eosinophils: 0.5,10*9/l
+      gt0011|White cell count: 21,10*9/l
+      gt0037|Event time: 2019-04-29T22:18Z
+  expected_output:
+    1:
+      gt0014|Patient with eczema: 0|local::at0090|No|
+      gt0019|Asthma predictive index: 1|local::at0029|Negative by strict criteria|
+      gt0018|Patient with allergic rhinitis: 1|local::at0093|Yes|
+      gt0015|Parent with asthma: 0|local::at0018|No|
+      gt0017|Wheezing apart from colds: 0|local::at0014|No|
+      gt0013|Wheezing episodes/year: 1|local::at0025|≥3|
+      gt0031|Major criteria count: 0
+
+- id: Positive by strict, major criteria
+  input:
+    1:
+      gt0003|Wheezing episodes/year: 1|local::at0025|≥3|
+      gt0004|Parent with asthma: 1|local::at0019|Yes|
+      gt0005|Wheezing apart from colds: 0|local::at0014|No|
+      gt0035|Event time: 2019-04-29T22:12Z
+      gt0007|Eczema: 0|local::at0090|No|
+      gt0008|Allergic rhinitis: 1|local::at0093|Yes|
+      gt0036|Event time: 2019-04-28T22:12Z
+      gt0010|Eosinophils: 1,10*9/l
+      gt0011|White cell count: 26,10*9/l
+      gt0037|Event time: 2019-04-29T22:18Z
+  expected_output:
+    1:
+      gt0014|Patient with eczema: 0|local::at0090|No|
+      gt0019|Asthma predictive index: 3|local::at0031|Positive by strict criteria|
+      gt0018|Patient with allergic rhinitis: 1|local::at0093|Yes|
+      gt0015|Parent with asthma: 1|local::at0019|Yes|
+      gt0017|Wheezing apart from colds: 0|local::at0014|No|
+      gt0013|Wheezing episodes/year: 1|local::at0025|≥3|
+      gt0031|Major criteria count: 1
+
+- id: Positive by loose, major criteria
+  input:
+    1:
+      gt0003|Wheezing episodes/year: 0|local::at0024|<3|
+      gt0004|Parent with asthma: 1|local::at0019|Yes|
+      gt0005|Wheezing apart from colds: 0|local::at0014|No|
+      gt0035|Event time: 2019-04-29T22:12Z
+      gt0007|Eczema: 0|local::at0090|No|
+      gt0008|Allergic rhinitis: 1|local::at0093|Yes|
+      gt0036|Event time: 2019-04-28T22:12Z
+      gt0010|Eosinophils: 1,10*9/l
+      gt0011|White cell count: 26,10*9/l
+      gt0037|Event time: 2019-04-29T22:18Z
+  expected_output:
+    1:
+      gt0014|Patient with eczema: 0|local::at0090|No|
+      gt0019|Asthma predictive index: 2|local::at0030|Positive by loose criteria|
+      gt0018|Patient with allergic rhinitis: 1|local::at0093|Yes|
+      gt0015|Parent with asthma: 1|local::at0019|Yes|
+      gt0017|Wheezing apart from colds: 0|local::at0014|No|
+      gt0013|Wheezing episodes/year: 0|local::at0024|<3|
+      gt0031|Major criteria count: 1
+
+- id: Negative by loose
+  input:
+    1:
+      gt0003|Wheezing episodes/year: 0|local::at0024|<3|
+      gt0004|Parent with asthma: 0|local::at0018|No|
+      gt0005|Wheezing apart from colds: 0|local::at0014|No|
+      gt0035|Event time: 2019-04-29T22:12Z
+      gt0007|Eczema: 0|local::at0090|No|
+      gt0008|Allergic rhinitis: 1|local::at0093|Yes|
+      gt0036|Event time: 2019-04-28T22:12Z
+      gt0010|Eosinophils: 1,10*9/l
+      gt0011|White cell count: 26,10*9/l
+      gt0037|Event time: 2019-04-29T22:18Z
+  expected_output:
+    1:
+      gt0014|Patient with eczema: 0|local::at0090|No|
+      gt0019|Asthma predictive index: 0|local::at0028|Negative by loose criteria|
+      gt0018|Patient with allergic rhinitis: 1|local::at0093|Yes|
+      gt0015|Parent with asthma: 0|local::at0018|No|
+      gt0017|Wheezing apart from colds: 0|local::at0014|No|
+      gt0013|Wheezing episodes/year: 0|local::at0024|<3|
+      gt0031|Major criteria count: 0
+
+- id: Eczema
+  input:
+    1:
+      gt0003|Wheezing episodes/year: 0|local::at0024|<3|
+      gt0004|Parent with asthma: 0|local::at0018|No|
+      gt0005|Wheezing apart from colds: 0|local::at0014|No|
+      gt0035|Event time: 2019-04-29T22:12Z
+      gt0007|Eczema: 1|local::at0091|Yes|
+      gt0008|Allergic rhinitis: 1|local::at0093|Yes|
+      gt0036|Event time: 2019-04-28T22:12Z
+      gt0010|Eosinophils: 1,10*9/l
+      gt0011|White cell count: 26,10*9/l
+      gt0037|Event time: 2019-04-29T22:18Z
+  expected_output:
+    1:
+      gt0014|Patient with eczema: 1|local::at0091|Yes|
+      gt0019|Asthma predictive index: 2|local::at0030|Positive by loose criteria|
+      gt0018|Patient with allergic rhinitis: 1|local::at0093|Yes|
+      gt0015|Parent with asthma: 0|local::at0018|No|
+      gt0017|Wheezing apart from colds: 0|local::at0014|No|
+      gt0013|Wheezing episodes/year: 0|local::at0024|<3|
+      gt0031|Major criteria count: 1
+
+


### PR DESCRIPTION
Changes:
(1)Small changes: event time, outp-> inp
(2) in Set minor criteria count rule I added a precondition requiring the existence of eosinophilia, otherwise the whole guideline won't run in case of no eosinophilia.
Note:
I don't see the reason, why eosinophils are given in the same unit as WBC-s, as it is rare that a patient's eos count can reach 1*10^9, it is not very easy to test the lack of eosinophilia with realistic values. For me, even 0.1 was not executed even in the test tab, 0.5 however worked (of course, in the execution tab only 1 works, so many test features has this value, with corresponding unrealistic WBC count)