### PR TITLE
ATRIA score migrated

### DIFF
--- a/gdl2/ATRIA_stroke_risk_score_Assessment.v1.gdl2.json
+++ b/gdl2/ATRIA_stroke_risk_score_Assessment.v1.gdl2.json
@@ -1,0 +1,196 @@
+{
+  "id": "ATRIA_stroke_risk_score_Assessment.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2016-12-12",
+      "name": "Eneimi Allwell-Brown",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "other_contributors": [
+      "Dennis Forslund",
+      "Jimmy Axelsson"
+    ],
+    "lifecycle_state": "Author draft",
+    "details": {
+      "sv": {
+        "id": "sv",
+        "purpose": "Att registrera 1-årsrisk för stroke eller annan tromboembolisk händelse hos patienter med förmaksflimmer. Denna arketyp är skapad för utvärdering av poäng genererad i enlighet med ATRIA stroke risk score, ett validerat instrument som används för uppskattning av strokerisk och som riktlinje för optimal behandling med antikoagulantia. ",
+        "keywords": [
+          "förmaksflimmer",
+          "stroke",
+          "ATRIA"
+        ],
+        "use": "Använd för att registrera utvärderad poäng genererad i enlighet med ATRIA stroke risk score. Totala poängen uppgår till maximalt 15p. Strokerisk;\r\n- En poäng om 0-5 indikerar mindre än 1% risk (låg risk)\r\n- 6p 1->2% risk (intermediär risk)\r\n- >6p >2% risk (hög risk)\r\n",
+        "misuse": "Endast avsedd för patienter med diagnosticerat förmaksflimmer.",
+        "copyright": "© Cambio Healthcare Systems"
+      },
+      "en": {
+        "id": "en",
+        "purpose": "To determine the 1-year predicted risk of ischaemic stroke or other thromembolism (TE) in individuals with atrial fibrillation. ATRIA stroke risk score has been validated as performing better than the CHADS2 and CHA2DS2-VASc risk models and provides more accurate and reliable stroke risk prediction, as well as guides optimal anticoagulation decision-making, in individuals with atrial fibrillation.",
+        "keywords": [
+          "atrial fibrillation",
+          "stroke risk",
+          "thromboembolism risk"
+        ],
+        "use": "Use to determine the risk of ischaemic stroke or thromboembolism from the calculated ATRIA stroke risk score.\r\nLow risk (less than 1%) with ATRIA stroke risk score 0 -5;\r\nIntermediate risk (1 - <2%) with ATRIA stroe risk score = 6; and\r\nHigh risk (>=2%) with ATRIA stroke risk score >=6.",
+        "misuse": "Do not use if the patient does not have atrial fibrillation.",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Singer DE, Chang Y, Borowsky LH, Fang MC, Pomernacki NK, Udaltsova N, Reynolds K, Go AS. A new risk scheme to predict ischemic stroke and other thromboembolism in atrial fibrillation: the ATRIA study stroke risk score. Journal of the American Heart Association. 2013 Jun 18;2(3):e000250.\r\n\r\nhttp://www.mdcalc.com/atria-stroke-risk-score/"
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0002": {
+        "id": "gt0002",
+        "model_id": "openEHR-EHR-OBSERVATION.atria_stroke_risk_score.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.atria_stroke_risk_score.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0003": {
+            "id": "gt0003",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0012]"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0004": {
+        "id": "gt0004",
+        "model_id": "openEHR-EHR-EVALUATION.atria_stroke_risk.v1",
+        "template_id": "openEHR-EHR-EVALUATION.atria_stroke_risk.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0005": {
+            "id": "gt0005",
+            "path": "/data[at0001]/items[at0002]"
+          }
+        }
+      }
+    },
+    "rules": {
+      "gt0006": {
+        "id": "gt0006",
+        "priority": 3,
+        "when": [
+          "$gt0003|ATRIA stroke risk score|<=5",
+          "$gt0003|ATRIA stroke risk score|>=0"
+        ],
+        "then": [
+          "$gt0005|ATRIA stroke risk|=0|local::at0004|Low risk of stroke (<1%)|"
+        ]
+      },
+      "gt0007": {
+        "id": "gt0007",
+        "priority": 2,
+        "when": [
+          "$gt0003|ATRIA stroke risk score|==6"
+        ],
+        "then": [
+          "$gt0005|ATRIA stroke risk|=1|local::at0005|Intermediate risk of stroke (1 - <2%)|"
+        ]
+      },
+      "gt0008": {
+        "id": "gt0008",
+        "priority": 1,
+        "when": [
+          "$gt0003|ATRIA stroke risk score|>6"
+        ],
+        "then": [
+          "$gt0005|ATRIA stroke risk|=2|local::at0006|High risk of stroke (≥2%)|"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "sv": {
+        "id": "sv",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "ATRIA Stroke Risk utvärdering",
+            "description": "ATRIA (anticoagulation and risk factors in atrial fibrillation) stroke risk score används för att uppskatta strokerisk hos patienter med förmaksflimmer. Instrumentet baseras på ett antal kända riskfaktorer: tidigare stroke, ålder, kön, komorbiditet, proteinuri och eGFR < 45ml/min (alt terminal njursvikt). Poängen uppgår till maximalt 15p. En poäng om 0-5 indikerar mindre än 1%, 6p 1->2% och >6p >2% risk för stroke. "
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "ATRIA stroke risk score",
+            "description": "*(en) Total number of points assigned based on the presence or absence of the 8 predictor variables."
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "ATRIA stroke risk",
+            "description": "*(en) Predicted risk of developing a stroke or thromboembolism within 1 year based on ATRIA stroke risk score."
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Låg risk"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Intermediär risk"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Hög risk"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      },
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "ATRIA Stroke Risk Assessment",
+            "description": "ATRIA (anticoagulation and risk factors in atrial fibrillation) stroke risk is the predicted risk of ischaemic stroke/thromboembolism (TE) in individuals with atrial fibrillation. It is derived from the ATRIA stroke risk score which is calculated from the sum of points assigned for the presence (or absence) of certain risk factors: previous stroke, age, sex, comorbidities (diabetes, congestive heart failure, hypertension), proteinuria, and eGFR < 45ml/min (or end stage renal disease). The ATRIA stroke risk score takes a value between 0 - 15, and it is from this score that ATRIA stroke risk is predicted. An ATRIA stroke risk score between 0 - 5 predicts a risk of ischaemic stroke/TE less than 1%; a score of 6 predicts 1 - <2% risk; and a score >6 predicts >=2% risk."
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "ATRIA stroke risk score",
+            "description": "Total number of points assigned based on the presence or absence of the 8 predictor variables."
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "ATRIA stroke risk",
+            "description": "Predicted risk of developing a stroke or thromboembolism within 1 year based on ATRIA stroke risk score."
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Set low risk of stroke"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Set intermediate risk of stroke"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Set high risk of stroke"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/ATRIA_stroke_risk_score_Assessment.v1.test.yml
+++ b/gdl2/ATRIA_stroke_risk_score_Assessment.v1.test.yml
@@ -1,0 +1,43 @@
+guidelines:
+  1: ATRIA_stroke_risk_score_Assessment.v1
+test_cases:
+- id: Low risk
+  input:
+    1:
+      gt0003|ATRIA stroke risk score: 0
+      gt0009|Event time: 2019-04-28T21:54Z
+  expected_output:
+    1:
+      gt0005|ATRIA stroke risk: 0|local::at0004|Low risk of stroke (<1%)|
+- id: Low risk 2
+  input:
+    1:
+      gt0003|ATRIA stroke risk score: 2
+      gt0009|Event time: 2019-04-28T21:54Z
+  expected_output:
+    1:
+      gt0005|ATRIA stroke risk: 0|local::at0004|Low risk of stroke (<1%)|
+- id: Low risk 5
+  input:
+    1:
+      gt0003|ATRIA stroke risk score: 5
+      gt0009|Event time: 2019-04-28T21:54Z
+  expected_output:
+    1:
+      gt0005|ATRIA stroke risk: 0|local::at0004|Low risk of stroke (<1%)|
+- id: Intermediate risk
+  input:
+    1:
+      gt0003|ATRIA stroke risk score: 6
+      gt0009|Event time: 2019-04-28T21:54Z
+  expected_output:
+    1:
+      gt0005|ATRIA stroke risk: 1|local::at0005|Intermediate risk of stroke (1 - <2%)|
+- id: High risk
+  input:
+    1:
+      gt0003|ATRIA stroke risk score: 9
+      gt0009|Event time: 2019-04-28T21:54Z
+  expected_output:
+    1:
+      gt0005|ATRIA stroke risk: 2|local::at0006|High risk of stroke (≥2%)|

--- a/gdl2/ATRIA_stroke_risk_score_Calculation.v1.gdl2.json
+++ b/gdl2/ATRIA_stroke_risk_score_Calculation.v1.gdl2.json
@@ -1,0 +1,849 @@
+{
+  "id": "ATRIA_stroke_risk_score_Calculation.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2016-11-30",
+      "name": "Eneimi Allwell-Brown",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "other_contributors": [
+      "Dennis Forslund",
+      "Jimmy Axelsson"
+    ],
+    "lifecycle_state": "Author draft",
+    "details": {
+      "sv": {
+        "id": "sv",
+        "purpose": "Beräkna poäng i enlighet med ATRIA stroke risk score. Instrumentet baseras på åtta faktorer; tidigare stroke, ålder, kön, komorbiditet, proteinuri och eGFR < 45ml/min (alt terminal njursvikt). Instrumentet är validerat, och används för uppskattning av strokerisk och som riktlinje för optimal behandling med antikoagulantia hos patienter med förmaksflimmer. \r\n",
+        "keywords": [
+          "förmaksflimmer",
+          "stroke",
+          "ATRIA"
+        ],
+        "use": "Beräkna poäng i enlighet med ATRIA stroke risk score, baserat på följande faktorer;\r\n - förekomst av diabetes mellitus, hjärtsvikt, hypertoni, proteinuri (U-albumin ≥30 mg/dl eller U-albumin:kreatinin-kvot ≥30 mg/g), eGFR < 45ml/min (eller terminal njursvikt) = 1 poäng vardera, och 0p om ej föreliggande;\r\n - kvinnligt kön = 1 poäng, och 0p om manligt; \r\n - ålder <65 år (utan tidigare stroke = 0p, med tidigare stroke = 8p), 65-74 år (utan tidigare stroke = 3p, med tidigare stroke = 7p), 75-84 år (utan tidigare stroke = 5p, med tidigare stroke = 7 p), ≥85 år (utan tidigare stroke = 6p, med tidigare stroke = 9p).",
+        "misuse": "Endast avsedd för patienter med diagnosticerat förmaksflimmer.",
+        "copyright": "© Cambio Healthcare Systems"
+      },
+      "en": {
+        "id": "en",
+        "purpose": "Calculates ATRIA stroke risk score based on the following assessed variables: prior stroke, age, sex, comorbidities (diabetes mellitus, congestive heart failure, hypertension), proteinuria, and eGFR <45ml/min (or ESRD - end stage renal disease). ATRIA stroke risk score has been validated as performing better than the CHADS2 and CHA2DS2-VASc risk models and provides more accurate and reliable stroke risk/thromboembolism prediction, as well as guides optimal anticoagulation decision-making, in individuals with atrial fibrillation.",
+        "keywords": [
+          "atrial fibrillation",
+          "stroke risk",
+          "thromboembolism risk"
+        ],
+        "use": "To calculate ATRIA stroke risk score based on:\n - presence of diabetes mellitus, congestive heart failure, hypertension, proteinuria (urinary albumin >=30 mg/dl OR urinary abumin:cratinine ratio >=30 mg/g), eGFR < 45ml/min (or ESRD) = 1 point each, and 0 if absent;\n - female sex = 1 point, and 0 if male; \n - age <65 years (with no prior stroke = 0, with prior stroke = 8 points), 65-74 years (with no prior stroke = 3, with prior stroke = 7 points), 75-84 years (with no prior stroke = 5, with prior stroke = 7 points), >=85 years (with no prior stroke = 6, with prior stroke = 9 points).\nThe ATRIA stroke risk score is further used in evaluating the 1-year risk of stroke or other thromboembolic event.",
+        "misuse": "Do not use this calculator if the individual does not have atrial fibrillation.",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Singer DE, Chang Y, Borowsky LH, Fang MC, Pomernacki NK, Udaltsova N, Reynolds K, Go AS. A new risk scheme to predict ischemic stroke and other thromboembolism in atrial fibrillation: the ATRIA study stroke risk score. Journal of the American Heart Association. 2013 Jun 18;2(3):e000250.\r\n\r\nhttp://www.mdcalc.com/atria-stroke-risk-score/"
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0003": {
+        "id": "gt0003",
+        "model_id": "openEHR-EHR-OBSERVATION.basic_demographic.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.basic_demographic.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0010": {
+            "id": "gt0010",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0008]"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0004]"
+          },
+          "gt0063": {
+            "id": "gt0063",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0006": {
+        "id": "gt0006",
+        "model_id": "openEHR-EHR-OBSERVATION.estimated_glomerular_filtration_rate.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.estimated_glomerular_filtration_rate.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0012": {
+            "id": "gt0012",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0004]"
+          },
+          "gt0064": {
+            "id": "gt0064",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0008": {
+        "id": "gt0008",
+        "model_id": "openEHR-EHR-OBSERVATION.atria_stroke_risk_score.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.atria_stroke_risk_score.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0020": {
+            "id": "gt0020",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0005]"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0006]"
+          },
+          "gt0022": {
+            "id": "gt0022",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0007]"
+          },
+          "gt0023": {
+            "id": "gt0023",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0008]"
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0009]"
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0010]"
+          },
+          "gt0026": {
+            "id": "gt0026",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0011]"
+          },
+          "gt0027": {
+            "id": "gt0027",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0012]"
+          },
+          "gt0053": {
+            "id": "gt0053",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0004]"
+          }
+        }
+      },
+      "gt0015": {
+        "id": "gt0015",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-microalbumin.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-microalbumin.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0016": {
+            "id": "gt0016",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.3]"
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.1]"
+          },
+          "gt0065": {
+            "id": "gt0065",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0054": {
+        "id": "gt0054",
+        "model_id": "openEHR-EHR-OBSERVATION.history_prior_medical_diagnosis.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.history_prior_medical_diagnosis.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0055": {
+            "id": "gt0055",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0021]/items[at0004]"
+          },
+          "gt0056": {
+            "id": "gt0056",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0019]/items[at0005]"
+          },
+          "gt0057": {
+            "id": "gt0057",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0019]/items[at0006]"
+          },
+          "gt0062": {
+            "id": "gt0062",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0019]/items[at0031]"
+          },
+          "gt0066": {
+            "id": "gt0066",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      }
+    },
+    "rules": {
+      "gt0036": {
+        "id": "gt0036",
+        "priority": 16,
+        "when": [
+          "$gt0053|History of stroke|==null",
+          "$gt0020|Age|==null",
+          "$gt0021|Sex|==null",
+          "$gt0022|History of diabetes mellitus|==null",
+          "$gt0023|History of congestive heart failure|==null",
+          "$gt0024|History of hypertension|==null",
+          "$gt0025|Proteinuria|==null",
+          "$gt0026|eGFR|==null"
+        ],
+        "then": [
+          "$gt0026|eGFR|=0|local::at0022|eGFR ≥45|",
+          "$gt0025|Proteinuria|=0|local::at0024|No|",
+          "$gt0024|History of hypertension|=0|local::at0026|No|",
+          "$gt0023|History of congestive heart failure|=0|local::at0028|No|",
+          "$gt0022|History of diabetes mellitus|=0|local::at0030|No|",
+          "$gt0021|Sex|=0|local::at0020|Male|",
+          "$gt0020|Age|=0|local::at0013|Age <65 years with no history of stroke.|",
+          "$gt0053|History of stroke|=0|local::at0032|No|"
+        ]
+      },
+      "gt0038": {
+        "id": "gt0038",
+        "priority": 15,
+        "when": [
+          "$gt0062|Stroke/cerebrovascular accident|==1|local::at0036|Yes|"
+        ],
+        "then": [
+          "$gt0053|History of stroke|=1|local::at0033|Yes|"
+        ]
+      },
+      "gt0039": {
+        "id": "gt0039",
+        "priority": 14,
+        "when": [
+          "$gt0062|Stroke/cerebrovascular accident|==0|local::at0035|No|",
+          "$gt0010|Birthdate|>($currentDateTime-65,a)"
+        ],
+        "then": [
+          "$gt0020|Age|=0|local::at0013|Age <65 years with no history of stroke.|"
+        ]
+      },
+      "gt0049": {
+        "id": "gt0049",
+        "priority": 13,
+        "when": [
+          "$gt0062|Stroke/cerebrovascular accident|==1|local::at0036|Yes|",
+          "$gt0010|Birthdate|>($currentDateTime-65,a)"
+        ],
+        "then": [
+          "$gt0020|Age|=8|local::at0018|Age <65 years with a history of stroke.|"
+        ]
+      },
+      "gt0046": {
+        "id": "gt0046",
+        "priority": 12,
+        "when": [
+          "$gt0062|Stroke/cerebrovascular accident|==0|local::at0035|No|",
+          "$gt0010|Birthdate|<($currentDateTime-64,a)",
+          "$gt0010|Birthdate|>=($currentDateTime-84,a)"
+        ],
+        "then": [
+          "$gt0020|Age|=3|local::at0014|Age 65-74 years with no history of stroke.|"
+        ]
+      },
+      "gt0050": {
+        "id": "gt0050",
+        "priority": 11,
+        "when": [
+          "$gt0062|Stroke/cerebrovascular accident|==1|local::at0036|Yes|",
+          "$gt0010|Birthdate|<($currentDateTime-64,a)",
+          "$gt0010|Birthdate|>=($currentDateTime-84,a)"
+        ],
+        "then": [
+          "$gt0020|Age|=7|local::at0017|Age 65-84 years with a history of stroke.|"
+        ]
+      },
+      "gt0047": {
+        "id": "gt0047",
+        "priority": 10,
+        "when": [
+          "$gt0062|Stroke/cerebrovascular accident|==0|local::at0035|No|",
+          "$gt0010|Birthdate|<($currentDateTime-74,a)",
+          "$gt0010|Birthdate|>=($currentDateTime-84,a)"
+        ],
+        "then": [
+          "$gt0020|Age|=5|local::at0015|Age 75-84 years with no history of stroke.|"
+        ]
+      },
+      "gt0048": {
+        "id": "gt0048",
+        "priority": 9,
+        "when": [
+          "$gt0062|Stroke/cerebrovascular accident|==0|local::at0035|No|",
+          "$gt0010|Birthdate|<=($currentDateTime-85,a)"
+        ],
+        "then": [
+          "$gt0020|Age|=6|local::at0016|Age ≥85 years with no history of stroke.|"
+        ]
+      },
+      "gt0052": {
+        "id": "gt0052",
+        "priority": 8,
+        "when": [
+          "$gt0062|Stroke/cerebrovascular accident|==1|local::at0036|Yes|",
+          "$gt0010|Birthdate|<=($currentDateTime-85,a)"
+        ],
+        "then": [
+          "$gt0020|Age|=9|local::at0019|Age ≥85 years with a history of stroke.|"
+        ]
+      },
+      "gt0040": {
+        "id": "gt0040",
+        "priority": 7,
+        "when": [
+          "$gt0011|Gender|==local::at0006|Female|"
+        ],
+        "then": [
+          "$gt0021|Sex|=1|local::at0021|Female|"
+        ]
+      },
+      "gt0044": {
+        "id": "gt0044",
+        "priority": 6,
+        "when": [
+          "($gt0016|Urine microalbumin|>=30,mg/dl)||($gt0017|Urine albumin:creatinine ratio|>=30,mg/gm)"
+        ],
+        "then": [
+          "$gt0025|Proteinuria|=1|local::at0025|Yes|"
+        ]
+      },
+      "gt0045": {
+        "id": "gt0045",
+        "priority": 5,
+        "when": [
+          "$gt0012|Estimated Glomerular Filtration Rate|<45,ml/min"
+        ],
+        "then": [
+          "$gt0026|eGFR|=1|local::at0023|eGFR <45|"
+        ]
+      },
+      "gt0058": {
+        "id": "gt0058",
+        "priority": 4,
+        "when": [
+          "$gt0055|Diabetes Mellitus|==1|local::at0008|Yes|"
+        ],
+        "then": [
+          "$gt0022|History of diabetes mellitus|=1|local::at0031|Yes|"
+        ]
+      },
+      "gt0059": {
+        "id": "gt0059",
+        "priority": 3,
+        "when": [
+          "$gt0056|Congestive Heart Failure|==1|local::at0010|Yes|"
+        ],
+        "then": [
+          "$gt0023|History of congestive heart failure|=1|local::at0029|Yes|"
+        ]
+      },
+      "gt0060": {
+        "id": "gt0060",
+        "priority": 2,
+        "when": [
+          "$gt0057|Hypertension|==1|local::at0012|Yes|"
+        ],
+        "then": [
+          "$gt0024|History of hypertension|=1|local::at0027|Yes|"
+        ]
+      },
+      "gt0037": {
+        "id": "gt0037",
+        "priority": 1,
+        "then": [
+          "$gt0027|ATRIA stroke risk score|.magnitude=((((($gt0021.value+$gt0022.value)+$gt0023.value)+$gt0024.value)+$gt0020.value)+$gt0025.value)+$gt0026.value"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "sv": {
+        "id": "sv",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "ATRIA stroke risk score calculator",
+            "description": "ATRIA (anticoagulation and risk factors in atrial fibrillation) stroke risk score används för att uppskatta strokerisk hos patienter med förmaksflimmer. Instrumentet baseras på ett antal kända riskfaktorer: tidigare stroke, ålder, kön, komorbiditet, proteinuri och eGFR < 45ml/min (alt terminal njursvikt). Poängen uppgår till maximalt 15p. En poäng om 0-5 indikerar mindre än 1%, 6p 1->2% och >6p >2% risk för stroke. "
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Tidigare stroke/TIA",
+            "description": "*(en) Has the individual ever suffered a stroke or transient ischaemic attack?"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Födelsedatum",
+            "description": "*(en) *"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Kön",
+            "description": "*(en) *"
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "eGFR",
+            "description": "*(en) Value describing estimation of glomerular filtration rate adjusted by body-surface area (mL/min/1.73m²)."
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "U-albumin",
+            "description": "*(en) Microalbumin level in this specimen."
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "text": "U-albumin/kreatinin-kvot",
+            "description": "*(en) Ratio of albumin and creatinine in this specimen."
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "text": "Tidigare stroke",
+            "description": "*(en) Has this individual ever suffered a stroke? Yes = true, No = false."
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "Ålder",
+            "description": "*(en) What is the age and has the individual ever had a prior stroke?"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "text": "Kön",
+            "description": "*(en) Is the individual male or female?"
+          },
+          "gt0022": {
+            "id": "gt0022",
+            "text": "Diabetes mellitus",
+            "description": "*(en) Does the individual have a history of diabetes mellitus?"
+          },
+          "gt0023": {
+            "id": "gt0023",
+            "text": "Hjärtsvikt",
+            "description": "*(en) Does the individual have a history of congestive heart failure?"
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "text": "Hypertoni",
+            "description": "*(en) Does the individual have a history of hypertension?"
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "text": "Proteinuri",
+            "description": "*(en) Does the individual have proteinuria?"
+          },
+          "gt0026": {
+            "id": "gt0026",
+            "text": "eGFR",
+            "description": "*(en) The estimated glomerular filtration rate (based on MDRD equation) or presence of end-stage renal disease (ESRD)."
+          },
+          "gt0027": {
+            "id": "gt0027",
+            "text": "ATRIA stroke risk score",
+            "description": "*(en) Total number of points assigned based on the presence or absence of the 8 predictor variables."
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "text": "Diabetes Mellitus Diagnos",
+            "description": "*(en) The index diagnosis"
+          },
+          "gt0031": {
+            "id": "gt0031",
+            "text": "Hjärtsvikt diagnos",
+            "description": "*(en) The index diagnosis"
+          },
+          "gt0033": {
+            "id": "gt0033",
+            "text": "Hypertoni diagnos",
+            "description": "*(en) The index diagnosis"
+          },
+          "gt0035": {
+            "id": "gt0035",
+            "text": "Stroke Diagnos",
+            "description": "*(en) The index diagnosis"
+          },
+          "gt0036": {
+            "id": "gt0036",
+            "text": "Standard"
+          },
+          "gt0037": {
+            "id": "gt0037",
+            "text": "Beräkna ATRIA stroke risk score"
+          },
+          "gt0038": {
+            "id": "gt0038",
+            "text": "CDS stroke "
+          },
+          "gt0039": {
+            "id": "gt0039",
+            "text": "CDS ålder <65 utan tidigare stroke"
+          },
+          "gt0040": {
+            "id": "gt0040",
+            "text": "CDS kön"
+          },
+          "gt0041": {
+            "id": "gt0041",
+            "text": "CDS Diabetes Mellitus"
+          },
+          "gt0042": {
+            "id": "gt0042",
+            "text": "CDS hjärtsvikt"
+          },
+          "gt0043": {
+            "id": "gt0043",
+            "text": "CDS Hypertoni"
+          },
+          "gt0044": {
+            "id": "gt0044",
+            "text": "CDS proteinuri"
+          },
+          "gt0045": {
+            "id": "gt0045",
+            "text": "CDS eGFR "
+          },
+          "gt0046": {
+            "id": "gt0046",
+            "text": "CDS ålder 65-84 utan tidigare stroke"
+          },
+          "gt0047": {
+            "id": "gt0047",
+            "text": "CDS ålder 75-84 med tidigare stroke"
+          },
+          "gt0048": {
+            "id": "gt0048",
+            "text": "CDS ålder >=85 utan tidigare stroke"
+          },
+          "gt0049": {
+            "id": "gt0049",
+            "text": "CDS ålder <65 med tidigare stroke"
+          },
+          "gt0050": {
+            "id": "gt0050",
+            "text": "CDS ålder 65-84 rule med tidigare stroke"
+          },
+          "gt0051": {
+            "id": "gt0051",
+            "text": "CDS ålder 74-84 med tidigare stroke"
+          },
+          "gt0052": {
+            "id": "gt0052",
+            "text": "CDS ålder >=85 med tidigare stroke"
+          },
+          "gt0053": {
+            "id": "gt0053",
+            "text": "Tidigare stroke"
+          },
+          "gt0055": {
+            "id": "gt0055",
+            "text": "Diabetes Mellitus",
+            "description": "*(en) Has the individual ever been diagnosed with Diabetes Mellitus?"
+          },
+          "gt0056": {
+            "id": "gt0056",
+            "text": "Hjärtsvikt",
+            "description": "*(en) Has the individual ever been diagnosed with Congestive Heart Failure?"
+          },
+          "gt0057": {
+            "id": "gt0057",
+            "text": "Hypertoni",
+            "description": "*(en) Has the individual ever been diagnosed with Hypertension?"
+          },
+          "gt0058": {
+            "id": "gt0058",
+            "text": "CDS diabetes mellitus"
+          },
+          "gt0059": {
+            "id": "gt0059",
+            "text": "CDS hjärtsvikt"
+          },
+          "gt0060": {
+            "id": "gt0060",
+            "text": "CDS hypertoni"
+          },
+          "gt0061": {
+            "id": "gt0061",
+            "text": "Diabetes Mellitus",
+            "description": "*(en) Has the individual ever been diagnosed with Diabetes Mellitus?"
+          },
+          "gt0062": {
+            "id": "gt0062",
+            "text": "Stroke/cerebrovaskulär händelse",
+            "description": "*(en) Has the individual ever been diagnosed with a stroke/cerebrovascular accident?"
+          },
+          "gt0063": {
+            "id": "gt0063",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0064": {
+            "id": "gt0064",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0065": {
+            "id": "gt0065",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0066": {
+            "id": "gt0066",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      },
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "ATRIA stroke risk score calculator",
+            "description": "ATRIA (anticoagulation and risk factors in atrial fibrillation) stroke risk score is used to determine the risk of stroke in patients with atrial fibrillation. It is the sum of points assigned for the presence (or absence) of certain risk factors: previous stroke, age, sex, comorbidities (diabetes, congestive heart failure, hypertension), proteinuria, and eGFR < 45ml/min (or end stage renal disease) in the patient. The ATRIA stroke risk score takes a value between 0 - 15, and it is from this score that ATRIA stroke risk is predicted. A score between 0 - 5 predicts a risk of ischaemic stroke/TE less than 1%; a score of 6 predicts 1 - <2% risk; and a score >6 predicts ≥2% risk."
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Prior stroke/TIA",
+            "description": "Has the individual ever suffered a stroke or transient ischaemic attack?"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Birthdate",
+            "description": "*"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Gender",
+            "description": "*"
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "Estimated Glomerular Filtration Rate",
+            "description": "Value describing estimation of glomerular filtration rate adjusted by body-surface area (mL/min/1.73m²)."
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "Urine microalbumin",
+            "description": "Microalbumin level in this specimen."
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "text": "Urine albumin:creatinine ratio",
+            "description": "Ratio of albumin and creatinine in this specimen."
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "text": "History of stroke",
+            "description": "Has this individual ever suffered a stroke? Yes = true, No = false."
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "Age",
+            "description": "What is the age and has the individual ever had a prior stroke?"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "text": "Sex",
+            "description": "Is the individual male or female?"
+          },
+          "gt0022": {
+            "id": "gt0022",
+            "text": "History of diabetes mellitus",
+            "description": "Does the individual have a history of diabetes mellitus?"
+          },
+          "gt0023": {
+            "id": "gt0023",
+            "text": "History of congestive heart failure",
+            "description": "Does the individual have a history of congestive heart failure?"
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "text": "History of hypertension",
+            "description": "Does the individual have a history of hypertension?"
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "text": "Proteinuria",
+            "description": "Does the individual have proteinuria?"
+          },
+          "gt0026": {
+            "id": "gt0026",
+            "text": "eGFR",
+            "description": "The estimated glomerular filtration rate (based on MDRD equation) or presence of end-stage renal disease (ESRD)."
+          },
+          "gt0027": {
+            "id": "gt0027",
+            "text": "ATRIA stroke risk score",
+            "description": "Total number of points assigned based on the presence or absence of the 8 predictor variables."
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "text": "Diabetes Mellitus Diagnosis",
+            "description": "The index diagnosis"
+          },
+          "gt0031": {
+            "id": "gt0031",
+            "text": "Congestive Heart Failure Diagnosis",
+            "description": "The index diagnosis"
+          },
+          "gt0033": {
+            "id": "gt0033",
+            "text": "Hypertension Diagnosis",
+            "description": "The index diagnosis"
+          },
+          "gt0035": {
+            "id": "gt0035",
+            "text": "Stroke Diagnosis",
+            "description": "The index diagnosis"
+          },
+          "gt0036": {
+            "id": "gt0036",
+            "text": "Set defaults"
+          },
+          "gt0037": {
+            "id": "gt0037",
+            "text": "Calculate ATRIA stroke risk score"
+          },
+          "gt0038": {
+            "id": "gt0038",
+            "text": "Set CDS stroke rule"
+          },
+          "gt0039": {
+            "id": "gt0039",
+            "text": "Set CDS Age <65 rule with stroke history absent"
+          },
+          "gt0040": {
+            "id": "gt0040",
+            "text": "Set CDS Sex rule"
+          },
+          "gt0041": {
+            "id": "gt0041",
+            "text": "Set CDS Diabetes Mellitus rule"
+          },
+          "gt0042": {
+            "id": "gt0042",
+            "text": "Set CDS Congestive Heart Failure rule"
+          },
+          "gt0043": {
+            "id": "gt0043",
+            "text": "Set CDS Hypertension rule"
+          },
+          "gt0044": {
+            "id": "gt0044",
+            "text": "Set CDS Proteinuria rule"
+          },
+          "gt0045": {
+            "id": "gt0045",
+            "text": "Set CDS eGFR rule"
+          },
+          "gt0046": {
+            "id": "gt0046",
+            "text": "Set CDS Age 65-84 rule with stroke history absent"
+          },
+          "gt0047": {
+            "id": "gt0047",
+            "text": "Set CDS Age 75-84 rule with stroke history absent"
+          },
+          "gt0048": {
+            "id": "gt0048",
+            "text": "Set CDS Age >=85 rule with stroke history absent"
+          },
+          "gt0049": {
+            "id": "gt0049",
+            "text": "Set CDS Age <65 rule with stroke history present"
+          },
+          "gt0050": {
+            "id": "gt0050",
+            "text": "Set CDS Age 65-84 rule with stroke history present"
+          },
+          "gt0051": {
+            "id": "gt0051",
+            "text": "Set CDS Age 74-84 rule with stroke history present"
+          },
+          "gt0052": {
+            "id": "gt0052",
+            "text": "Set CDS Age >=85 rule with stroke history present"
+          },
+          "gt0053": {
+            "id": "gt0053",
+            "text": "History of stroke"
+          },
+          "gt0055": {
+            "id": "gt0055",
+            "text": "Diabetes Mellitus",
+            "description": "Has the individual ever been diagnosed with Diabetes Mellitus?"
+          },
+          "gt0056": {
+            "id": "gt0056",
+            "text": "Congestive Heart Failure",
+            "description": "Has the individual ever been diagnosed with Congestive Heart Failure?"
+          },
+          "gt0057": {
+            "id": "gt0057",
+            "text": "Hypertension",
+            "description": "Has the individual ever been diagnosed with Hypertension?"
+          },
+          "gt0058": {
+            "id": "gt0058",
+            "text": "Set history of diabetes mellitus"
+          },
+          "gt0059": {
+            "id": "gt0059",
+            "text": "Set history of congestive heart failure"
+          },
+          "gt0060": {
+            "id": "gt0060",
+            "text": "Set history of hypertension"
+          },
+          "gt0061": {
+            "id": "gt0061",
+            "text": "Diabetes Mellitus",
+            "description": "Has the individual ever been diagnosed with Diabetes Mellitus?"
+          },
+          "gt0062": {
+            "id": "gt0062",
+            "text": "Stroke/cerebrovascular accident",
+            "description": "Has the individual ever been diagnosed with a stroke/cerebrovascular accident?"
+          },
+          "gt0063": {
+            "id": "gt0063",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0064": {
+            "id": "gt0064",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0065": {
+            "id": "gt0065",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0066": {
+            "id": "gt0066",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/ATRIA_stroke_risk_score_Calculation.v1.test.yml
+++ b/gdl2/ATRIA_stroke_risk_score_Calculation.v1.test.yml
@@ -1,0 +1,254 @@
+guidelines:
+  1: ATRIA_stroke_risk_score_Calculation.v1
+test_cases:
+- id: over 75yr female, ATRIA 13
+  input:
+    1:
+      gt0010|Birthdate: 1944-04-15T20:14Z
+      gt0011|Gender: local::at0006|Female|
+      gt0063|Event time: 2019-04-29T20:14Z
+      gt0012|Estimated Glomerular Filtration Rate: 44,ml/min
+      gt0064|Event time: 2019-04-29T20:40Z
+      gt0016|Urine microalbumin: 30,mg/dl
+      gt0017|Urine albumin:creatinine ratio: 31,mg/gm
+      gt0065|Event time: 2019-04-22T20:41Z
+      gt0055|Diabetes Mellitus: 1|local::at0008|Yes|
+      gt0056|Congestive Heart Failure: 1|local::at0010|Yes|
+      gt0057|Hypertension: 1|local::at0012|Yes|
+      gt0062|Stroke/cerebrovascular accident: 1|local::at0036|Yes|
+      gt0066|Event time: 2019-04-29T20:18Z
+  expected_output:
+    1:
+      gt0053|History of stroke: 1|local::at0033|Yes|
+      gt0022|History of diabetes mellitus: 1|local::at0031|Yes|
+      gt0024|History of hypertension: 1|local::at0027|Yes|
+      gt0026|eGFR: 1|local::at0023|eGFR <45|
+      gt0025|Proteinuria: 1|local::at0025|Yes|
+      gt0021|Sex: 1|local::at0021|Female|
+      gt0027|ATRIA stroke risk score: 13
+      gt0020|Age: 7|local::at0017|Age 65-84 years with a history of stroke.|
+      gt0023|History of congestive heart failure: 1|local::at0029|Yes|
+
+- id: same but GFR and microalbumin fine
+  input:
+    1:
+      gt0010|Birthdate: 1944-04-15T20:14Z
+      gt0011|Gender: local::at0006|Female|
+      gt0063|Event time: 2019-04-29T20:14Z
+      gt0012|Estimated Glomerular Filtration Rate: 47,ml/min
+      gt0064|Event time: 2019-04-29T20:40Z
+      gt0016|Urine microalbumin: 28,mg/dl
+      gt0017|Urine albumin:creatinine ratio: 31,mg/gm
+      gt0065|Event time: 2019-04-22T20:41Z
+      gt0055|Diabetes Mellitus: 1|local::at0008|Yes|
+      gt0056|Congestive Heart Failure: 1|local::at0010|Yes|
+      gt0057|Hypertension: 1|local::at0012|Yes|
+      gt0062|Stroke/cerebrovascular accident: 1|local::at0036|Yes|
+      gt0066|Event time: 2019-04-29T20:18Z
+  expected_output:
+    1:
+      gt0053|History of stroke: 1|local::at0033|Yes|
+      gt0022|History of diabetes mellitus: 1|local::at0031|Yes|
+      gt0024|History of hypertension: 1|local::at0027|Yes|
+      gt0026|eGFR: 0|local::at0022|eGFR ≥45|
+      gt0025|Proteinuria: 1|local::at0025|Yes|
+      gt0021|Sex: 1|local::at0021|Female|
+      gt0027|ATRIA stroke risk score: 12
+      gt0020|Age: 7|local::at0017|Age 65-84 years with a history of stroke.|
+      gt0023|History of congestive heart failure: 1|local::at0029|Yes|
+
+- id: no diabetes, normal albumin creatinine ratio
+  input:
+    1:
+      gt0010|Birthdate: 1944-04-15T20:14Z
+      gt0011|Gender: local::at0006|Female|
+      gt0063|Event time: 2019-04-29T20:14Z
+      gt0012|Estimated Glomerular Filtration Rate: 47,ml/min
+      gt0064|Event time: 2019-04-29T20:40Z
+      gt0016|Urine microalbumin: 28,mg/dl
+      gt0017|Urine albumin:creatinine ratio: 26,mg/gm
+      gt0065|Event time: 2019-04-22T20:41Z
+      gt0055|Diabetes Mellitus: 0|local::at0007|No|
+      gt0056|Congestive Heart Failure: 1|local::at0010|Yes|
+      gt0057|Hypertension: 1|local::at0012|Yes|
+      gt0062|Stroke/cerebrovascular accident: 1|local::at0036|Yes|
+      gt0066|Event time: 2019-04-29T20:18Z
+  expected_output:
+    1:
+      gt0053|History of stroke: 1|local::at0033|Yes|
+      gt0022|History of diabetes mellitus: 0|local::at0030|No|
+      gt0024|History of hypertension: 1|local::at0027|Yes|
+      gt0026|eGFR: 0|local::at0022|eGFR ≥45|
+      gt0025|Proteinuria: 0|local::at0024|No|
+      gt0021|Sex: 1|local::at0021|Female|
+      gt0027|ATRIA stroke risk score: 10
+      gt0020|Age: 7|local::at0017|Age 65-84 years with a history of stroke.|
+      gt0023|History of congestive heart failure: 1|local::at0029|Yes|
+
+- id: old female with only hypertension
+  input:
+    1:
+      gt0010|Birthdate: 1944-04-15T20:14Z
+      gt0011|Gender: local::at0006|Female|
+      gt0063|Event time: 2019-04-29T20:14Z
+      gt0012|Estimated Glomerular Filtration Rate: 47,ml/min
+      gt0064|Event time: 2019-04-29T20:40Z
+      gt0016|Urine microalbumin: 28,mg/dl
+      gt0017|Urine albumin:creatinine ratio: 26,mg/gm
+      gt0065|Event time: 2019-04-22T20:41Z
+      gt0055|Diabetes Mellitus: 0|local::at0007|No|
+      gt0056|Congestive Heart Failure: 0|local::at0009|No|
+      gt0057|Hypertension: 1|local::at0012|Yes|
+      gt0062|Stroke/cerebrovascular accident: 0|local::at0035|No|
+      gt0066|Event time: 2019-04-29T20:18Z
+  expected_output:
+    1:
+      gt0053|History of stroke: 0|local::at0032|No|
+      gt0022|History of diabetes mellitus: 0|local::at0030|No|
+      gt0024|History of hypertension: 1|local::at0027|Yes|
+      gt0026|eGFR: 0|local::at0022|eGFR ≥45|
+      gt0025|Proteinuria: 0|local::at0024|No|
+      gt0021|Sex: 1|local::at0021|Female|
+      gt0027|ATRIA stroke risk score: 7
+      gt0020|Age: 5|local::at0015|Age 75-84 years with no history of stroke.|
+      gt0023|History of congestive heart failure: 0|local::at0028|No|
+
+- id: above 75 male, no prev stroke
+  input:
+    1:
+      gt0010|Birthdate: 1944-04-15T20:14Z
+      gt0011|Gender: local::at0005|Male|
+      gt0063|Event time: 2019-04-29T20:14Z
+      gt0012|Estimated Glomerular Filtration Rate: 47,ml/min
+      gt0064|Event time: 2019-04-29T20:40Z
+      gt0016|Urine microalbumin: 28,mg/dl
+      gt0017|Urine albumin:creatinine ratio: 26,mg/gm
+      gt0065|Event time: 2019-04-22T20:41Z
+      gt0055|Diabetes Mellitus: 0|local::at0007|No|
+      gt0056|Congestive Heart Failure: 1|local::at0010|Yes|
+      gt0057|Hypertension: 0|local::at0011|No|
+      gt0062|Stroke/cerebrovascular accident: 0|local::at0035|No|
+      gt0066|Event time: 2019-04-29T20:18Z
+  expected_output:
+    1:
+      gt0053|History of stroke: 0|local::at0032|No|
+      gt0022|History of diabetes mellitus: 0|local::at0030|No|
+      gt0024|History of hypertension: 0|local::at0026|No|
+      gt0026|eGFR: 0|local::at0022|eGFR ≥45|
+      gt0025|Proteinuria: 0|local::at0024|No|
+      gt0021|Sex: 0|local::at0020|Male|
+      gt0027|ATRIA stroke risk score: 6
+      gt0020|Age: 5|local::at0015|Age 75-84 years with no history of stroke.|
+      gt0023|History of congestive heart failure: 1|local::at0029|Yes|
+
+- id: above 75 male with history of stroke
+  input:
+    1:
+      gt0010|Birthdate: 1944-04-15T20:14Z
+      gt0011|Gender: local::at0005|Male|
+      gt0063|Event time: 2019-04-29T20:14Z
+      gt0012|Estimated Glomerular Filtration Rate: 47,ml/min
+      gt0064|Event time: 2019-04-29T20:40Z
+      gt0016|Urine microalbumin: 28,mg/dl
+      gt0017|Urine albumin:creatinine ratio: 26,mg/gm
+      gt0065|Event time: 2019-04-22T20:41Z
+      gt0055|Diabetes Mellitus: 0|local::at0007|No|
+      gt0056|Congestive Heart Failure: 1|local::at0010|Yes|
+      gt0057|Hypertension: 0|local::at0011|No|
+      gt0062|Stroke/cerebrovascular accident: 1|local::at0036|Yes|
+      gt0066|Event time: 2019-04-29T20:18Z
+  expected_output:
+    1:
+      gt0053|History of stroke: 1|local::at0033|Yes|
+      gt0022|History of diabetes mellitus: 0|local::at0030|No|
+      gt0024|History of hypertension: 0|local::at0026|No|
+      gt0026|eGFR: 0|local::at0022|eGFR ≥45|
+      gt0025|Proteinuria: 0|local::at0024|No|
+      gt0021|Sex: 0|local::at0020|Male|
+      gt0027|ATRIA stroke risk score: 8
+      gt0020|Age: 7|local::at0017|Age 65-84 years with a history of stroke.|
+      gt0023|History of congestive heart failure: 1|local::at0029|Yes|
+
+- id: 64 year old with stroke history
+  input:
+    1:
+      gt0010|Birthdate: 1955-04-15T20:14Z
+      gt0011|Gender: local::at0005|Male|
+      gt0063|Event time: 2019-04-29T20:14Z
+      gt0012|Estimated Glomerular Filtration Rate: 47,ml/min
+      gt0064|Event time: 2019-04-29T20:40Z
+      gt0016|Urine microalbumin: 28,mg/dl
+      gt0017|Urine albumin:creatinine ratio: 26,mg/gm
+      gt0065|Event time: 2019-04-22T20:41Z
+      gt0055|Diabetes Mellitus: 0|local::at0007|No|
+      gt0056|Congestive Heart Failure: 1|local::at0010|Yes|
+      gt0057|Hypertension: 0|local::at0011|No|
+      gt0062|Stroke/cerebrovascular accident: 1|local::at0036|Yes|
+      gt0066|Event time: 2019-04-29T20:18Z
+  expected_output:
+    1:
+      gt0053|History of stroke: 1|local::at0033|Yes|
+      gt0022|History of diabetes mellitus: 0|local::at0030|No|
+      gt0024|History of hypertension: 0|local::at0026|No|
+      gt0026|eGFR: 0|local::at0022|eGFR ≥45|
+      gt0025|Proteinuria: 0|local::at0024|No|
+      gt0021|Sex: 0|local::at0020|Male|
+      gt0027|ATRIA stroke risk score: 8
+      gt0020|Age: 7|local::at0017|Age 65-84 years with a history of stroke.|
+      gt0023|History of congestive heart failure: 1|local::at0029|Yes|
+
+- id: Almost 65 yrs old
+  input:
+    1:
+      gt0010|Birthdate: 1954-04-30T20:14Z
+      gt0011|Gender: local::at0005|Male|
+      gt0063|Event time: 2019-04-29T20:14Z
+      gt0012|Estimated Glomerular Filtration Rate: 47,ml/min
+      gt0064|Event time: 2019-04-29T20:40Z
+      gt0016|Urine microalbumin: 28,mg/dl
+      gt0017|Urine albumin:creatinine ratio: 26,mg/gm
+      gt0065|Event time: 2019-04-22T20:41Z
+      gt0055|Diabetes Mellitus: 0|local::at0007|No|
+      gt0056|Congestive Heart Failure: 1|local::at0010|Yes|
+      gt0057|Hypertension: 0|local::at0011|No|
+      gt0062|Stroke/cerebrovascular accident: 1|local::at0036|Yes|
+      gt0066|Event time: 2019-04-29T20:18Z
+  expected_output:
+    1:
+      gt0053|History of stroke: 1|local::at0033|Yes|
+      gt0022|History of diabetes mellitus: 0|local::at0030|No|
+      gt0024|History of hypertension: 0|local::at0026|No|
+      gt0026|eGFR: 0|local::at0022|eGFR ≥45|
+      gt0025|Proteinuria: 0|local::at0024|No|
+      gt0021|Sex: 0|local::at0020|Male|
+      gt0027|ATRIA stroke risk score: 8
+      gt0020|Age: 7|local::at0017|Age 65-84 years with a history of stroke.|
+      gt0023|History of congestive heart failure: 1|local::at0029|Yes|
+
+- id: 66 yrs old with CHF and history of stroke
+  input:
+    1:
+      gt0010|Birthdate: 1952-04-30T20:14Z
+      gt0011|Gender: local::at0005|Male|
+      gt0063|Event time: 2019-04-29T20:14Z
+      gt0012|Estimated Glomerular Filtration Rate: 47,ml/min
+      gt0064|Event time: 2019-04-29T20:40Z
+      gt0016|Urine microalbumin: 28,mg/dl
+      gt0017|Urine albumin:creatinine ratio: 26,mg/gm
+      gt0065|Event time: 2019-04-22T20:41Z
+      gt0055|Diabetes Mellitus: 0|local::at0007|No|
+      gt0056|Congestive Heart Failure: 1|local::at0010|Yes|
+      gt0057|Hypertension: 0|local::at0011|No|
+      gt0062|Stroke/cerebrovascular accident: 1|local::at0036|Yes|
+      gt0066|Event time: 2019-04-29T20:18Z
+  expected_output:
+    1:
+      gt0053|History of stroke: 1|local::at0033|Yes|
+      gt0022|History of diabetes mellitus: 0|local::at0030|No|
+      gt0024|History of hypertension: 0|local::at0026|No|
+      gt0026|eGFR: 0|local::at0022|eGFR ≥45|
+      gt0025|Proteinuria: 0|local::at0024|No|
+      gt0021|Sex: 0|local::at0020|Male|
+      gt0027|ATRIA stroke risk score: 8
+      gt0020|Age: 7|local::at0017|Age 65-84 years with a history of stroke.|
+      gt0023|History of congestive heart failure: 1|local::at0029|Yes|

--- a/gdl2/ATRIA_stroke_risk_score_Calculation.v2.gdl2.json
+++ b/gdl2/ATRIA_stroke_risk_score_Calculation.v2.gdl2.json
@@ -1,0 +1,849 @@
+{
+  "id": "ATRIA_stroke_risk_score_Calculation.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2016-11-30",
+      "name": "Eneimi Allwell-Brown",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "other_contributors": [
+      "Dennis Forslund",
+      "Jimmy Axelsson"
+    ],
+    "lifecycle_state": "Author draft",
+    "details": {
+      "sv": {
+        "id": "sv",
+        "purpose": "Beräkna poäng i enlighet med ATRIA stroke risk score. Instrumentet baseras på åtta faktorer; tidigare stroke, ålder, kön, komorbiditet, proteinuri och eGFR < 45ml/min (alt terminal njursvikt). Instrumentet är validerat, och används för uppskattning av strokerisk och som riktlinje för optimal behandling med antikoagulantia hos patienter med förmaksflimmer. \r\n",
+        "keywords": [
+          "förmaksflimmer",
+          "stroke",
+          "ATRIA"
+        ],
+        "use": "Beräkna poäng i enlighet med ATRIA stroke risk score, baserat på följande faktorer;\r\n - förekomst av diabetes mellitus, hjärtsvikt, hypertoni, proteinuri (U-albumin ≥30 mg/dl eller U-albumin:kreatinin-kvot ≥30 mg/g), eGFR < 45ml/min (eller terminal njursvikt) = 1 poäng vardera, och 0p om ej föreliggande;\r\n - kvinnligt kön = 1 poäng, och 0p om manligt; \r\n - ålder <65 år (utan tidigare stroke = 0p, med tidigare stroke = 8p), 65-74 år (utan tidigare stroke = 3p, med tidigare stroke = 7p), 75-84 år (utan tidigare stroke = 5p, med tidigare stroke = 7 p), ≥85 år (utan tidigare stroke = 6p, med tidigare stroke = 9p).",
+        "misuse": "Endast avsedd för patienter med diagnosticerat förmaksflimmer.",
+        "copyright": "© Cambio Healthcare Systems"
+      },
+      "en": {
+        "id": "en",
+        "purpose": "Calculates ATRIA stroke risk score based on the following assessed variables: prior stroke, age, sex, comorbidities (diabetes mellitus, congestive heart failure, hypertension), proteinuria, and eGFR <45ml/min (or ESRD - end stage renal disease). ATRIA stroke risk score has been validated as performing better than the CHADS2 and CHA2DS2-VASc risk models and provides more accurate and reliable stroke risk/thromboembolism prediction, as well as guides optimal anticoagulation decision-making, in individuals with atrial fibrillation.",
+        "keywords": [
+          "atrial fibrillation",
+          "stroke risk",
+          "thromboembolism risk"
+        ],
+        "use": "To calculate ATRIA stroke risk score based on:\n - presence of diabetes mellitus, congestive heart failure, hypertension, proteinuria (urinary albumin >=30 mg/dl OR urinary abumin:cratinine ratio >=30 mg/g), eGFR < 45ml/min (or ESRD) = 1 point each, and 0 if absent;\n - female sex = 1 point, and 0 if male; \n - age <65 years (with no prior stroke = 0, with prior stroke = 8 points), 65-74 years (with no prior stroke = 3, with prior stroke = 7 points), 75-84 years (with no prior stroke = 5, with prior stroke = 7 points), >=85 years (with no prior stroke = 6, with prior stroke = 9 points).\nThe ATRIA stroke risk score is further used in evaluating the 1-year risk of stroke or other thromboembolic event.",
+        "misuse": "Do not use this calculator if the individual does not have atrial fibrillation.",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Singer DE, Chang Y, Borowsky LH, Fang MC, Pomernacki NK, Udaltsova N, Reynolds K, Go AS. A new risk scheme to predict ischemic stroke and other thromboembolism in atrial fibrillation: the ATRIA study stroke risk score. Journal of the American Heart Association. 2013 Jun 18;2(3):e000250.\r\n\r\nhttp://www.mdcalc.com/atria-stroke-risk-score/"
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0003": {
+        "id": "gt0003",
+        "model_id": "openEHR-EHR-OBSERVATION.basic_demographic.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.basic_demographic.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0010": {
+            "id": "gt0010",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0008]"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0004]"
+          },
+          "gt0063": {
+            "id": "gt0063",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0006": {
+        "id": "gt0006",
+        "model_id": "openEHR-EHR-OBSERVATION.estimated_glomerular_filtration_rate.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.estimated_glomerular_filtration_rate.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0012": {
+            "id": "gt0012",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0004]"
+          },
+          "gt0064": {
+            "id": "gt0064",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0008": {
+        "id": "gt0008",
+        "model_id": "openEHR-EHR-OBSERVATION.atria_stroke_risk_score.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.atria_stroke_risk_score.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0020": {
+            "id": "gt0020",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0005]"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0006]"
+          },
+          "gt0022": {
+            "id": "gt0022",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0007]"
+          },
+          "gt0023": {
+            "id": "gt0023",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0008]"
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0009]"
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0010]"
+          },
+          "gt0026": {
+            "id": "gt0026",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0011]"
+          },
+          "gt0027": {
+            "id": "gt0027",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0012]"
+          },
+          "gt0053": {
+            "id": "gt0053",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0004]"
+          }
+        }
+      },
+      "gt0015": {
+        "id": "gt0015",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-microalbumin.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-microalbumin.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0016": {
+            "id": "gt0016",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.3]"
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.1]"
+          },
+          "gt0065": {
+            "id": "gt0065",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0054": {
+        "id": "gt0054",
+        "model_id": "openEHR-EHR-OBSERVATION.history_prior_medical_diagnosis.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.history_prior_medical_diagnosis.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0055": {
+            "id": "gt0055",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0021]/items[at0004]"
+          },
+          "gt0056": {
+            "id": "gt0056",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0019]/items[at0005]"
+          },
+          "gt0057": {
+            "id": "gt0057",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0019]/items[at0006]"
+          },
+          "gt0062": {
+            "id": "gt0062",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0019]/items[at0031]"
+          },
+          "gt0066": {
+            "id": "gt0066",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      }
+    },
+    "rules": {
+      "gt0036": {
+        "id": "gt0036",
+        "priority": 16,
+        "when": [
+          "$gt0053|History of stroke|==null",
+          "$gt0020|Age|==null",
+          "$gt0021|Sex|==null",
+          "$gt0022|History of diabetes mellitus|==null",
+          "$gt0023|History of congestive heart failure|==null",
+          "$gt0024|History of hypertension|==null",
+          "$gt0025|Proteinuria|==null",
+          "$gt0026|eGFR|==null"
+        ],
+        "then": [
+          "$gt0026|eGFR|=0|local::at0022|eGFR ≥45|",
+          "$gt0025|Proteinuria|=0|local::at0024|No|",
+          "$gt0024|History of hypertension|=0|local::at0026|No|",
+          "$gt0023|History of congestive heart failure|=0|local::at0028|No|",
+          "$gt0022|History of diabetes mellitus|=0|local::at0030|No|",
+          "$gt0021|Sex|=0|local::at0020|Male|",
+          "$gt0020|Age|=0|local::at0013|Age <65 years with no history of stroke.|",
+          "$gt0053|History of stroke|=0|local::at0032|No|"
+        ]
+      },
+      "gt0038": {
+        "id": "gt0038",
+        "priority": 15,
+        "when": [
+          "$gt0062|Stroke/cerebrovascular accident|==1|local::at0036|Yes|"
+        ],
+        "then": [
+          "$gt0053|History of stroke|=1|local::at0033|Yes|"
+        ]
+      },
+      "gt0039": {
+        "id": "gt0039",
+        "priority": 14,
+        "when": [
+          "$gt0062|Stroke/cerebrovascular accident|==0|local::at0035|No|",
+          "$gt0010|Birthdate|>($currentDateTime-65,a)"
+        ],
+        "then": [
+          "$gt0020|Age|=0|local::at0013|Age <65 years with no history of stroke.|"
+        ]
+      },
+      "gt0049": {
+        "id": "gt0049",
+        "priority": 13,
+        "when": [
+          "$gt0062|Stroke/cerebrovascular accident|==1|local::at0036|Yes|",
+          "$gt0010|Birthdate|>($currentDateTime-65,a)"
+        ],
+        "then": [
+          "$gt0020|Age|=8|local::at0018|Age <65 years with a history of stroke.|"
+        ]
+      },
+      "gt0046": {
+        "id": "gt0046",
+        "priority": 12,
+        "when": [
+          "$gt0062|Stroke/cerebrovascular accident|==0|local::at0035|No|",
+          "$gt0010|Birthdate|<$currentDateTime-65,a",
+          "$gt0010|Birthdate|>=$currentDateTime-75,a"
+        ],
+        "then": [
+          "$gt0020|Age|=3|local::at0014|Age 65-74 years with no history of stroke.|"
+        ]
+      },
+      "gt0050": {
+        "id": "gt0050",
+        "priority": 11,
+        "when": [
+          "$gt0062|Stroke/cerebrovascular accident|==1|local::at0036|Yes|",
+          "$gt0010|Birthdate|<$currentDateTime-65,a",
+          "$gt0010|Birthdate|>=$currentDateTime-85,a"
+        ],
+        "then": [
+          "$gt0020|Age|=7|local::at0017|Age 65-84 years with a history of stroke.|"
+        ]
+      },
+      "gt0047": {
+        "id": "gt0047",
+        "priority": 10,
+        "when": [
+          "$gt0062|Stroke/cerebrovascular accident|==0|local::at0035|No|",
+          "$gt0010|Birthdate|<$currentDateTime-75,a",
+          "$gt0010|Birthdate|>=$currentDateTime-85,a"
+        ],
+        "then": [
+          "$gt0020|Age|=5|local::at0015|Age 75-84 years with no history of stroke.|"
+        ]
+      },
+      "gt0048": {
+        "id": "gt0048",
+        "priority": 9,
+        "when": [
+          "$gt0062|Stroke/cerebrovascular accident|==0|local::at0035|No|",
+          "$gt0010|Birthdate|<=($currentDateTime-85,a)"
+        ],
+        "then": [
+          "$gt0020|Age|=6|local::at0016|Age ≥85 years with no history of stroke.|"
+        ]
+      },
+      "gt0052": {
+        "id": "gt0052",
+        "priority": 8,
+        "when": [
+          "$gt0062|Stroke/cerebrovascular accident|==1|local::at0036|Yes|",
+          "$gt0010|Birthdate|<=($currentDateTime-85,a)"
+        ],
+        "then": [
+          "$gt0020|Age|=9|local::at0019|Age ≥85 years with a history of stroke.|"
+        ]
+      },
+      "gt0040": {
+        "id": "gt0040",
+        "priority": 7,
+        "when": [
+          "$gt0011|Gender|==local::at0006|Female|"
+        ],
+        "then": [
+          "$gt0021|Sex|=1|local::at0021|Female|"
+        ]
+      },
+      "gt0044": {
+        "id": "gt0044",
+        "priority": 6,
+        "when": [
+          "($gt0016|Urine microalbumin|>=30,mg/dl)||($gt0017|Urine albumin:creatinine ratio|>=30,mg/gm)"
+        ],
+        "then": [
+          "$gt0025|Proteinuria|=1|local::at0025|Yes|"
+        ]
+      },
+      "gt0045": {
+        "id": "gt0045",
+        "priority": 5,
+        "when": [
+          "$gt0012|Estimated Glomerular Filtration Rate|<45,ml/min"
+        ],
+        "then": [
+          "$gt0026|eGFR|=1|local::at0023|eGFR <45|"
+        ]
+      },
+      "gt0058": {
+        "id": "gt0058",
+        "priority": 4,
+        "when": [
+          "$gt0055|Diabetes Mellitus|==1|local::at0008|Yes|"
+        ],
+        "then": [
+          "$gt0022|History of diabetes mellitus|=1|local::at0031|Yes|"
+        ]
+      },
+      "gt0059": {
+        "id": "gt0059",
+        "priority": 3,
+        "when": [
+          "$gt0056|Congestive Heart Failure|==1|local::at0010|Yes|"
+        ],
+        "then": [
+          "$gt0023|History of congestive heart failure|=1|local::at0029|Yes|"
+        ]
+      },
+      "gt0060": {
+        "id": "gt0060",
+        "priority": 2,
+        "when": [
+          "$gt0057|Hypertension|==1|local::at0012|Yes|"
+        ],
+        "then": [
+          "$gt0024|History of hypertension|=1|local::at0027|Yes|"
+        ]
+      },
+      "gt0037": {
+        "id": "gt0037",
+        "priority": 1,
+        "then": [
+          "$gt0027|ATRIA stroke risk score|.magnitude=((((($gt0021.value+$gt0022.value)+$gt0023.value)+$gt0024.value)+$gt0020.value)+$gt0025.value)+$gt0026.value"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "sv": {
+        "id": "sv",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "ATRIA stroke risk score calculator",
+            "description": "ATRIA (anticoagulation and risk factors in atrial fibrillation) stroke risk score används för att uppskatta strokerisk hos patienter med förmaksflimmer. Instrumentet baseras på ett antal kända riskfaktorer: tidigare stroke, ålder, kön, komorbiditet, proteinuri och eGFR < 45ml/min (alt terminal njursvikt). Poängen uppgår till maximalt 15p. En poäng om 0-5 indikerar mindre än 1%, 6p 1->2% och >6p >2% risk för stroke. "
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Tidigare stroke/TIA",
+            "description": "*(en) Has the individual ever suffered a stroke or transient ischaemic attack?"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Födelsedatum",
+            "description": "*(en) *"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Kön",
+            "description": "*(en) *"
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "eGFR",
+            "description": "*(en) Value describing estimation of glomerular filtration rate adjusted by body-surface area (mL/min/1.73m²)."
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "U-albumin",
+            "description": "*(en) Microalbumin level in this specimen."
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "text": "U-albumin/kreatinin-kvot",
+            "description": "*(en) Ratio of albumin and creatinine in this specimen."
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "text": "Tidigare stroke",
+            "description": "*(en) Has this individual ever suffered a stroke? Yes = true, No = false."
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "Ålder",
+            "description": "*(en) What is the age and has the individual ever had a prior stroke?"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "text": "Kön",
+            "description": "*(en) Is the individual male or female?"
+          },
+          "gt0022": {
+            "id": "gt0022",
+            "text": "Diabetes mellitus",
+            "description": "*(en) Does the individual have a history of diabetes mellitus?"
+          },
+          "gt0023": {
+            "id": "gt0023",
+            "text": "Hjärtsvikt",
+            "description": "*(en) Does the individual have a history of congestive heart failure?"
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "text": "Hypertoni",
+            "description": "*(en) Does the individual have a history of hypertension?"
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "text": "Proteinuri",
+            "description": "*(en) Does the individual have proteinuria?"
+          },
+          "gt0026": {
+            "id": "gt0026",
+            "text": "eGFR",
+            "description": "*(en) The estimated glomerular filtration rate (based on MDRD equation) or presence of end-stage renal disease (ESRD)."
+          },
+          "gt0027": {
+            "id": "gt0027",
+            "text": "ATRIA stroke risk score",
+            "description": "*(en) Total number of points assigned based on the presence or absence of the 8 predictor variables."
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "text": "Diabetes Mellitus Diagnos",
+            "description": "*(en) The index diagnosis"
+          },
+          "gt0031": {
+            "id": "gt0031",
+            "text": "Hjärtsvikt diagnos",
+            "description": "*(en) The index diagnosis"
+          },
+          "gt0033": {
+            "id": "gt0033",
+            "text": "Hypertoni diagnos",
+            "description": "*(en) The index diagnosis"
+          },
+          "gt0035": {
+            "id": "gt0035",
+            "text": "Stroke Diagnos",
+            "description": "*(en) The index diagnosis"
+          },
+          "gt0036": {
+            "id": "gt0036",
+            "text": "Standard"
+          },
+          "gt0037": {
+            "id": "gt0037",
+            "text": "Beräkna ATRIA stroke risk score"
+          },
+          "gt0038": {
+            "id": "gt0038",
+            "text": "CDS stroke "
+          },
+          "gt0039": {
+            "id": "gt0039",
+            "text": "CDS ålder <65 utan tidigare stroke"
+          },
+          "gt0040": {
+            "id": "gt0040",
+            "text": "CDS kön"
+          },
+          "gt0041": {
+            "id": "gt0041",
+            "text": "CDS Diabetes Mellitus"
+          },
+          "gt0042": {
+            "id": "gt0042",
+            "text": "CDS hjärtsvikt"
+          },
+          "gt0043": {
+            "id": "gt0043",
+            "text": "CDS Hypertoni"
+          },
+          "gt0044": {
+            "id": "gt0044",
+            "text": "CDS proteinuri"
+          },
+          "gt0045": {
+            "id": "gt0045",
+            "text": "CDS eGFR "
+          },
+          "gt0046": {
+            "id": "gt0046",
+            "text": "CDS ålder 65-84 utan tidigare stroke"
+          },
+          "gt0047": {
+            "id": "gt0047",
+            "text": "CDS ålder 75-84 med tidigare stroke"
+          },
+          "gt0048": {
+            "id": "gt0048",
+            "text": "CDS ålder >=85 utan tidigare stroke"
+          },
+          "gt0049": {
+            "id": "gt0049",
+            "text": "CDS ålder <65 med tidigare stroke"
+          },
+          "gt0050": {
+            "id": "gt0050",
+            "text": "CDS ålder 65-84 rule med tidigare stroke"
+          },
+          "gt0051": {
+            "id": "gt0051",
+            "text": "CDS ålder 74-84 med tidigare stroke"
+          },
+          "gt0052": {
+            "id": "gt0052",
+            "text": "CDS ålder >=85 med tidigare stroke"
+          },
+          "gt0053": {
+            "id": "gt0053",
+            "text": "Tidigare stroke"
+          },
+          "gt0055": {
+            "id": "gt0055",
+            "text": "Diabetes Mellitus",
+            "description": "*(en) Has the individual ever been diagnosed with Diabetes Mellitus?"
+          },
+          "gt0056": {
+            "id": "gt0056",
+            "text": "Hjärtsvikt",
+            "description": "*(en) Has the individual ever been diagnosed with Congestive Heart Failure?"
+          },
+          "gt0057": {
+            "id": "gt0057",
+            "text": "Hypertoni",
+            "description": "*(en) Has the individual ever been diagnosed with Hypertension?"
+          },
+          "gt0058": {
+            "id": "gt0058",
+            "text": "CDS diabetes mellitus"
+          },
+          "gt0059": {
+            "id": "gt0059",
+            "text": "CDS hjärtsvikt"
+          },
+          "gt0060": {
+            "id": "gt0060",
+            "text": "CDS hypertoni"
+          },
+          "gt0061": {
+            "id": "gt0061",
+            "text": "Diabetes Mellitus",
+            "description": "*(en) Has the individual ever been diagnosed with Diabetes Mellitus?"
+          },
+          "gt0062": {
+            "id": "gt0062",
+            "text": "Stroke/cerebrovaskulär händelse",
+            "description": "*(en) Has the individual ever been diagnosed with a stroke/cerebrovascular accident?"
+          },
+          "gt0063": {
+            "id": "gt0063",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0064": {
+            "id": "gt0064",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0065": {
+            "id": "gt0065",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0066": {
+            "id": "gt0066",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      },
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "ATRIA stroke risk score calculator",
+            "description": "ATRIA (anticoagulation and risk factors in atrial fibrillation) stroke risk score is used to determine the risk of stroke in patients with atrial fibrillation. It is the sum of points assigned for the presence (or absence) of certain risk factors: previous stroke, age, sex, comorbidities (diabetes, congestive heart failure, hypertension), proteinuria, and eGFR < 45ml/min (or end stage renal disease) in the patient. The ATRIA stroke risk score takes a value between 0 - 15, and it is from this score that ATRIA stroke risk is predicted. A score between 0 - 5 predicts a risk of ischaemic stroke/TE less than 1%; a score of 6 predicts 1 - <2% risk; and a score >6 predicts ≥2% risk."
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Prior stroke/TIA",
+            "description": "Has the individual ever suffered a stroke or transient ischaemic attack?"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Birthdate",
+            "description": "*"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Gender",
+            "description": "*"
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "Estimated Glomerular Filtration Rate",
+            "description": "Value describing estimation of glomerular filtration rate adjusted by body-surface area (mL/min/1.73m²)."
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "Urine microalbumin",
+            "description": "Microalbumin level in this specimen."
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "text": "Urine albumin:creatinine ratio",
+            "description": "Ratio of albumin and creatinine in this specimen."
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "text": "History of stroke",
+            "description": "Has this individual ever suffered a stroke? Yes = true, No = false."
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "Age",
+            "description": "What is the age and has the individual ever had a prior stroke?"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "text": "Sex",
+            "description": "Is the individual male or female?"
+          },
+          "gt0022": {
+            "id": "gt0022",
+            "text": "History of diabetes mellitus",
+            "description": "Does the individual have a history of diabetes mellitus?"
+          },
+          "gt0023": {
+            "id": "gt0023",
+            "text": "History of congestive heart failure",
+            "description": "Does the individual have a history of congestive heart failure?"
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "text": "History of hypertension",
+            "description": "Does the individual have a history of hypertension?"
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "text": "Proteinuria",
+            "description": "Does the individual have proteinuria?"
+          },
+          "gt0026": {
+            "id": "gt0026",
+            "text": "eGFR",
+            "description": "The estimated glomerular filtration rate (based on MDRD equation) or presence of end-stage renal disease (ESRD)."
+          },
+          "gt0027": {
+            "id": "gt0027",
+            "text": "ATRIA stroke risk score",
+            "description": "Total number of points assigned based on the presence or absence of the 8 predictor variables."
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "text": "Diabetes Mellitus Diagnosis",
+            "description": "The index diagnosis"
+          },
+          "gt0031": {
+            "id": "gt0031",
+            "text": "Congestive Heart Failure Diagnosis",
+            "description": "The index diagnosis"
+          },
+          "gt0033": {
+            "id": "gt0033",
+            "text": "Hypertension Diagnosis",
+            "description": "The index diagnosis"
+          },
+          "gt0035": {
+            "id": "gt0035",
+            "text": "Stroke Diagnosis",
+            "description": "The index diagnosis"
+          },
+          "gt0036": {
+            "id": "gt0036",
+            "text": "Set defaults"
+          },
+          "gt0037": {
+            "id": "gt0037",
+            "text": "Calculate ATRIA stroke risk score"
+          },
+          "gt0038": {
+            "id": "gt0038",
+            "text": "Set CDS stroke rule"
+          },
+          "gt0039": {
+            "id": "gt0039",
+            "text": "Set CDS Age <65 rule with stroke history absent"
+          },
+          "gt0040": {
+            "id": "gt0040",
+            "text": "Set CDS Sex rule"
+          },
+          "gt0041": {
+            "id": "gt0041",
+            "text": "Set CDS Diabetes Mellitus rule"
+          },
+          "gt0042": {
+            "id": "gt0042",
+            "text": "Set CDS Congestive Heart Failure rule"
+          },
+          "gt0043": {
+            "id": "gt0043",
+            "text": "Set CDS Hypertension rule"
+          },
+          "gt0044": {
+            "id": "gt0044",
+            "text": "Set CDS Proteinuria rule"
+          },
+          "gt0045": {
+            "id": "gt0045",
+            "text": "Set CDS eGFR rule"
+          },
+          "gt0046": {
+            "id": "gt0046",
+            "text": "Set CDS Age 65-74 rule with stroke history absent"
+          },
+          "gt0047": {
+            "id": "gt0047",
+            "text": "Set CDS Age 75-84 rule with stroke history absent"
+          },
+          "gt0048": {
+            "id": "gt0048",
+            "text": "Set CDS Age >=85 rule with stroke history absent"
+          },
+          "gt0049": {
+            "id": "gt0049",
+            "text": "Set CDS Age <65 rule with stroke history present"
+          },
+          "gt0050": {
+            "id": "gt0050",
+            "text": "Set CDS Age 65-84 rule with stroke history present"
+          },
+          "gt0051": {
+            "id": "gt0051",
+            "text": "Set CDS Age 74-84 rule with stroke history present"
+          },
+          "gt0052": {
+            "id": "gt0052",
+            "text": "Set CDS Age >=85 rule with stroke history present"
+          },
+          "gt0053": {
+            "id": "gt0053",
+            "text": "History of stroke"
+          },
+          "gt0055": {
+            "id": "gt0055",
+            "text": "Diabetes Mellitus",
+            "description": "Has the individual ever been diagnosed with Diabetes Mellitus?"
+          },
+          "gt0056": {
+            "id": "gt0056",
+            "text": "Congestive Heart Failure",
+            "description": "Has the individual ever been diagnosed with Congestive Heart Failure?"
+          },
+          "gt0057": {
+            "id": "gt0057",
+            "text": "Hypertension",
+            "description": "Has the individual ever been diagnosed with Hypertension?"
+          },
+          "gt0058": {
+            "id": "gt0058",
+            "text": "Set history of diabetes mellitus"
+          },
+          "gt0059": {
+            "id": "gt0059",
+            "text": "Set history of congestive heart failure"
+          },
+          "gt0060": {
+            "id": "gt0060",
+            "text": "Set history of hypertension"
+          },
+          "gt0061": {
+            "id": "gt0061",
+            "text": "Diabetes Mellitus",
+            "description": "Has the individual ever been diagnosed with Diabetes Mellitus?"
+          },
+          "gt0062": {
+            "id": "gt0062",
+            "text": "Stroke/cerebrovascular accident",
+            "description": "Has the individual ever been diagnosed with a stroke/cerebrovascular accident?"
+          },
+          "gt0063": {
+            "id": "gt0063",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0064": {
+            "id": "gt0064",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0065": {
+            "id": "gt0065",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0066": {
+            "id": "gt0066",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/ATRIA_stroke_risk_score_Calculation.v2.test.yml
+++ b/gdl2/ATRIA_stroke_risk_score_Calculation.v2.test.yml
@@ -1,5 +1,5 @@
 guidelines:
-  1: ATRIA_stroke_risk_score_Calculation.v1
+  1: ATRIA_stroke_risk_score_Calculation.v2
 test_cases:
 - id: over 75yr female, ATRIA 13
   input:
@@ -200,7 +200,7 @@ test_cases:
 - id: Almost 65 yrs old
   input:
     1:
-      gt0010|Birthdate: 1954-04-30T20:14Z
+      gt0010|Birthdate: 1954-06-18T10:31+01:00[Europe/Stockholm]
       gt0011|Gender: local::at0005|Male|
       gt0063|Event time: 2019-04-29T20:14Z
       gt0012|Estimated Glomerular Filtration Rate: 47,ml/min
@@ -212,7 +212,7 @@ test_cases:
       gt0056|Congestive Heart Failure: 1|local::at0010|Yes|
       gt0057|Hypertension: 0|local::at0011|No|
       gt0062|Stroke/cerebrovascular accident: 1|local::at0036|Yes|
-      gt0066|Event time: 2019-04-29T20:18Z
+      gt0066|Event time: 2019-06-17T10:31+02:00[Europe/Stockholm]
   expected_output:
     1:
       gt0053|History of stroke: 1|local::at0033|Yes|

--- a/gdl2/ATRIA_stroke_risk_score_Calculation.v2.test.yml
+++ b/gdl2/ATRIA_stroke_risk_score_Calculation.v2.test.yml
@@ -1,0 +1,254 @@
+guidelines:
+  1: ATRIA_stroke_risk_score_Calculation.v1
+test_cases:
+- id: over 75yr female, ATRIA 13
+  input:
+    1:
+      gt0010|Birthdate: 1944-04-15T20:14Z
+      gt0011|Gender: local::at0006|Female|
+      gt0063|Event time: 2019-04-29T20:14Z
+      gt0012|Estimated Glomerular Filtration Rate: 44,ml/min
+      gt0064|Event time: 2019-04-29T20:40Z
+      gt0016|Urine microalbumin: 30,mg/dl
+      gt0017|Urine albumin:creatinine ratio: 31,mg/gm
+      gt0065|Event time: 2019-04-22T20:41Z
+      gt0055|Diabetes Mellitus: 1|local::at0008|Yes|
+      gt0056|Congestive Heart Failure: 1|local::at0010|Yes|
+      gt0057|Hypertension: 1|local::at0012|Yes|
+      gt0062|Stroke/cerebrovascular accident: 1|local::at0036|Yes|
+      gt0066|Event time: 2019-04-29T20:18Z
+  expected_output:
+    1:
+      gt0053|History of stroke: 1|local::at0033|Yes|
+      gt0022|History of diabetes mellitus: 1|local::at0031|Yes|
+      gt0024|History of hypertension: 1|local::at0027|Yes|
+      gt0026|eGFR: 1|local::at0023|eGFR <45|
+      gt0025|Proteinuria: 1|local::at0025|Yes|
+      gt0021|Sex: 1|local::at0021|Female|
+      gt0027|ATRIA stroke risk score: 13
+      gt0020|Age: 7|local::at0017|Age 65-84 years with a history of stroke.|
+      gt0023|History of congestive heart failure: 1|local::at0029|Yes|
+
+- id: same but GFR and microalbumin fine
+  input:
+    1:
+      gt0010|Birthdate: 1944-04-15T20:14Z
+      gt0011|Gender: local::at0006|Female|
+      gt0063|Event time: 2019-04-29T20:14Z
+      gt0012|Estimated Glomerular Filtration Rate: 47,ml/min
+      gt0064|Event time: 2019-04-29T20:40Z
+      gt0016|Urine microalbumin: 28,mg/dl
+      gt0017|Urine albumin:creatinine ratio: 31,mg/gm
+      gt0065|Event time: 2019-04-22T20:41Z
+      gt0055|Diabetes Mellitus: 1|local::at0008|Yes|
+      gt0056|Congestive Heart Failure: 1|local::at0010|Yes|
+      gt0057|Hypertension: 1|local::at0012|Yes|
+      gt0062|Stroke/cerebrovascular accident: 1|local::at0036|Yes|
+      gt0066|Event time: 2019-04-29T20:18Z
+  expected_output:
+    1:
+      gt0053|History of stroke: 1|local::at0033|Yes|
+      gt0022|History of diabetes mellitus: 1|local::at0031|Yes|
+      gt0024|History of hypertension: 1|local::at0027|Yes|
+      gt0026|eGFR: 0|local::at0022|eGFR ≥45|
+      gt0025|Proteinuria: 1|local::at0025|Yes|
+      gt0021|Sex: 1|local::at0021|Female|
+      gt0027|ATRIA stroke risk score: 12
+      gt0020|Age: 7|local::at0017|Age 65-84 years with a history of stroke.|
+      gt0023|History of congestive heart failure: 1|local::at0029|Yes|
+
+- id: no diabetes, normal albumin creatinine ratio
+  input:
+    1:
+      gt0010|Birthdate: 1944-04-15T20:14Z
+      gt0011|Gender: local::at0006|Female|
+      gt0063|Event time: 2019-04-29T20:14Z
+      gt0012|Estimated Glomerular Filtration Rate: 47,ml/min
+      gt0064|Event time: 2019-04-29T20:40Z
+      gt0016|Urine microalbumin: 28,mg/dl
+      gt0017|Urine albumin:creatinine ratio: 26,mg/gm
+      gt0065|Event time: 2019-04-22T20:41Z
+      gt0055|Diabetes Mellitus: 0|local::at0007|No|
+      gt0056|Congestive Heart Failure: 1|local::at0010|Yes|
+      gt0057|Hypertension: 1|local::at0012|Yes|
+      gt0062|Stroke/cerebrovascular accident: 1|local::at0036|Yes|
+      gt0066|Event time: 2019-04-29T20:18Z
+  expected_output:
+    1:
+      gt0053|History of stroke: 1|local::at0033|Yes|
+      gt0022|History of diabetes mellitus: 0|local::at0030|No|
+      gt0024|History of hypertension: 1|local::at0027|Yes|
+      gt0026|eGFR: 0|local::at0022|eGFR ≥45|
+      gt0025|Proteinuria: 0|local::at0024|No|
+      gt0021|Sex: 1|local::at0021|Female|
+      gt0027|ATRIA stroke risk score: 10
+      gt0020|Age: 7|local::at0017|Age 65-84 years with a history of stroke.|
+      gt0023|History of congestive heart failure: 1|local::at0029|Yes|
+
+- id: old female with only hypertension
+  input:
+    1:
+      gt0010|Birthdate: 1944-04-15T20:14Z
+      gt0011|Gender: local::at0006|Female|
+      gt0063|Event time: 2019-04-29T20:14Z
+      gt0012|Estimated Glomerular Filtration Rate: 47,ml/min
+      gt0064|Event time: 2019-04-29T20:40Z
+      gt0016|Urine microalbumin: 28,mg/dl
+      gt0017|Urine albumin:creatinine ratio: 26,mg/gm
+      gt0065|Event time: 2019-04-22T20:41Z
+      gt0055|Diabetes Mellitus: 0|local::at0007|No|
+      gt0056|Congestive Heart Failure: 0|local::at0009|No|
+      gt0057|Hypertension: 1|local::at0012|Yes|
+      gt0062|Stroke/cerebrovascular accident: 0|local::at0035|No|
+      gt0066|Event time: 2019-04-29T20:18Z
+  expected_output:
+    1:
+      gt0053|History of stroke: 0|local::at0032|No|
+      gt0022|History of diabetes mellitus: 0|local::at0030|No|
+      gt0024|History of hypertension: 1|local::at0027|Yes|
+      gt0026|eGFR: 0|local::at0022|eGFR ≥45|
+      gt0025|Proteinuria: 0|local::at0024|No|
+      gt0021|Sex: 1|local::at0021|Female|
+      gt0027|ATRIA stroke risk score: 7
+      gt0020|Age: 5|local::at0015|Age 75-84 years with no history of stroke.|
+      gt0023|History of congestive heart failure: 0|local::at0028|No|
+
+- id: above 75 male, no prev stroke
+  input:
+    1:
+      gt0010|Birthdate: 1944-04-15T20:14Z
+      gt0011|Gender: local::at0005|Male|
+      gt0063|Event time: 2019-04-29T20:14Z
+      gt0012|Estimated Glomerular Filtration Rate: 47,ml/min
+      gt0064|Event time: 2019-04-29T20:40Z
+      gt0016|Urine microalbumin: 28,mg/dl
+      gt0017|Urine albumin:creatinine ratio: 26,mg/gm
+      gt0065|Event time: 2019-04-22T20:41Z
+      gt0055|Diabetes Mellitus: 0|local::at0007|No|
+      gt0056|Congestive Heart Failure: 1|local::at0010|Yes|
+      gt0057|Hypertension: 0|local::at0011|No|
+      gt0062|Stroke/cerebrovascular accident: 0|local::at0035|No|
+      gt0066|Event time: 2019-04-29T20:18Z
+  expected_output:
+    1:
+      gt0053|History of stroke: 0|local::at0032|No|
+      gt0022|History of diabetes mellitus: 0|local::at0030|No|
+      gt0024|History of hypertension: 0|local::at0026|No|
+      gt0026|eGFR: 0|local::at0022|eGFR ≥45|
+      gt0025|Proteinuria: 0|local::at0024|No|
+      gt0021|Sex: 0|local::at0020|Male|
+      gt0027|ATRIA stroke risk score: 6
+      gt0020|Age: 5|local::at0015|Age 75-84 years with no history of stroke.|
+      gt0023|History of congestive heart failure: 1|local::at0029|Yes|
+
+- id: above 75 male with history of stroke
+  input:
+    1:
+      gt0010|Birthdate: 1944-04-15T20:14Z
+      gt0011|Gender: local::at0005|Male|
+      gt0063|Event time: 2019-04-29T20:14Z
+      gt0012|Estimated Glomerular Filtration Rate: 47,ml/min
+      gt0064|Event time: 2019-04-29T20:40Z
+      gt0016|Urine microalbumin: 28,mg/dl
+      gt0017|Urine albumin:creatinine ratio: 26,mg/gm
+      gt0065|Event time: 2019-04-22T20:41Z
+      gt0055|Diabetes Mellitus: 0|local::at0007|No|
+      gt0056|Congestive Heart Failure: 1|local::at0010|Yes|
+      gt0057|Hypertension: 0|local::at0011|No|
+      gt0062|Stroke/cerebrovascular accident: 1|local::at0036|Yes|
+      gt0066|Event time: 2019-04-29T20:18Z
+  expected_output:
+    1:
+      gt0053|History of stroke: 1|local::at0033|Yes|
+      gt0022|History of diabetes mellitus: 0|local::at0030|No|
+      gt0024|History of hypertension: 0|local::at0026|No|
+      gt0026|eGFR: 0|local::at0022|eGFR ≥45|
+      gt0025|Proteinuria: 0|local::at0024|No|
+      gt0021|Sex: 0|local::at0020|Male|
+      gt0027|ATRIA stroke risk score: 8
+      gt0020|Age: 7|local::at0017|Age 65-84 years with a history of stroke.|
+      gt0023|History of congestive heart failure: 1|local::at0029|Yes|
+
+- id: 64 year old with stroke history
+  input:
+    1:
+      gt0010|Birthdate: 1955-04-15T20:14Z
+      gt0011|Gender: local::at0005|Male|
+      gt0063|Event time: 2019-04-29T20:14Z
+      gt0012|Estimated Glomerular Filtration Rate: 47,ml/min
+      gt0064|Event time: 2019-04-29T20:40Z
+      gt0016|Urine microalbumin: 28,mg/dl
+      gt0017|Urine albumin:creatinine ratio: 26,mg/gm
+      gt0065|Event time: 2019-04-22T20:41Z
+      gt0055|Diabetes Mellitus: 0|local::at0007|No|
+      gt0056|Congestive Heart Failure: 1|local::at0010|Yes|
+      gt0057|Hypertension: 0|local::at0011|No|
+      gt0062|Stroke/cerebrovascular accident: 1|local::at0036|Yes|
+      gt0066|Event time: 2019-04-29T20:18Z
+  expected_output:
+    1:
+      gt0053|History of stroke: 1|local::at0033|Yes|
+      gt0022|History of diabetes mellitus: 0|local::at0030|No|
+      gt0024|History of hypertension: 0|local::at0026|No|
+      gt0026|eGFR: 0|local::at0022|eGFR ≥45|
+      gt0025|Proteinuria: 0|local::at0024|No|
+      gt0021|Sex: 0|local::at0020|Male|
+      gt0027|ATRIA stroke risk score: 9
+      gt0020|Age: 8|local::at0018|Age <65 years with a history of stroke.|
+      gt0023|History of congestive heart failure: 1|local::at0029|Yes|
+
+- id: Almost 65 yrs old
+  input:
+    1:
+      gt0010|Birthdate: 1954-04-30T20:14Z
+      gt0011|Gender: local::at0005|Male|
+      gt0063|Event time: 2019-04-29T20:14Z
+      gt0012|Estimated Glomerular Filtration Rate: 47,ml/min
+      gt0064|Event time: 2019-04-29T20:40Z
+      gt0016|Urine microalbumin: 28,mg/dl
+      gt0017|Urine albumin:creatinine ratio: 26,mg/gm
+      gt0065|Event time: 2019-04-22T20:41Z
+      gt0055|Diabetes Mellitus: 0|local::at0007|No|
+      gt0056|Congestive Heart Failure: 1|local::at0010|Yes|
+      gt0057|Hypertension: 0|local::at0011|No|
+      gt0062|Stroke/cerebrovascular accident: 1|local::at0036|Yes|
+      gt0066|Event time: 2019-04-29T20:18Z
+  expected_output:
+    1:
+      gt0053|History of stroke: 1|local::at0033|Yes|
+      gt0022|History of diabetes mellitus: 0|local::at0030|No|
+      gt0024|History of hypertension: 0|local::at0026|No|
+      gt0026|eGFR: 0|local::at0022|eGFR ≥45|
+      gt0025|Proteinuria: 0|local::at0024|No|
+      gt0021|Sex: 0|local::at0020|Male|
+      gt0027|ATRIA stroke risk score: 9
+      gt0020|Age: 8|local::at0018|Age <65 years with a history of stroke.|
+      gt0023|History of congestive heart failure: 1|local::at0029|Yes|
+
+- id: 66 yrs old with CHF and history of stroke
+  input:
+    1:
+      gt0010|Birthdate: 1952-04-30T20:14Z
+      gt0011|Gender: local::at0005|Male|
+      gt0063|Event time: 2019-04-29T20:14Z
+      gt0012|Estimated Glomerular Filtration Rate: 47,ml/min
+      gt0064|Event time: 2019-04-29T20:40Z
+      gt0016|Urine microalbumin: 28,mg/dl
+      gt0017|Urine albumin:creatinine ratio: 26,mg/gm
+      gt0065|Event time: 2019-04-22T20:41Z
+      gt0055|Diabetes Mellitus: 0|local::at0007|No|
+      gt0056|Congestive Heart Failure: 1|local::at0010|Yes|
+      gt0057|Hypertension: 0|local::at0011|No|
+      gt0062|Stroke/cerebrovascular accident: 1|local::at0036|Yes|
+      gt0066|Event time: 2019-04-29T20:18Z
+  expected_output:
+    1:
+      gt0053|History of stroke: 1|local::at0033|Yes|
+      gt0022|History of diabetes mellitus: 0|local::at0030|No|
+      gt0024|History of hypertension: 0|local::at0026|No|
+      gt0026|eGFR: 0|local::at0022|eGFR ≥45|
+      gt0025|Proteinuria: 0|local::at0024|No|
+      gt0021|Sex: 0|local::at0020|Male|
+      gt0027|ATRIA stroke risk score: 8
+      gt0020|Age: 7|local::at0017|Age 65-84 years with a history of stroke.|
+      gt0023|History of congestive heart failure: 1|local::at0029|Yes|


### PR DESCRIPTION
Changes:
(1) Event time, outp->inp
(2) CurrentDateTime without value
---
(3) I guess the age calculations were not completely correct, in some cases two rules could fire for example. I corrected this in a new file, 2 test cases show this problem around the end of the test files.