### PR TITLE
MELD migrated

### DIFF
--- a/gdl2/MELD_score_Assessment.v1.gdl2.json
+++ b/gdl2/MELD_score_Assessment.v1.gdl2.json
@@ -1,0 +1,224 @@
+{
+  "id": "MELD_score_Assessment.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2017-03-01",
+      "name": "Eneimi Allwell-Brown",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "other_contributors": [
+      "Dennis Forslund",
+      "Jimmy Axelsson"
+    ],
+    "lifecycle_state": "Author draft",
+    "details": {
+      "sv": {
+        "id": "sv",
+        "purpose": "Att utvärdera poäng i enlighet med Model For End-Stage Liver Disease (MELD) Score, som används för att på kort sikt uppskatta mortalitet hos patienter med terminal leversjukdom och därigenom bedöma behov av levertransplantation.",
+        "keywords": [
+          "levercirros",
+          "cirros",
+          "leversvikt",
+          "alkoholhepatit",
+          "kronisk leversjukdom",
+          "leversjukdom",
+          "gastroenterologi",
+          "MELD",
+          "MELD score"
+        ],
+        "use": "Använd för att utvärdera poäng genererad i enlighet med Model For End-Stage Liver Disease (MELD) Score, som används för att på kort sikt uppskatta mortalitet hos patienter med terminal leversjukdom och därigenom bedöma behov av levertransplantation.\r\n\r\nInstrumentet baseras på ett antal parametrar:\r\n\r\n- Kreatinin (mg/dl eller umol/L)\r\n- Totalt bilirubin (mg/dl eller umol/L)\r\n- Natrum (mmol/L)\r\n- International Normalized Ratio for prothrombin time (INR)\r\n- Huruvida patienten under senaste veckan genomgått dialys vid åtminstone två tillfällen eller CVVHD under minst 24 timmar\r\n\r\nFormel för ursprungliga MELD Score = = 9.57 * ln(kreatinin, mg/dL) + 3.78 * ln(bilirubin, mg/dL) + 11.20 * ln(INR) + 6.43; har patienten genomgått dialys sätts kreatininvärdet automatiskt till 4 mg/dl. \r\n\r\nFormel för senaste versionen av MELD score = oMELD + [1.32 * (137-Na)] – [0.033 * oMELD * (137-Na)]; (baserat på referensvärde för natrium = 125-137 mmol/L.)\r\n\r\nResultatet används för att uppskatta 90-dagarsmortalitet hos patienter med terminal leversjukdom, och registreras med hjälp av en separat arketyp - openEHR-EHR-EVALUATION.meld_score.v1.\r\n\r\nMELD Score är även användbar för att uppskatta överlevnad hos patienter med varicerblödning, levercirros kombinerat med infektion, fulminant leversvikt, alkoholhepatit och andra former av kronisk leversjukdom, samt för att prioritera behov av levertransplantation.\r\n\r\n90-dagars mortalitet baserat på MELD Score:\r\n\r\n40p = 71.3% \r\n30-39p = 52.6%\r\n20-29p = 19.6%\r\n10-19p = 6.0%\r\n≤9p = 1.9%",
+        "misuse": "Endast avsedd för patienter över 12 års ålder. \r\n\r\nMELD Score är ej avsedd för att uppskatta mortalitet efter levertransplantation.",
+        "copyright": "© Cambio Healthcare Systems"
+      },
+      "en": {
+        "id": "en",
+        "purpose": "To assess 90-day mortality rates in individuals with end-stage liver disease, based on the calculate MELD score.",
+        "keywords": [
+          "liver cirrhosis",
+          "liver failure",
+          "hepatic failure",
+          "end-stage liver disease"
+        ],
+        "use": "To assess 90-day mortality rate, based on the calculated MELD score that considers serum creatinine, total serum bilirubin, and serum sodium concentrations; the International Normalized Ratio for prothrombin time (INR); and whether or not the individual has had at least two dialysis sessions or 24hrs of continuous venovenous hemodialysis (CVVHD) in the last week before serum creatinine was measured.\r\n\r\nOriginal MELD (oMELD) score = 9.57 * ln(creatinine, mg/dL) + 3.78 * ln(bilirubin, mg/dL) + 11.20 * ln(INR) + 6.43; a positive history of dialysis automatically defaults serum creatinine concentration to 4 mg/dl.\r\nMELD score = oMELD + [1.32 * (137-Na)] – [0.033 * oMELD * (137-Na)]; based on a normal serum sodium concentration of 125-137 mmol/L.\r\nMELD score is calculated by a separate application: MELD_score_Calculation.v1. \r\nMELD score is also accurate in predicting survival in patients with variceal bleeding, determining mortality in patients with cirrhosis who develop infections, predicting mortality in patients with fulminant hepatic failure, alcoholic hepatitis and other forms of chronic liver disease, as well as in prioritizing recipients of liver transplantation.\r\n\r\n90-day mortality rates based on MELD score are: \r\nscore = 40 (71.3% mortality); \r\nscore = 30-39 (52.6% mortality); \r\nscore = 20-29 (19.6% mortality); \r\nscore = 10-19 (6.0% mortality) and \r\nscore = 9 or less (1.9% mortality).",
+        "misuse": "Not applicable for children under 12 years of age.\r\nMELD score is not useful for predicting mortality following liver transplantation.",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Kamath PS, Wiesner RH, Malinchoc M, Kremers W, Therneau TM, Kosberg CL, D'Amico G, Dickson ER, Kim W. A model to predict survival in patients with end‐stage liver disease. Hepatology. 2001 Feb 1;33(2):464-70.\r\n\r\nWiesner R, Edwards E, Freeman R, Harper A, Kim R, Kamath P, Kremers W, Lake J, Howard T, Merion RM, Wolfe RA. Model for end-stage liver disease (MELD) and allocation of donor livers. Gastroenterology. 2003 Jan 31;124(1):91-6.\r\n\r\nSaid A, Williams J, Holden J, Remington P, Gangnon R, Musat A, Lucey MR. Model for end stage liver disease score predicts mortality across a broad spectrum of liver disease. Journal of hepatology. 2004 Jun 30;40(6):897-903.\r\n\r\nDunn W, Jamil LH, Brown LS, Wiesner RH, Kim W, Menon KV, Malinchoc M, Kamath PS, Shah V. MELD accurately predicts mortality in patients with alcoholic hepatitis. Hepatology. 2005 Feb 1;41(2):353-8.\r\n\r\nKamath PS, Kim W. The model for end‐stage liver disease (MELD). Hepatology. 2007 Mar 1;45(3):797-805."
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0002": {
+        "id": "gt0002",
+        "model_id": "openEHR-EHR-OBSERVATION.meld_score.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.meld_score.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0003": {
+            "id": "gt0003",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0005]"
+          }
+        }
+      },
+      "gt0004": {
+        "id": "gt0004",
+        "model_id": "openEHR-EHR-EVALUATION.meld_score.v1",
+        "template_id": "openEHR-EHR-EVALUATION.meld_score.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0005": {
+            "id": "gt0005",
+            "path": "/data[at0001]/items[at0002]"
+          }
+        }
+      }
+    },
+    "rules": {
+      "gt0006": {
+        "id": "gt0006",
+        "priority": 5,
+        "when": [
+          "$gt0003|MELD score|<=9,1"
+        ],
+        "then": [
+          "$gt0005|90-day mortality|=1.9,%"
+        ]
+      },
+      "gt0007": {
+        "id": "gt0007",
+        "priority": 4,
+        "when": [
+          "$gt0003|MELD score|<=19,1",
+          "$gt0003|MELD score|>=10,1"
+        ],
+        "then": [
+          "$gt0005|90-day mortality|=6,%"
+        ]
+      },
+      "gt0008": {
+        "id": "gt0008",
+        "priority": 3,
+        "when": [
+          "$gt0003|MELD score|<=29,1",
+          "$gt0003|MELD score|>=20,1"
+        ],
+        "then": [
+          "$gt0005|90-day mortality|=19.6,%"
+        ]
+      },
+      "gt0009": {
+        "id": "gt0009",
+        "priority": 2,
+        "when": [
+          "$gt0003|MELD score|<=39,1",
+          "$gt0003|MELD score|>=30,1"
+        ],
+        "then": [
+          "$gt0005|90-day mortality|=52.6,%"
+        ]
+      },
+      "gt0010": {
+        "id": "gt0010",
+        "priority": 1,
+        "when": [
+          "$gt0003|MELD score|==40,1"
+        ],
+        "then": [
+          "$gt0005|90-day mortality|=71.3,%"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "sv": {
+        "id": "sv",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Model For End-Stage Liver Disease (MELD) score utvärdering",
+            "description": "Utvärdering av poäng genererad i enlighet med Model For End-Stage Liver Disease (MELD) Score, som används för att på kort sikt uppskatta mortalitet hos patienter med terminal leversjukdom och därigenom bedöma behov av levertransplantation."
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "MELD score",
+            "description": "*(en) Calculated value of the 2016 Model For End-Stage Liver Disease (MELD)."
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "90-dagars mortalitet",
+            "description": "*(en) Assessed 90-day mortality based on MELD score."
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "CDS mortalitet - MELD score ≤ 9"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "CDS mortalitet - MELD score 10 - 19"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "CDS mortalitet - MELD score 20 - 29"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "CDS mortalitet - MELD score 30 - 39"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "CDS mortalitet - MELD score = 40"
+          }
+        }
+      },
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Model For End-Stage Liver Disease (MELD) score Assessment",
+            "description": "Model For End-Stage Liver Disease (MELD) score is a measure of mortality risk in patients with end-stage liver disease. It is a reliable way of estimating disease severity, determining prognosis, and assigning organ allocation priority in patients with end-stage liver disease. The score is calculated from a regression equation that includes serum sodium, creatinine and total bilirubin concentrations, the International Normalized Ratio for prothrombin time (INR) and whether or not the individual has had at least two dialysis sessions in the last week before serum creatinine was measured. MELD score is considered as good as the Child-Turcotte-Pugh (CTP) score in predicting short-term mortality in end-stage liver disease, as well as an accurate predictor of survival in patients with variceal bleeding, mortality in patients with cirrhosis who develop infections, mortality in patients with fulminant hepatic failure, alcoholic hepatitis and other forms of chronic liver disease. 90-day mortality rates based on MELD score are: score = 40 (71.3% mortality); score = 30-39 (52.6% mortality); score = 20-29 (19.6% mortality); score = 10-19 (6.0% mortality) and score = 9 or less (1.9% mortality)."
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "MELD score",
+            "description": "Calculated value of the 2016 Model For End-Stage Liver Disease (MELD)."
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "90-day mortality",
+            "description": "Assessed 90-day mortality based on MELD score."
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Set mortality with MELD score ≤ 9"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Set mortality with MELD score 10 - 19"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Set mortality with MELD score 20 - 29"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Set mortality with MELD score 30 - 39"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Set mortality with MELD score = 40"
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/MELD_score_Assessment.v1.test.yml
+++ b/gdl2/MELD_score_Assessment.v1.test.yml
@@ -1,0 +1,38 @@
+guidelines:
+  1: MELD_score_Assessment.v1
+test_cases:
+- id: Low meld
+  input:
+    1:
+      gt0003|MELD score: 8,1
+  expected_output:
+    1:
+      gt0005|90-day mortality: 1.9,%
+- id: MELD 11
+  input:
+    1:
+      gt0003|MELD score: 11,1
+  expected_output:
+    1:
+      gt0005|90-day mortality: 6,%
+- id: MELD 22
+  input:
+    1:
+      gt0003|MELD score: 22,1
+  expected_output:
+    1:
+      gt0005|90-day mortality: 19.6,%
+- id: 33
+  input:
+    1:
+      gt0003|MELD score: 33,1
+  expected_output:
+    1:
+      gt0005|90-day mortality: 52.6,%
+- id: 40
+  input:
+    1:
+      gt0003|MELD score: 40,1
+  expected_output:
+    1:
+      gt0005|90-day mortality: 71.3,%

--- a/gdl2/MELD_score_Calculation.v1.gdl2.json
+++ b/gdl2/MELD_score_Calculation.v1.gdl2.json
@@ -1,0 +1,718 @@
+{
+  "id": "MELD_score_Calculation.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2017-01-21",
+      "name": "Eneimi Allwell-Brown",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "other_contributors": [
+      "Dennis Forslund",
+      "Jimmy Axelsson"
+    ],
+    "lifecycle_state": "Author draft",
+    "details": {
+      "sv": {
+        "id": "sv",
+        "purpose": "Att registrera data i enlighet med såväl senaste som ursprungliga versionen av MELD Score, vilken används för att på kort sikt uppskatta mortalitet hos patienter med terminal leversjukdom och därigenom bedöma behov av levertransplantation.",
+        "keywords": [
+          "kronisk leversjukdom",
+          "Child-Turcotte-Pugh",
+          "leversvikt",
+          "cirros",
+          "levercirros",
+          "alkoholhepatit",
+          "MELD"
+        ],
+        "use": "Att registrera data i enlighet med såväl senaste som ursprungliga versionen av MELD Score, baserat på ett antal parametrar:\r\n\r\n- Kreatinin (mg/dl eller umol/L)\r\n- Totalt bilirubin (mg/dl eller umol/L)\r\n- Natrum (mmol/L)\r\n- International Normalized Ratio for prothrombin time (INR)\r\n- Huruvida patienten under senaste veckan genomgått dialys vid åtminstone två tillfällen eller CVVHD under minst 24 timmar\r\n\r\nFormel för ursprungliga MELD Score = = 9.57 * ln(kreatinin, mg/dL) + 3.78 * ln(bilirubin, mg/dL) + 11.20 * ln(INR) + 6.43; har patienten genomgått dialys sätts kreatininvärdet automatiskt till 4 mg/dl. \r\n\r\nFormel för senaste versionen av MELD score = oMELD + [1.32 * (137-Na)] – [0.033 * oMELD * (137-Na)]; (baserat på referensvärde för natrium = 125-137 mmol/L.)\r\n\r\nResultatet används för att uppskatta 90-dagarsmortalitet hos patienter med terminal leversjukdom, och registreras med hjälp av en separat arketyp - openEHR-EHR-EVALUATION.meld_score.v1.\r\n\r\nMELD Score är även användbar för att uppskatta överlevnad hos patienter med varicerblödning, levercirros kombinerat med infektion, fulminant leversvikt, alkoholhepatit och andra former av kronisk leversjukdom, samt för att prioritera behov av levertransplantation.\r\n",
+        "misuse": "Endast avsedd för patienter över 12 års ålder. \r\n\r\nMELD Score är ej avsedd för att uppskatta mortalitet efter levertransplantation.\r\n",
+        "copyright": "© Cambio Healthcare Systems"
+      },
+      "en": {
+        "id": "en",
+        "purpose": "To calculate the MELD score, used for predicting short-term mortality of end-stage liver disease, as well as organ transplant priority.",
+        "keywords": [
+          "end-stage liver disease",
+          "Child-Turcotte-Pugh",
+          "hepatic failure",
+          "chronic liver disease",
+          "CTP score"
+        ],
+        "use": "To calculate the MELD score and the Original MELD score, based on serum creatinine (mg/dl or umol/L), total serum bilirubin (mg/dl or umol/L), and serum sodium (mmol/L) concentrations, the International Normalized Ratio for prothrombin time (INR) and whether or not the individual has had at least two dialysis sessions or 24hrs of continuous venovenous hemodialysis (CVVHD) in the last week before serum creatinine was measured.\n\nOriginal MELD (oMELD) score = 9.57 * ln(creatinine, mg/dL) + 3.78 * ln(bilirubin, mg/dL) + 11.20 * ln(INR) + 6.43; a positive history of dialysis automatically defaults serum creatinine concentration to 4 mg/dl.\nMELD score = oMELD + [1.32 * (137-Na)] – [0.033 * oMELD * (137-Na)]; based on a normal serum sodium concentration of 125-137 mmol/L.\n\nThe calculated MELD score is used to determine the 90-day mortality in patients with end-stage liver disease, and that evaluation is done by a separate MELD_score_Assessment application. MELD score is also accurate in predicting survival in patients with variceal bleeding, determining mortality in patients with cirrhosis who develop infections, predicting mortality in patients with fulminant hepatic failure, alcoholic hepatitis and other forms of chronic liver disease, as well as in prioritizing recipients of liver transplantation. 90-day mortality rates based on MELD score are: score = 40 (71.3% mortality); score = 30-39 (52.6% mortality); score = 20-29 (19.6% mortality); score = 10-19 (6.0% mortality) and score = 9 or less (1.9% mortality).",
+        "misuse": "Not applicable for children under 12 years of age.\r\nMELD score is not useful for predicting mortality following liver transplantation.",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Kamath PS, Wiesner RH, Malinchoc M, Kremers W, Therneau TM, Kosberg CL, D'Amico G, Dickson ER, Kim W. A model to predict survival in patients with end‐stage liver disease. Hepatology. 2001 Feb 1;33(2):464-70.\r\n\r\nWiesner R, Edwards E, Freeman R, Harper A, Kim R, Kamath P, Kremers W, Lake J, Howard T, Merion RM, Wolfe RA. Model for end-stage liver disease (MELD) and allocation of donor livers. Gastroenterology. 2003 Jan 31;124(1):91-6.\r\n\r\nSaid A, Williams J, Holden J, Remington P, Gangnon R, Musat A, Lucey MR. Model for end stage liver disease score predicts mortality across a broad spectrum of liver disease. Journal of hepatology. 2004 Jun 30;40(6):897-903.\r\n\r\nDunn W, Jamil LH, Brown LS, Wiesner RH, Kim W, Menon KV, Malinchoc M, Kamath PS, Shah V. MELD accurately predicts mortality in patients with alcoholic hepatitis. Hepatology. 2005 Feb 1;41(2):353-8.\r\n\r\nKamath PS, Kim W. The model for end‐stage liver disease (MELD). Hepatology. 2007 Mar 1;45(3):797-805."
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0002": {
+        "id": "gt0002",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-urea_and_electrolytes.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-urea_and_electrolytes.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0003": {
+            "id": "gt0003",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.5]"
+          },
+          "gt0041": {
+            "id": "gt0041",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.7]"
+          },
+          "gt0044": {
+            "id": "gt0044",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0005": {
+        "id": "gt0005",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-liver_function.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-liver_function.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0006": {
+            "id": "gt0006",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.4]"
+          },
+          "gt0045": {
+            "id": "gt0045",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0007": {
+        "id": "gt0007",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-coagulation_profile.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-coagulation_profile.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0008": {
+            "id": "gt0008",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0.101]"
+          },
+          "gt0046": {
+            "id": "gt0046",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0009": {
+        "id": "gt0009",
+        "model_id": "openEHR-EHR-OBSERVATION.meld_score.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.meld_score.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0010": {
+            "id": "gt0010",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0006]"
+          },
+          "gt0047": {
+            "id": "gt0047",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0011": {
+        "id": "gt0011",
+        "model_id": "openEHR-EHR-OBSERVATION.meld_score.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.meld_score.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0012": {
+            "id": "gt0012",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0004]"
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0005]"
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0006]"
+          }
+        }
+      },
+      "gt0015": {
+        "id": "gt0015",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-coagulation_profile.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-coagulation_profile.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0016": {
+            "id": "gt0016",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0.101]"
+          }
+        }
+      },
+      "gt0017": {
+        "id": "gt0017",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-liver_function.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-liver_function.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0018": {
+            "id": "gt0018",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.4]"
+          }
+        }
+      },
+      "gt0019": {
+        "id": "gt0019",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-urea_and_electrolytes.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-urea_and_electrolytes.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0020": {
+            "id": "gt0020",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.5]"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.7]"
+          }
+        }
+      }
+    },
+    "rules": {
+      "gt0031": {
+        "id": "gt0031",
+        "priority": 16,
+        "when": [
+          "$gt0041|Creatinine|.unit=='umol/l'"
+        ],
+        "then": [
+          "$gt0021|Creatinine|.precision=2",
+          "$gt0021|Creatinine|.unit='mg/dl'",
+          "$gt0021|Creatinine|.magnitude=$gt0041.magnitude/88.42"
+        ]
+      },
+      "gt0024": {
+        "id": "gt0024",
+        "priority": 15,
+        "when": [
+          "$gt0041|Creatinine|.unit=='mg/dl'"
+        ],
+        "then": [
+          "$gt0021|Creatinine|=$gt0041|Creatinine|"
+        ]
+      },
+      "gt0028": {
+        "id": "gt0028",
+        "priority": 14,
+        "when": [
+          "$gt0006|Total bilirubin|.magnitude>17.1",
+          "$gt0006|Total bilirubin|.unit=='µmol/l'"
+        ],
+        "then": [
+          "$gt0018|Total bilirubin|.precision=2",
+          "$gt0018|Total bilirubin|.unit='mg/dl'",
+          "$gt0018|Total bilirubin|.magnitude=$gt0006.magnitude/17.1"
+        ]
+      },
+      "gt0038": {
+        "id": "gt0038",
+        "priority": 13,
+        "when": [
+          "$gt0006|Total bilirubin|.magnitude<=17.1",
+          "$gt0006|Total bilirubin|.unit=='µmol/l'"
+        ],
+        "then": [
+          "$gt0018|Total bilirubin|.unit='mg/dl'",
+          "$gt0018|Total bilirubin|.magnitude=1"
+        ]
+      },
+      "gt0026": {
+        "id": "gt0026",
+        "priority": 12,
+        "when": [
+          "$gt0006|Total bilirubin|.magnitude>1",
+          "$gt0006|Total bilirubin|.unit=='mg/dl'"
+        ],
+        "then": [
+          "$gt0018|Total bilirubin|=$gt0006|Total bilirubin|"
+        ]
+      },
+      "gt0039": {
+        "id": "gt0039",
+        "priority": 11,
+        "when": [
+          "$gt0006|Total bilirubin|.unit=='mg/dl'",
+          "$gt0006|Total bilirubin|<=1,mg/dl"
+        ],
+        "then": [
+          "$gt0018|Total bilirubin|.unit='mg/dl'",
+          "$gt0018|Total bilirubin|.magnitude=1"
+        ]
+      },
+      "gt0023": {
+        "id": "gt0023",
+        "priority": 10,
+        "when": [
+          "$gt0003|Sodium|<=137,mmol/l",
+          "$gt0003|Sodium|>=125,mmol/l"
+        ],
+        "then": [
+          "$gt0020|Sodium|=$gt0003|Sodium|"
+        ]
+      },
+      "gt0034": {
+        "id": "gt0034",
+        "priority": 9,
+        "when": [
+          "$gt0003|Sodium|<125,mmol/l"
+        ],
+        "then": [
+          "$gt0020|Sodium|=125,mmol/l"
+        ]
+      },
+      "gt0035": {
+        "id": "gt0035",
+        "priority": 8,
+        "when": [
+          "$gt0003|Sodium|>137,mmol/l"
+        ],
+        "then": [
+          "$gt0020|Sodium|=137,mmol/l"
+        ]
+      },
+      "gt0025": {
+        "id": "gt0025",
+        "priority": 7,
+        "when": [
+          "$gt0008|INR|>1"
+        ],
+        "then": [
+          "$gt0016|INR|=$gt0008|INR|"
+        ]
+      },
+      "gt0040": {
+        "id": "gt0040",
+        "priority": 6,
+        "when": [
+          "$gt0008|INR|<=1"
+        ],
+        "then": [
+          "$gt0016|INR|=1"
+        ]
+      },
+      "gt0027": {
+        "id": "gt0027",
+        "priority": 5,
+        "when": [
+          "$gt0010|Dialysis history|!=null"
+        ],
+        "then": [
+          "$gt0014|Dialysis history|=$gt0010|Dialysis history|"
+        ]
+      },
+      "gt0029": {
+        "id": "gt0029",
+        "priority": 4,
+        "when": [
+          "$gt0014|Dialysis history|==0|local::at0007|No|",
+          "$gt0021|Creatinine|>=1,mg/dl",
+          "$gt0021|Creatinine|<4,mg/dl"
+        ],
+        "then": [
+          "$gt0012|Original MELD (oMELD) score|.precision=0",
+          "$gt0012|Original MELD (oMELD) score|.unit='1'",
+          "$gt0012|Original MELD (oMELD) score|.magnitude=((9.57*log($gt0021.magnitude))+(3.78*log($gt0006.magnitude)))+(11.2*log($gt0008))+6.43"
+        ]
+      },
+      "gt0043": {
+        "id": "gt0043",
+        "priority": 3,
+        "when": [
+          "$gt0021|Creatinine|<1,mg/dl",
+          "$gt0014|Dialysis history|==0|local::at0007|No|"
+        ],
+        "then": [
+          "$gt0012|Original MELD (oMELD) score|.precision=0",
+          "$gt0012|Original MELD (oMELD) score|.unit='1'",
+          "$gt0012|Original MELD (oMELD) score|.magnitude=(((9.57*log(1))+(3.78*log($gt0006.magnitude)))+(11.2*log($gt0008)))+6.43"
+        ]
+      },
+      "gt0033": {
+        "id": "gt0033",
+        "priority": 2,
+        "when": [
+          "($gt0014|Dialysis history|==1|local::at0008|Yes|)||($gt0021|Creatinine|>=4,mg/dl)"
+        ],
+        "then": [
+          "$gt0012|Original MELD (oMELD) score|.precision=0",
+          "$gt0012|Original MELD (oMELD) score|.unit='1'",
+          "$gt0012|Original MELD (oMELD) score|.magnitude=(((9.57*log(4))+(3.78*log($gt0006.magnitude)))+(11.2*log($gt0008)))+6.43"
+        ]
+      },
+      "gt0030": {
+        "id": "gt0030",
+        "priority": 1,
+        "then": [
+          "$gt0013|MELD score|.precision=0",
+          "$gt0013|MELD score|.unit='1'",
+          "$gt0013|MELD score|.magnitude=((1.32*(137-$gt0020.magnitude))-((0.033*$gt0012.magnitude)*(137-$gt0020.magnitude)))+$gt0012.magnitude"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "sv": {
+        "id": "sv",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Model For End-Stage Liver Disease (MELD) score ",
+            "description": "Model For End-Stage Liver Disease (MELD) Score används för att på kort sikt uppskatta mortalitet hos patienter med terminal leversjukdom och därigenom bedöma behov av levertransplantation."
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "Natrium",
+            "description": "*(en) Sodium level in this specimen."
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Totalt bilirubin",
+            "description": "*(en) Concentration of bilirubin (conjugated and unconjugated) in the serum."
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "INR",
+            "description": "*(en) International Normalized Ratio."
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Dialys",
+            "description": "*(en) Has the patient had dialysis at least twice, or 24hrs of continuous venovenous hemodialysis (CVVHD), in the past week?"
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "Original MELD (oMELD) score",
+            "description": "*(en) Calculated value of the Original, Pre-2016, Model for End-Stage Liver Disease (oMELD)."
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "MELD score",
+            "description": "*(en) Calculated value of the 2016 Model For End-Stage Liver Disease (MELD)."
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "Dialys",
+            "description": "*(en) Has the patient had dialysis at least twice, or 24hrs of continuous venovenous hemodialysis (CVVHD), in the past week?"
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "INR",
+            "description": "*(en) International Normalized Ratio."
+          },
+          "gt0018": {
+            "id": "gt0018",
+            "text": "Totalt bilirubin",
+            "description": "*(en) Concentration of bilirubin (conjugated and unconjugated) in the serum."
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "Natrium",
+            "description": "*(en) Sodium level in this specimen."
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "text": "Kreatinin",
+            "description": "*(en) Creatinine level in this specimen"
+          },
+          "gt0023": {
+            "id": "gt0023",
+            "text": "CDS natrium"
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "text": "CDS Kreatinin"
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "text": "CDS INR"
+          },
+          "gt0026": {
+            "id": "gt0026",
+            "text": "CDS Totalt bilirubin"
+          },
+          "gt0027": {
+            "id": "gt0027",
+            "text": "CDS dialys"
+          },
+          "gt0028": {
+            "id": "gt0028",
+            "text": "Omvandla s-bilirubin till mg/dl"
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "text": "Beräkna original MELD score utan dialys"
+          },
+          "gt0030": {
+            "id": "gt0030",
+            "text": "Beräkna MELD score"
+          },
+          "gt0031": {
+            "id": "gt0031",
+            "text": "Omvandla s-kreatinin till mg/dl"
+          },
+          "gt0033": {
+            "id": "gt0033",
+            "text": "Beräkna original MELD score med dialys"
+          },
+          "gt0034": {
+            "id": "gt0034",
+            "text": "CDS natrium till låg/normal"
+          },
+          "gt0035": {
+            "id": "gt0035",
+            "text": "CDS natrium till hög/normal"
+          },
+          "gt0036": {
+            "id": "gt0036",
+            "text": "CDS kreatinin <1 umol/L"
+          },
+          "gt0037": {
+            "id": "gt0037",
+            "text": "CDS kreatinin <1 mg/dl"
+          },
+          "gt0038": {
+            "id": "gt0038",
+            "text": "CDS bilirubin <1 umol/L"
+          },
+          "gt0039": {
+            "id": "gt0039",
+            "text": "CDS bilirubin <1 mg/dl"
+          },
+          "gt0040": {
+            "id": "gt0040",
+            "text": "CDS INR <1"
+          },
+          "gt0041": {
+            "id": "gt0041",
+            "text": "Kreatinin",
+            "description": "*(en) Creatinine level in this specimen"
+          },
+          "gt0043": {
+            "id": "gt0043",
+            "text": "Beräkna original MELD score utan dialys och s-kreatinin < 1 mg/dl"
+          },
+          "gt0044": {
+            "id": "gt0044",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0045": {
+            "id": "gt0045",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0046": {
+            "id": "gt0046",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0047": {
+            "id": "gt0047",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0048": {
+            "id": "gt0048",
+            "text": "*(en) hh",
+            "description": ""
+          }
+        }
+      },
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Model For End-Stage Liver Disease (MELD) score Calculator",
+            "description": "Model For End-Stage Liver Disease (MELD) score is a measure of mortality risk in patients with end-stage liver disease. It is a reliable way of estimating disease severity, determining prognosis, and assigning organ allocation priority in patients with end-stage liver disease. It is the standard used by the Organ Procurement and Transplantation Network (OPTN) and determines who is the highest priority to receive liver transplants in the US. The score is calculated from a regression equation that includes serum sodium, creatinine and total bilirubin concentrations, the International Normalized Ratio for prothrombin time (INR) and whether or not the individual has had at least two dialysis sessions in the last week before serum creatinine was measured. It is based on a previous \\\"Original MELD score\\\" that is calculated using the same equation and the same set of variables, but does not include serum sodium concentration. MELD score is considered as good as the Child-Turcotte-Pugh (CTP) score in predicting short-term mortality in end-stage liver disease, as well as an accurate predictor of survival in patients with variceal bleeding, mortality in patients with cirrhosis who develop infections, mortality in patients with fulminant hepatic failure, alcoholic hepatitis and other forms of chronic liver disease. 90-day mortality rates based on MELD score are: score = 40 (71.3% mortality); score = 30-39 (52.6% mortality); score = 20-29 (19.6% mortality); score = 10-19 (6.0% mortality) and score = 9 or less (1.9% mortality)."
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "Sodium",
+            "description": "Sodium level in this specimen."
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Total bilirubin",
+            "description": "Concentration of bilirubin (conjugated and unconjugated) in the serum."
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "INR",
+            "description": "International Normalized Ratio."
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Dialysis history",
+            "description": "Has the patient had dialysis at least twice, or 24hrs of continuous venovenous hemodialysis (CVVHD), in the past week?"
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "Original MELD (oMELD) score",
+            "description": "Calculated value of the Original, Pre-2016, Model for End-Stage Liver Disease (oMELD)."
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "MELD score",
+            "description": "Calculated value of the 2016 Model For End-Stage Liver Disease (MELD)."
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "Dialysis history",
+            "description": "Has the patient had dialysis at least twice, or 24hrs of continuous venovenous hemodialysis (CVVHD), in the past week?"
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "INR",
+            "description": "International Normalized Ratio."
+          },
+          "gt0018": {
+            "id": "gt0018",
+            "text": "Total bilirubin",
+            "description": "Concentration of bilirubin (conjugated and unconjugated) in the serum."
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "Sodium",
+            "description": "Sodium level in this specimen."
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "text": "Creatinine",
+            "description": "Creatinine level in this specimen"
+          },
+          "gt0023": {
+            "id": "gt0023",
+            "text": "Set serum sodium"
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "text": "Set serum creatinine"
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "text": "Set INR"
+          },
+          "gt0026": {
+            "id": "gt0026",
+            "text": "Set serum bilirubin >1 mg/dl"
+          },
+          "gt0027": {
+            "id": "gt0027",
+            "text": "Set dialysis history"
+          },
+          "gt0028": {
+            "id": "gt0028",
+            "text": "Convert and set serum bilirubin >17.1 umol/L to mg/dl"
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "text": "Calculate original MELD score with no dialysis"
+          },
+          "gt0030": {
+            "id": "gt0030",
+            "text": "Calculate MELD score"
+          },
+          "gt0031": {
+            "id": "gt0031",
+            "text": "Convert serum creatinine to mg/dl"
+          },
+          "gt0033": {
+            "id": "gt0033",
+            "text": "Calculate original MELD score with dialysis"
+          },
+          "gt0034": {
+            "id": "gt0034",
+            "text": "Set serum sodium to low normal"
+          },
+          "gt0035": {
+            "id": "gt0035",
+            "text": "Set serum sodium to high normal"
+          },
+          "gt0036": {
+            "id": "gt0036",
+            "text": "Set serum creatinine <1 umol/L"
+          },
+          "gt0037": {
+            "id": "gt0037",
+            "text": "Set serum creatinine <1 mg/dl"
+          },
+          "gt0038": {
+            "id": "gt0038",
+            "text": "Convert and set serum bilirubin ≤17.1 umol/L to mg/dl"
+          },
+          "gt0039": {
+            "id": "gt0039",
+            "text": "Set serum bilirubin ≤1 mg/dl"
+          },
+          "gt0040": {
+            "id": "gt0040",
+            "text": "Set INR <1"
+          },
+          "gt0041": {
+            "id": "gt0041",
+            "text": "Creatinine",
+            "description": "Creatinine level in this specimen"
+          },
+          "gt0043": {
+            "id": "gt0043",
+            "text": "Calculate original MELD score with no dialysis and serum creatinine < 1 mg/dl"
+          },
+          "gt0044": {
+            "id": "gt0044",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0045": {
+            "id": "gt0045",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0046": {
+            "id": "gt0046",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0047": {
+            "id": "gt0047",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0048": {
+            "id": "gt0048",
+            "text": "hh"
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/MELD_score_Calculation.v1.test.yml
+++ b/gdl2/MELD_score_Calculation.v1.test.yml
@@ -1,0 +1,182 @@
+guidelines:
+  1: MELD_score_Calculation.v1
+test_cases:
+- id: case_1
+  input:
+    1:
+      gt0003|Sodium: 120,mmol/l
+      gt0041|Creatinine: 2,mg/dl
+      gt0044|Event time: 2019-04-29T23:28Z
+      gt0006|Total bilirubin: 2,mg/dl
+      gt0045|Event time: 2019-04-29T23:28Z
+      gt0008|INR: 1.0
+      gt0046|Event time: 2019-04-29T23:28Z
+      gt0010|Dialysis history: 0|local::at0007|No|
+      gt0047|Event time: 2019-04-28T23:28Z
+  expected_output:
+    1:
+      gt0014|Dialysis history: 0|local::at0007|No|
+      gt0012|Original MELD (oMELD) score: 16,1
+      gt0013|MELD score: 25,1
+      gt0016|INR: 1
+      gt0018|Total bilirubin: 2,mg/dl
+      gt0021|Creatinine: 2,mg/dl
+      gt0020|Sodium: 125,mmol/l
+
+
+
+
+
+- id: low creatinine, INR 2.0
+  input:
+    1:
+      gt0003|Sodium: 140,mmol/l
+      gt0041|Creatinine: 87,umol/l
+      gt0044|Event time: 2019-04-29T23:28Z
+      gt0006|Total bilirubin: 33,µmol/l
+      gt0045|Event time: 2019-04-29T23:28Z
+      gt0008|INR: 2.0
+      gt0046|Event time: 2019-04-29T23:28Z
+      gt0010|Dialysis history: 0|local::at0007|No|
+      gt0047|Event time: 2019-04-28T23:28Z
+  expected_output:
+    1:
+      gt0014|Dialysis history: 0|local::at0007|No|
+      gt0012|Original MELD (oMELD) score: 27,1
+      gt0013|MELD score: 27,1
+      gt0016|INR: 2.0
+      gt0018|Total bilirubin: 1.93,mg/dl
+      gt0021|Creatinine: 0.98,mg/dl
+      gt0020|Sodium: 137,mmol/l
+- id: Low bilirubin, creatinine above threshold
+  input:
+    1:
+      gt0003|Sodium: 140,mmol/l
+      gt0041|Creatinine: 110,umol/l
+      gt0044|Event time: 2019-04-29T23:28Z
+      gt0006|Total bilirubin: 16,µmol/l
+      gt0045|Event time: 2019-04-29T23:28Z
+      gt0008|INR: 2.0
+      gt0046|Event time: 2019-04-29T23:28Z
+      gt0010|Dialysis history: 0|local::at0007|No|
+      gt0047|Event time: 2019-04-28T23:28Z
+  expected_output:
+    1:
+      gt0014|Dialysis history: 0|local::at0007|No|
+      gt0012|Original MELD (oMELD) score: 27,1
+      gt0013|MELD score: 27,1
+      gt0016|INR: 2.0
+      gt0018|Total bilirubin: 1,mg/dl
+      gt0021|Creatinine: 1.24,mg/dl
+      gt0020|Sodium: 137,mmol/l
+- id: Creatinine in mg/dl
+  input:
+    1:
+      gt0003|Sodium: 140,mmol/l
+      gt0041|Creatinine: 2,mg/dl
+      gt0044|Event time: 2019-04-29T23:28Z
+      gt0006|Total bilirubin: 16,µmol/l
+      gt0045|Event time: 2019-04-29T23:28Z
+      gt0008|INR: 2.0
+      gt0046|Event time: 2019-04-29T23:28Z
+      gt0010|Dialysis history: 0|local::at0007|No|
+      gt0047|Event time: 2019-04-28T23:28Z
+  expected_output:
+    1:
+      gt0014|Dialysis history: 0|local::at0007|No|
+      gt0012|Original MELD (oMELD) score: 31,1
+      gt0013|MELD score: 31,1
+      gt0016|INR: 2.0
+      gt0018|Total bilirubin: 1,mg/dl
+      gt0021|Creatinine: 2,mg/dl
+      gt0020|Sodium: 137,mmol/l
+
+
+- id: Normal sodium
+  input:
+    1:
+      gt0003|Sodium: 130,mmol/l
+      gt0041|Creatinine: 2,mg/dl
+      gt0044|Event time: 2019-04-29T23:28Z
+      gt0006|Total bilirubin: 16,µmol/l
+      gt0045|Event time: 2019-04-29T23:28Z
+      gt0008|INR: 2.0
+      gt0046|Event time: 2019-04-29T23:28Z
+      gt0010|Dialysis history: 0|local::at0007|No|
+      gt0047|Event time: 2019-04-28T23:28Z
+  expected_output:
+    1:
+      gt0014|Dialysis history: 0|local::at0007|No|
+      gt0012|Original MELD (oMELD) score: 31,1
+      gt0013|MELD score: 33,1
+      gt0016|INR: 2.0
+      gt0018|Total bilirubin: 1,mg/dl
+      gt0021|Creatinine: 2,mg/dl
+      gt0020|Sodium: 130,mmol/l
+
+- id: Low normal sodium
+  input:
+    1:
+      gt0003|Sodium: 120,mmol/l
+      gt0041|Creatinine: 2,mg/dl
+      gt0044|Event time: 2019-04-29T23:28Z
+      gt0006|Total bilirubin: 16,µmol/l
+      gt0045|Event time: 2019-04-29T23:28Z
+      gt0008|INR: 2.0
+      gt0046|Event time: 2019-04-29T23:28Z
+      gt0010|Dialysis history: 0|local::at0007|No|
+      gt0047|Event time: 2019-04-28T23:28Z
+  expected_output:
+    1:
+      gt0014|Dialysis history: 0|local::at0007|No|
+      gt0012|Original MELD (oMELD) score: 31,1
+      gt0013|MELD score: 35,1
+      gt0016|INR: 2.0
+      gt0018|Total bilirubin: 1,mg/dl
+      gt0021|Creatinine: 2,mg/dl
+      gt0020|Sodium: 125,mmol/l
+
+- id: Small INR
+  input:
+    1:
+      gt0003|Sodium: 120,mmol/l
+      gt0041|Creatinine: 2,mg/dl
+      gt0044|Event time: 2019-04-29T23:28Z
+      gt0006|Total bilirubin: 16,µmol/l
+      gt0045|Event time: 2019-04-29T23:28Z
+      gt0008|INR: 0.6
+      gt0046|Event time: 2019-04-29T23:28Z
+      gt0010|Dialysis history: 0|local::at0007|No|
+      gt0047|Event time: 2019-04-28T23:28Z
+  expected_output:
+    1:
+      gt0014|Dialysis history: 0|local::at0007|No|
+      gt0012|Original MELD (oMELD) score: 18,1
+      gt0013|MELD score: 27,1
+      gt0016|INR: 1
+      gt0018|Total bilirubin: 1,mg/dl
+      gt0021|Creatinine: 2,mg/dl
+      gt0020|Sodium: 125,mmol/l
+
+- id: Dialisis history
+  input:
+    1:
+      gt0003|Sodium: 140,mmol/l
+      gt0041|Creatinine: 110,umol/l
+      gt0044|Event time: 2019-04-23T20:53Z
+      gt0006|Total bilirubin: 16,µmol/l
+      gt0045|Event time: 2019-04-29T20:53Z
+      gt0008|INR: 2
+      gt0046|Event time: 2019-04-25T20:53Z
+      gt0010|Dialysis history: 1|local::at0008|Yes|
+      gt0047|Event time: 2019-04-28T20:54Z
+  expected_output:
+    1:
+      gt0014|Dialysis history: 1|local::at0008|Yes|
+      gt0012|Original MELD (oMELD) score: 38,1
+      gt0013|MELD score: 38,1
+      gt0016|INR: 2
+      gt0018|Total bilirubin: 1,mg/dl
+      gt0021|Creatinine: 1.24,mg/dl
+      gt0020|Sodium: 137,mmol/l
+


### PR DESCRIPTION
Sorry, I forgot to fetch this and next one previously.
Changes:
(1) out->in, event time
(2) INR.value was replaced with INR in the rule, as this is what was set in previous rules.
(3) in MELD score with no dialysis, a paranthese was removed, as it strangely, first didn't want to run and then gave wrong results, now the test cases were double checked against https://www.mdcalc.com/meld-score-model-end-stage-liver-disease-12-older