### PR TITLE
MEWS migrated

### DIFF
--- a/gdl2/MEWS.v1.1.gdl2.json
+++ b/gdl2/MEWS.v1.1.gdl2.json
@@ -1,0 +1,712 @@
+{
+  "id": "MEWS.v1.1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2016-09-26",
+      "name": "Konstantinos Kalliamvakos",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "Konstantinos.Kalliamvakos@cambio.se"
+    },
+    "other_contributors": [
+      "Dr Niklas Skyttberg",
+      "Dennis Forslund",
+      "Jimmy Axelsson"
+    ],
+    "lifecycle_state": "Not set",
+    "details": {
+      "sv": {
+        "id": "sv",
+        "purpose": "Att baserat på kliniska parametrar identifiera patienter med hög risk att försämras och med hjälp av denna information vidta adekvata förebyggande åtgärder.\r\n",
+        "keywords": [
+          "modified early warning score",
+          "MEWS",
+          "vitalparameter",
+          "vitala parametrar"
+        ],
+        "use": "Använd för att baserat på kliniska parametrar identifiera patienter med hög risk att försämras och med hjälp av denna information vidta adekvata förebyggande åtgärder.\r\n\r\nModified Early Warning Score (MEWS) baseras på fem parametrar som enkelt kontrolleras genom klinisk undersökning:\r\n\r\n- Andningsfrekvens\r\n- Systoliskt blodtryck\r\n- Hjärtfrekvens\r\n- Medvetandegrad (AVPU)\r\n- Kroppstemperatur\r\n\r\nEn total poäng om ≥5p och/eller 3p för separat parameter bör föranleda skyndsam bedömning av läkare då det är förenligt med försämrande tillstånd och ökad risk för hjärtstopp och behov av intensivvård.\r\n\r\nFlertalet sjukhus använder lokalt anpassade versioner av MEWS där diures inkluderas - denna modell kan enkelt justeras för att tillmötesgå specifika önskemål.",
+        "misuse": "Får ej användas för att registrera National Early Warning Score (NEWS). ",
+        "copyright": "Cambio Healthcare Systems"
+      },
+      "en": {
+        "id": "en",
+        "purpose": "To calculate a score based on categorising physiological readings and observations, as a simple method to support objective assessment of the degree of illness in an unwell patient.",
+        "keywords": [
+          "modified early warning score",
+          "MEWS",
+          "vital signs",
+          "pulse",
+          "urine",
+          "blood pressure"
+        ],
+        "use": "Use to record a composite score to support assessmennt of the degree of illness in an unwell patient.\r\n\r\nThe Modified Early Warning Score (MEWS) is based on five parameters easily controlled for through simple bedside examination:\r\n\r\n- Respiration rate\r\n- Systolic blood pressure\r\n- Heart rate\r\n- Level of consciousness (AVPU)\r\n- Body temperature\r\n\r\nA total score of ≥5p and/or 3p of one parameter should result in higher level of care as it is consistent with deteriorating state of the patient and increased risk of cardiac arrest and need for intensive care. \r\n\r\nSeveral hospitals use locally modified versions of the instrument including urine output - the model can be adjusted to accommodate specific requests.",
+        "misuse": "Not to be used to record National Early Warning Score (NEWS). ",
+        "copyright": "Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Subbe CP, Kruger M, Rutherford P, et al. Validation of a modified early warning score in medical admissions. Q J Med 2001;94:521–6.  \r\n\r\nModified Early Warning Scale, MEWS. Capio S:t Görans Sjukhus. Version 4.0. 2011-09-05"
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0002": {
+        "id": "gt0002",
+        "model_id": "openEHR-EHR-OBSERVATION.mews.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.mews.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0016": {
+            "id": "gt0016",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0004]"
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0009]"
+          },
+          "gt0018": {
+            "id": "gt0018",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0014]"
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0019]"
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0023]"
+          },
+          "gt0022": {
+            "id": "gt0022",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0032]"
+          }
+        }
+      },
+      "gt0003": {
+        "id": "gt0003",
+        "model_id": "openEHR-EHR-OBSERVATION.pulse.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.pulse.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0015": {
+            "id": "gt0015",
+            "path": "/data[at0002]/events[at0003]/data[at0001]/items[at0004]"
+          },
+          "gt0041": {
+            "id": "gt0041",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0005": {
+        "id": "gt0005",
+        "model_id": "openEHR-EHR-OBSERVATION.respiration.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.respiration.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0013": {
+            "id": "gt0013",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0004]"
+          },
+          "gt0042": {
+            "id": "gt0042",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0006": {
+        "id": "gt0006",
+        "model_id": "openEHR-EHR-OBSERVATION.avpu.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.avpu.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0011": {
+            "id": "gt0011",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0004]"
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0009]"
+          },
+          "gt0043": {
+            "id": "gt0043",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0007": {
+        "id": "gt0007",
+        "model_id": "openEHR-EHR-OBSERVATION.body_temperature.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.body_temperature.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0010": {
+            "id": "gt0010",
+            "path": "/data[at0002]/events[at0003]/data[at0001]/items[at0004]"
+          },
+          "gt0044": {
+            "id": "gt0044",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0008": {
+        "id": "gt0008",
+        "model_id": "openEHR-EHR-OBSERVATION.blood_pressure.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.blood_pressure.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0009": {
+            "id": "gt0009",
+            "path": "/data[at0001]/events[at0006]/data[at0003]/items[at0004]"
+          },
+          "gt0045": {
+            "id": "gt0045",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      }
+    },
+    "rules": {
+      "gt0026": {
+        "id": "gt0026",
+        "priority": 15,
+        "when": [
+          "$gt0016|Respiratory Rate|==null",
+          "$gt0017|Heart Rate|==null",
+          "$gt0018|Systolic Blood Pressure|==null",
+          "$gt0019|Temperature|==null",
+          "$gt0020|Level of consciousness|==null"
+        ],
+        "then": [
+          "$gt0016|Respiratory Rate|=0|local::at0005|9 - 14 bpm|",
+          "$gt0017|Heart Rate|=0|local::at0010|51 - 100 bpm|",
+          "$gt0018|Systolic Blood Pressure|=0|local::at0015|101 - 199 mmHg|",
+          "$gt0019|Temperature|=0|local::at0020|35 - 38.4 °C|",
+          "$gt0020|Level of consciousness|=0|local::at0024|Alert|"
+        ]
+      },
+      "gt0025": {
+        "id": "gt0025",
+        "priority": 14,
+        "when": [
+          "$gt0013|Respiration rate|.magnitude>=15",
+          "$gt0013|Respiration rate|.magnitude<=20"
+        ],
+        "then": [
+          "$gt0016|Respiratory Rate|=1|local::at0006|15 - 20 bpm|"
+        ]
+      },
+      "gt0024": {
+        "id": "gt0024",
+        "priority": 13,
+        "when": [
+          "($gt0013|Respiration rate|.magnitude<9)||(($gt0013|Respiration rate|.magnitude>=21)&&($gt0013|Respiration rate|.magnitude<=29))"
+        ],
+        "then": [
+          "$gt0016|Respiratory Rate|=2|local::at0007|< 9 or 21 - 29 bpm|"
+        ]
+      },
+      "gt0023": {
+        "id": "gt0023",
+        "priority": 12,
+        "when": [
+          "$gt0013|Respiration rate|.magnitude>=30"
+        ],
+        "then": [
+          "$gt0016|Respiratory Rate|=3|local::at0008|≥ 30 bpm|"
+        ]
+      },
+      "gt0027": {
+        "id": "gt0027",
+        "priority": 11,
+        "when": [
+          "(($gt0015|Rate|.magnitude>=41)&&($gt0015|Rate|.magnitude<=50))||(($gt0015|Rate|.magnitude>=101)&&($gt0015|Rate|.magnitude<=110))"
+        ],
+        "then": [
+          "$gt0017|Heart Rate|=1|local::at0011|41 - 50 or 101 - 110 bpm|"
+        ]
+      },
+      "gt0028": {
+        "id": "gt0028",
+        "priority": 10,
+        "when": [
+          "($gt0015|Rate|.magnitude<=40)||(($gt0015|Rate|.magnitude>=111)&&($gt0015|Rate|.magnitude<=129))"
+        ],
+        "then": [
+          "$gt0017|Heart Rate|=2|local::at0012|≤ 40 or 111 - 129 bpm|"
+        ]
+      },
+      "gt0029": {
+        "id": "gt0029",
+        "priority": 9,
+        "when": [
+          "$gt0015|Rate|.magnitude>=130"
+        ],
+        "then": [
+          "$gt0017|Heart Rate|=3|local::at0013|≥ 130 bpm|"
+        ]
+      },
+      "gt0030": {
+        "id": "gt0030",
+        "priority": 8,
+        "when": [
+          "$gt0009|Systolic|.magnitude>=81",
+          "$gt0009|Systolic|.magnitude<=100"
+        ],
+        "then": [
+          "$gt0018|Systolic Blood Pressure|=1|local::at0016|81 - 100 mmHg|"
+        ]
+      },
+      "gt0031": {
+        "id": "gt0031",
+        "priority": 7,
+        "when": [
+          "(($gt0009|Systolic|.magnitude>=71)&&($gt0009|Systolic|.magnitude<=80))||($gt0009|Systolic|.magnitude>=200)"
+        ],
+        "then": [
+          "$gt0018|Systolic Blood Pressure|=2|local::at0017|71 - 80 or ≥ 200 mmHg|"
+        ]
+      },
+      "gt0032": {
+        "id": "gt0032",
+        "priority": 6,
+        "when": [
+          "$gt0009|Systolic|.magnitude<=70"
+        ],
+        "then": [
+          "$gt0018|Systolic Blood Pressure|=3|local::at0018|≤ 70 mmHg|"
+        ]
+      },
+      "gt0033": {
+        "id": "gt0033",
+        "priority": 5,
+        "when": [
+          "($gt0010|Body temperature|.magnitude<=35.0)||($gt0010|Body temperature|.magnitude>=38.5)"
+        ],
+        "then": [
+          "$gt0019|Temperature|=2|local::at0022|< 35 or ≥ 38.5 °C|"
+        ]
+      },
+      "gt0034": {
+        "id": "gt0034",
+        "priority": 4,
+        "when": [
+          "!fired($gt0034)",
+          "!fired($gt0035)",
+          "!fired($gt0036)",
+          "($gt0011|AVPU Observation|==local::at0006|Voice|)||($gt0012|New Confusion|==local::at0011|Present|)"
+        ],
+        "then": [
+          "$gt0020|Level of consciousness|=1|local::at0025|New confusion or Voice|"
+        ]
+      },
+      "gt0035": {
+        "id": "gt0035",
+        "priority": 3,
+        "when": [
+          "!fired($gt0035)",
+          "$gt0011|AVPU Observation|==local::at0007|Pain|"
+        ],
+        "then": [
+          "$gt0020|Level of consciousness|=2|local::at0026|Pain|"
+        ]
+      },
+      "gt0036": {
+        "id": "gt0036",
+        "priority": 2,
+        "when": [
+          "!fired($gt0036)",
+          "$gt0011|AVPU Observation|==local::at0008|Unresponsive|"
+        ],
+        "then": [
+          "$gt0020|Level of consciousness|=3|local::at0027|Unresponsive|"
+        ]
+      },
+      "gt0040": {
+        "id": "gt0040",
+        "priority": 1,
+        "then": [
+          "$gt0022|Total score|.magnitude=((($gt0016.value+$gt0017.value)+$gt0018.value)+$gt0019.value)+$gt0020.value"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "sv": {
+        "id": "sv",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Modified Early Warning Score",
+            "description": "Modified Early Warning Score (MEWS) används för att baserat på kliniska parametrar identifiera patienter med hög risk att försämras och med hjälp av denna information vidta adekvata förebyggande åtgärder."
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "*(en) Systolic",
+            "description": "*(en) Peak systemic arterial blood pressure  - measured in systolic or contraction phase of the heart cycle."
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "*(en) Body temperature",
+            "description": "*(en) The measured body temperature (as a surrogate for the whole body)."
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "*(en) AVPU Observation",
+            "description": "*(en) The observation of the patient's responsiveness."
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "*(en) New Confusion",
+            "description": "*(en) *"
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "*(en) Respiration rate",
+            "description": "*(en) Rate of respiration."
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "*(en) Total urine output/24 hr",
+            "description": "*(en) *"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "*(en) Rate",
+            "description": "*(en) The rate, measured in beats per minute."
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "*(en) Respiratory Rate",
+            "description": "*(en) *"
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "text": "*(en) Heart Rate",
+            "description": "*(en) *"
+          },
+          "gt0018": {
+            "id": "gt0018",
+            "text": "*(en) Systolic Blood Pressure",
+            "description": "*(en) *"
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "text": "*(en) Temperature",
+            "description": "*(en) *"
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "*(en) Level of consciousness",
+            "description": "*(en) *"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "text": "*(en) Urine output/24 hr",
+            "description": "*(en) *"
+          },
+          "gt0022": {
+            "id": "gt0022",
+            "text": "*(en) Total score",
+            "description": "*(en) *"
+          },
+          "gt0023": {
+            "id": "gt0023",
+            "text": "*(en) CDS respiration to 3"
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "text": "*(en) CDS respiration to 2"
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "text": "*(en) CDS respiration to 1"
+          },
+          "gt0026": {
+            "id": "gt0026",
+            "text": "*(en) CDS default"
+          },
+          "gt0027": {
+            "id": "gt0027",
+            "text": "*(en) CDS heart rate to 1"
+          },
+          "gt0028": {
+            "id": "gt0028",
+            "text": "*(en) CDS heart rate to 2"
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "text": "*(en) CDS heart rate to 3"
+          },
+          "gt0030": {
+            "id": "gt0030",
+            "text": "*(en) CDS systolic blood pressure to 1"
+          },
+          "gt0031": {
+            "id": "gt0031",
+            "text": "*(en) CDS systolic blood pressure to 2"
+          },
+          "gt0032": {
+            "id": "gt0032",
+            "text": "*(en) CDS systolic blood pressure to 3"
+          },
+          "gt0033": {
+            "id": "gt0033",
+            "text": "*(en) CDS temperature to 2"
+          },
+          "gt0034": {
+            "id": "gt0034",
+            "text": "*(en) CDS level of consciousness to 1"
+          },
+          "gt0035": {
+            "id": "gt0035",
+            "text": "*(en) CDS level of consciousness to 2"
+          },
+          "gt0036": {
+            "id": "gt0036",
+            "text": "*(en) CDS level of consciousness to 3"
+          },
+          "gt0037": {
+            "id": "gt0037",
+            "text": "*(en) CDS urine output to 1"
+          },
+          "gt0038": {
+            "id": "gt0038",
+            "text": "*(en) CDS urine output to 2"
+          },
+          "gt0039": {
+            "id": "gt0039",
+            "text": "*(en) CDS urine output to 3"
+          },
+          "gt0040": {
+            "id": "gt0040",
+            "text": "*(en) Calculate total score"
+          },
+          "gt0041": {
+            "id": "gt0041",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0042": {
+            "id": "gt0042",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0043": {
+            "id": "gt0043",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0044": {
+            "id": "gt0044",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0045": {
+            "id": "gt0045",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      },
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Modified Early Warning Score",
+            "description": "MEWS acts as a 'track and trigger' system (reaction system) that is used to provide an objective indication of the degree of disease in a patient, so that actions can be put in at the right time. The MEWS score must always lead to a decision to continue treatment plan. With MEWS-measurements and clear action plans, the possibility increases of both detecting and treating failing patients in time."
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Systolic",
+            "description": "Peak systemic arterial blood pressure  - measured in systolic or contraction phase of the heart cycle."
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Body temperature",
+            "description": "The measured body temperature (as a surrogate for the whole body)."
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "AVPU Observation",
+            "description": "The observation of the patient's responsiveness."
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "New Confusion",
+            "description": "*"
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "Respiration rate",
+            "description": "Rate of respiration."
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "Total urine output/24 hr",
+            "description": "*"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "Rate",
+            "description": "The rate, measured in beats per minute."
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "Respiratory Rate",
+            "description": "*"
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "text": "Heart Rate",
+            "description": "*"
+          },
+          "gt0018": {
+            "id": "gt0018",
+            "text": "Systolic Blood Pressure",
+            "description": "*"
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "text": "Temperature",
+            "description": "*"
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "Level of consciousness",
+            "description": "*"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "text": "Urine output/24 hr",
+            "description": "*"
+          },
+          "gt0022": {
+            "id": "gt0022",
+            "text": "Total score",
+            "description": "*"
+          },
+          "gt0023": {
+            "id": "gt0023",
+            "text": "CDS respiration to 3"
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "text": "CDS respiration to 2"
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "text": "CDS respiration to 1"
+          },
+          "gt0026": {
+            "id": "gt0026",
+            "text": "CDS default"
+          },
+          "gt0027": {
+            "id": "gt0027",
+            "text": "CDS heart rate to 1"
+          },
+          "gt0028": {
+            "id": "gt0028",
+            "text": "CDS heart rate to 2"
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "text": "CDS heart rate to 3"
+          },
+          "gt0030": {
+            "id": "gt0030",
+            "text": "CDS systolic blood pressure to 1"
+          },
+          "gt0031": {
+            "id": "gt0031",
+            "text": "CDS systolic blood pressure to 2"
+          },
+          "gt0032": {
+            "id": "gt0032",
+            "text": "CDS systolic blood pressure to 3"
+          },
+          "gt0033": {
+            "id": "gt0033",
+            "text": "CDS temperature to 2"
+          },
+          "gt0034": {
+            "id": "gt0034",
+            "text": "CDS level of consciousness to 1"
+          },
+          "gt0035": {
+            "id": "gt0035",
+            "text": "CDS level of consciousness to 2"
+          },
+          "gt0036": {
+            "id": "gt0036",
+            "text": "CDS level of consciousness to 3"
+          },
+          "gt0037": {
+            "id": "gt0037",
+            "text": "CDS urine output to 1"
+          },
+          "gt0038": {
+            "id": "gt0038",
+            "text": "CDS urine output to 2"
+          },
+          "gt0039": {
+            "id": "gt0039",
+            "text": "CDS urine output to 3"
+          },
+          "gt0040": {
+            "id": "gt0040",
+            "text": "Calculate total score"
+          },
+          "gt0041": {
+            "id": "gt0041",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0042": {
+            "id": "gt0042",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0043": {
+            "id": "gt0043",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0044": {
+            "id": "gt0044",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0045": {
+            "id": "gt0045",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/MEWS.v1.1.test.yml
+++ b/gdl2/MEWS.v1.1.test.yml
@@ -1,0 +1,145 @@
+guidelines:
+  1: MEWS.v1.1
+test_cases:
+- id: confused, unresponsive patient, RR22
+  input:
+    1:
+      gt0015|Rate: 77,/min
+      gt0041|Event time: 2019-04-27T23:12Z
+      gt0013|Respiration rate: 22,/min
+      gt0042|Event time: 2019-04-27T23:14Z
+      gt0011|AVPU Observation: local::at0008|Unresponsive|
+      gt0012|New Confusion: local::at0011|Present|
+      gt0043|Event time: 2019-04-27T23:14Z
+      gt0010|Body temperature: 37,°C
+      gt0044|Event time: 2019-04-27T23:12Z
+      gt0009|Systolic: 120,mm[Hg]
+      gt0045|Event time: 2019-04-27T23:14Z
+  expected_output:
+    1:
+      gt0016|Respiratory Rate: 2|local::at0007|< 9 or 21 - 29 bpm|
+      gt0020|Level of consciousness: 3|local::at0027|Unresponsive|
+      gt0022|Total score: 5
+      gt0019|Temperature: 0|local::at0020|35 - 38.4 °C|
+      gt0017|Heart Rate: 0|local::at0010|51 - 100 bpm|
+      gt0018|Systolic Blood Pressure: 0|local::at0015|101 - 199 mmHg|
+
+- id: hypothermia and BP 90
+  input:
+    1:
+      gt0015|Rate: 77,/min
+      gt0041|Event time: 2019-04-27T23:12Z
+      gt0013|Respiration rate: 22,/min
+      gt0042|Event time: 2019-04-27T23:14Z
+      gt0011|AVPU Observation: local::at0008|Unresponsive|
+      gt0012|New Confusion: local::at0011|Present|
+      gt0043|Event time: 2019-04-27T23:14Z
+      gt0010|Body temperature: 34,°C
+      gt0044|Event time: 2019-04-27T23:12Z
+      gt0009|Systolic: 90,mm[Hg]
+      gt0045|Event time: 2019-04-27T23:14Z
+  expected_output:
+    1:
+      gt0016|Respiratory Rate: 2|local::at0007|< 9 or 21 - 29 bpm|
+      gt0020|Level of consciousness: 3|local::at0027|Unresponsive|
+      gt0022|Total score: 8
+      gt0019|Temperature: 2|local::at0022|< 35 or ≥ 38.5 °C|
+      gt0017|Heart Rate: 0|local::at0010|51 - 100 bpm|
+      gt0018|Systolic Blood Pressure: 1|local::at0016|81 - 100 mmHg|
+
+- id: Hhypothermia, very low BP, consciousness pain
+  input:
+    1:
+      gt0015|Rate: 77,/min
+      gt0041|Event time: 2019-04-27T23:12Z
+      gt0013|Respiration rate: 22,/min
+      gt0042|Event time: 2019-04-27T23:14Z
+      gt0011|AVPU Observation: local::at0007|Pain|
+      gt0012|New Confusion: local::at0011|Present|
+      gt0043|Event time: 2019-04-27T23:14Z
+      gt0010|Body temperature: 34,°C
+      gt0044|Event time: 2019-04-27T23:12Z
+      gt0009|Systolic: 78,mm[Hg]
+      gt0045|Event time: 2019-04-27T23:14Z
+  expected_output:
+    1:
+      gt0016|Respiratory Rate: 2|local::at0007|< 9 or 21 - 29 bpm|
+      gt0020|Level of consciousness: 2|local::at0026|Pain|
+      gt0022|Total score: 8
+      gt0019|Temperature: 2|local::at0022|< 35 or ≥ 38.5 °C|
+      gt0017|Heart Rate: 0|local::at0010|51 - 100 bpm|
+      gt0018|Systolic Blood Pressure: 2|local::at0017|71 - 80 or ≥ 200 mmHg|
+
+
+- id: voice, HR below 50
+  input:
+    1:
+      gt0015|Rate: 49,/min
+      gt0041|Event time: 2019-04-27T23:12Z
+      gt0013|Respiration rate: 22,/min
+      gt0042|Event time: 2019-04-27T23:14Z
+      gt0011|AVPU Observation: local::at0006|Voice|
+      gt0012|New Confusion: local::at0011|Present|
+      gt0043|Event time: 2019-04-27T23:14Z
+      gt0010|Body temperature: 34,°C
+      gt0044|Event time: 2019-04-27T23:12Z
+      gt0009|Systolic: 78,mm[Hg]
+      gt0045|Event time: 2019-04-27T23:14Z
+  expected_output:
+    1:
+      gt0016|Respiratory Rate: 2|local::at0007|< 9 or 21 - 29 bpm|
+      gt0020|Level of consciousness: 1|local::at0025|New confusion or Voice|
+      gt0022|Total score: 8
+      gt0019|Temperature: 2|local::at0022|< 35 or ≥ 38.5 °C|
+      gt0017|Heart Rate: 1|local::at0011|41 - 50 or 101 - 110 bpm|
+      gt0018|Systolic Blood Pressure: 2|local::at0017|71 - 80 or ≥ 200 mmHg|
+
+
+
+- id: extreme low HR and BP
+  input:
+    1:
+      gt0015|Rate: 37,/min
+      gt0041|Event time: 2019-04-27T23:12Z
+      gt0013|Respiration rate: 22,/min
+      gt0042|Event time: 2019-04-27T23:14Z
+      gt0011|AVPU Observation: local::at0006|Voice|
+      gt0012|New Confusion: local::at0011|Present|
+      gt0043|Event time: 2019-04-27T23:14Z
+      gt0010|Body temperature: 34,°C
+      gt0044|Event time: 2019-04-27T23:12Z
+      gt0009|Systolic: 69,mm[Hg]
+      gt0045|Event time: 2019-04-27T23:14Z
+  expected_output:
+    1:
+      gt0016|Respiratory Rate: 2|local::at0007|< 9 or 21 - 29 bpm|
+      gt0020|Level of consciousness: 1|local::at0025|New confusion or Voice|
+      gt0022|Total score: 10
+      gt0019|Temperature: 2|local::at0022|< 35 or ≥ 38.5 °C|
+      gt0017|Heart Rate: 2|local::at0012|≤ 40 or 111 - 129 bpm|
+      gt0018|Systolic Blood Pressure: 3|local::at0018|≤ 70 mmHg|
+
+
+- id: respiratory rate low, alert, high BP, high HR
+  input:
+    1:
+      gt0015|Rate: 110,/min
+      gt0041|Event time: 2019-04-27T23:12Z
+      gt0013|Respiration rate: 8,/min
+      gt0042|Event time: 2019-04-27T23:14Z
+      gt0011|AVPU Observation: local::at0005|Alert|
+      gt0012|New Confusion: local::at0010|Absent|
+      gt0043|Event time: 2019-04-27T23:14Z
+      gt0010|Body temperature: 34,°C
+      gt0044|Event time: 2019-04-27T23:12Z
+      gt0009|Systolic: 210,mm[Hg]
+      gt0045|Event time: 2019-04-27T23:14Z
+  expected_output:
+    1:
+      gt0016|Respiratory Rate: 2|local::at0007|< 9 or 21 - 29 bpm|
+      gt0020|Level of consciousness: 0|local::at0024|Alert|
+      gt0022|Total score: 7
+      gt0019|Temperature: 2|local::at0022|< 35 or ≥ 38.5 °C|
+      gt0017|Heart Rate: 1|local::at0011|41 - 50 or 101 - 110 bpm|
+      gt0018|Systolic Blood Pressure: 2|local::at0017|71 - 80 or ≥ 200 mmHg|
+

--- a/gdl2/MEWS.v1.2.gdl2.json
+++ b/gdl2/MEWS.v1.2.gdl2.json
@@ -1,0 +1,777 @@
+{
+  "id": "MEWS.v1.2",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2016-09-26",
+      "name": "Konstantinos Kalliamvakos",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "Konstantinos.Kalliamvakos@cambio.se"
+    },
+    "other_contributors": [
+      "Dr Niklas Skyttberg",
+      "Oskar Nielsen",
+      "Dennis Forslund",
+      "Jimmy Axelsson"
+    ],
+    "lifecycle_state": "Author draft",
+    "details": {
+      "sv": {
+        "id": "sv",
+        "purpose": "För att beräkna en summa baserad på kategorisering av fysiologiska avläsningar och observationer, som en enkel metod för att stödja objektiv bedömning av graden av sjukdom hos en sjuk patient.",
+        "keywords": [
+          "MEWS",
+          "Modified Early Warning Score",
+          "puls",
+          "vitaltecken",
+          "urin",
+          "blodtryck"
+        ],
+        "use": "Används för att räkna ut en sammansatt poäng för att stödja bedömningen av graden av sjukdom hos en sjuk patient.",
+        "misuse": "Får ej användas för att beräkna National Early Warning Score (NEWS)."
+      },
+      "en": {
+        "id": "en",
+        "purpose": "To calculate a score based on categorising physiological readings and observations, as a simple method to support objective assessment of the degree of illness in an unwell patient.",
+        "keywords": [
+          "modified early warning score",
+          "MEWS",
+          "vital signs",
+          "pulse",
+          "urine",
+          "blood pressure"
+        ],
+        "use": "Use to calculate a composite score to support assessment of the degree of illness in an unwell patient.",
+        "misuse": "Not to be used to record National Early Warning Score (NEWS). Use openEHR-EHR-OBSERVATION.news.v1 instead.",
+        "copyright": "Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Modified Early Warning Scale, MEWS. Capio S:t Görans Sjukhus. Version 4.0. 2011-09-05"
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0002": {
+        "id": "gt0002",
+        "model_id": "openEHR-EHR-OBSERVATION.mews.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.mews.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0003": {
+            "id": "gt0003",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0004]"
+          },
+          "gt0004": {
+            "id": "gt0004",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0009]"
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0014]"
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0019]"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0023]"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0028]"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0032]"
+          }
+        }
+      },
+      "gt0010": {
+        "id": "gt0010",
+        "model_id": "openEHR-EHR-OBSERVATION.respiration.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.respiration.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0011": {
+            "id": "gt0011",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0004]"
+          },
+          "gt0045": {
+            "id": "gt0045",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0012": {
+        "id": "gt0012",
+        "model_id": "openEHR-EHR-OBSERVATION.pulse.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.pulse.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0013": {
+            "id": "gt0013",
+            "path": "/data[at0002]/events[at0003]/data[at0001]/items[at0004]"
+          },
+          "gt0044": {
+            "id": "gt0044",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0014": {
+        "id": "gt0014",
+        "model_id": "openEHR-EHR-OBSERVATION.blood_pressure.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.blood_pressure.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0015": {
+            "id": "gt0015",
+            "path": "/data[at0001]/events[at0006]/data[at0003]/items[at0004]"
+          },
+          "gt0043": {
+            "id": "gt0043",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0016": {
+        "id": "gt0016",
+        "model_id": "openEHR-EHR-OBSERVATION.body_temperature.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.body_temperature.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0017": {
+            "id": "gt0017",
+            "path": "/data[at0002]/events[at0003]/data[at0001]/items[at0004]"
+          },
+          "gt0042": {
+            "id": "gt0042",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0018": {
+        "id": "gt0018",
+        "model_id": "openEHR-EHR-OBSERVATION.avpu.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.avpu.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0019": {
+            "id": "gt0019",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0004]"
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0009]"
+          },
+          "gt0041": {
+            "id": "gt0041",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0021": {
+        "id": "gt0021",
+        "model_id": "openEHR-EHR-OBSERVATION.urine_output.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.urine_output.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0022": {
+            "id": "gt0022",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0004]"
+          },
+          "gt0040": {
+            "id": "gt0040",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      }
+    },
+    "default_actions": [
+      "$gt0003|Respiratory Rate|=0|local::at0005|9 - 14 bpm|",
+      "$gt0004|Heart Rate|=0|local::at0010|51 - 100 bpm|",
+      "$gt0005|Systolic Blood Pressure|=0|local::at0015|101 - 199 mmHg|",
+      "$gt0006|Temperature|=0|local::at0020|35 - 38.4 °C|",
+      "$gt0008|Urine output/24 hr|=0|local::at0029|Approx. 1 500 ml|",
+      "$gt0007|Level of consciousness|=0|local::at0024|Alert|"
+    ],
+    "rules": {
+      "gt0023": {
+        "id": "gt0023",
+        "priority": 17,
+        "when": [
+          "!fired($gt0023)",
+          "$gt0011|Respiration rate|>=30,/min"
+        ],
+        "then": [
+          "$gt0003|Respiratory Rate|=3|local::at0008|≥ 30 bpm|"
+        ]
+      },
+      "gt0024": {
+        "id": "gt0024",
+        "priority": 16,
+        "when": [
+          "!fired($gt0024)",
+          "($gt0011|Respiration rate|<9,/min)||(($gt0011|Respiration rate|>=21,/min)&&($gt0011|Respiration rate|<30,/min))"
+        ],
+        "then": [
+          "$gt0003|Respiratory Rate|=2|local::at0007|< 9 or 21 - 29 bpm|"
+        ]
+      },
+      "gt0025": {
+        "id": "gt0025",
+        "priority": 15,
+        "when": [
+          "!fired($gt0025)",
+          "$gt0011|Respiration rate|>=15,/min",
+          "$gt0011|Respiration rate|<21,/min"
+        ],
+        "then": [
+          "$gt0003|Respiratory Rate|=1|local::at0006|15 - 20 bpm|"
+        ]
+      },
+      "gt0026": {
+        "id": "gt0026",
+        "priority": 14,
+        "when": [
+          "!fired($gt0026)",
+          "$gt0013|Pulse|>=130,/min"
+        ],
+        "then": [
+          "$gt0004|Heart Rate|=3|local::at0013|≥ 130 bpm|"
+        ]
+      },
+      "gt0027": {
+        "id": "gt0027",
+        "priority": 13,
+        "when": [
+          "!fired($gt0027)",
+          "($gt0013|Pulse|<=40,/min)||(($gt0013|Pulse|>=111,/min)&&($gt0013|Pulse|<130,/min))"
+        ],
+        "then": [
+          "$gt0004|Heart Rate|=2|local::at0012|≤ 40 or 111 - 129 bpm|"
+        ]
+      },
+      "gt0028": {
+        "id": "gt0028",
+        "priority": 12,
+        "when": [
+          "!fired($gt0028)",
+          "(($gt0013|Pulse|>=41,/min)&&($gt0013|Pulse|<51,/min))||(($gt0013|Pulse|>=101,/min)&&($gt0013|Pulse|<111,/min))"
+        ],
+        "then": [
+          "$gt0004|Heart Rate|=1|local::at0011|41 - 50 or 101 - 110 bpm|"
+        ]
+      },
+      "gt0029": {
+        "id": "gt0029",
+        "priority": 11,
+        "when": [
+          "!fired($gt0029)",
+          "$gt0015|Systolic blood pressure|<=70,mm[Hg]"
+        ],
+        "then": [
+          "$gt0005|Systolic Blood Pressure|=3|local::at0018|≤ 70 mmHg|"
+        ]
+      },
+      "gt0030": {
+        "id": "gt0030",
+        "priority": 10,
+        "when": [
+          "!fired($gt0030)",
+          "(($gt0015|Systolic blood pressure|>=71,mm[Hg])&&($gt0015|Systolic blood pressure|<81,mm[Hg]))||($gt0015|Systolic blood pressure|>=200,mm[Hg])"
+        ],
+        "then": [
+          "$gt0005|Systolic Blood Pressure|=2|local::at0017|71 - 80 or ≥ 200 mmHg|"
+        ]
+      },
+      "gt0031": {
+        "id": "gt0031",
+        "priority": 9,
+        "when": [
+          "!fired($gt0031)",
+          "$gt0015|Systolic blood pressure|>=81,mm[Hg]",
+          "$gt0015|Systolic blood pressure|<101,mm[Hg]"
+        ],
+        "then": [
+          "$gt0005|Systolic Blood Pressure|=1|local::at0016|81 - 100 mmHg|"
+        ]
+      },
+      "gt0032": {
+        "id": "gt0032",
+        "priority": 8,
+        "when": [
+          "!fired($gt0032)",
+          "($gt0017|Temperature|.magnitude<35)||($gt0017|Temperature|.magnitude>=38.5)"
+        ],
+        "then": [
+          "$gt0006|Temperature|=2|local::at0022|< 35 or ≥ 38.5 °C|"
+        ]
+      },
+      "gt0033": {
+        "id": "gt0033",
+        "priority": 7,
+        "when": [
+          "!fired($gt0033)",
+          "$gt0019|AVPU Observation|==local::at0008|Unresponsive|"
+        ],
+        "then": [
+          "$gt0007|Level of consciousness|=3|local::at0027|Unresponsive|"
+        ]
+      },
+      "gt0034": {
+        "id": "gt0034",
+        "priority": 6,
+        "when": [
+          "!fired($gt0034)",
+          "$gt0019|AVPU Observation|==local::at0007|Pain|"
+        ],
+        "then": [
+          "$gt0007|Level of consciousness|=2|local::at0026|Pain|"
+        ]
+      },
+      "gt0035": {
+        "id": "gt0035",
+        "priority": 5,
+        "when": [
+          "!fired($gt0033)",
+          "!fired($gt0034)",
+          "!fired($gt0035)",
+          "($gt0019|AVPU Observation|==local::at0006|Voice|)||($gt0020|New Confusion|==local::at0011|Present|)"
+        ],
+        "then": [
+          "$gt0007|Level of consciousness|=1|local::at0025|New confusion or Voice|"
+        ]
+      },
+      "gt0036": {
+        "id": "gt0036",
+        "priority": 4,
+        "when": [
+          "!fired($gt0036)",
+          "$gt0022|Total urine output/24 hr|>=0,ml",
+          "$gt0022|Total urine output/24 hr|<250,ml"
+        ],
+        "then": [
+          "$gt0008|Urine output/24 hr|=3|local::at0033|No diuresis|"
+        ]
+      },
+      "gt0037": {
+        "id": "gt0037",
+        "priority": 3,
+        "when": [
+          "!fired($gt0037)",
+          "$gt0022|Total urine output/24 hr|>=250,ml",
+          "$gt0022|Total urine output/24 hr|<=750,ml"
+        ],
+        "then": [
+          "$gt0008|Urine output/24 hr|=2|local::at0031|Approx. 500 ml|"
+        ]
+      },
+      "gt0038": {
+        "id": "gt0038",
+        "priority": 2,
+        "when": [
+          "!fired($gt0038)",
+          "(($gt0022|Total urine output/24 hr|<=1250,ml)&&($gt0022|Total urine output/24 hr|>750,ml))||($gt0022|Total urine output/24 hr|>2500,ml)"
+        ],
+        "then": [
+          "$gt0008|Urine output/24 hr|=1|local::at0030|Approx. 1 000 ml or > 2 500 ml|"
+        ]
+      },
+      "gt0039": {
+        "id": "gt0039",
+        "priority": 1,
+        "when": [
+          "!fired($gt0039)"
+        ],
+        "then": [
+          "$gt0009|Total score|.magnitude=(((($gt0003.value+$gt0004.value)+$gt0005.value)+$gt0006.value)+$gt0007.value)+$gt0008.value"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "sv": {
+        "id": "sv",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Modified Early Warning Score",
+            "description": "MEWS fungerar som ett \\\"track and trigger\\\"-system (reaktionssystem) som används för att ge en objektiv indikation på graden av sjukdom hos en patient för att kunna sätta in åtgärder vid rätt tidpunkt. MEWS-värden måste alltid leda till ett ställningstagande till fortsatt behandlingsplan. Med MEWS-mätningar och tydliga handlingsplaner ökar möjligheten att sviktande patienter både upptäcks och behandlas i tid."
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "Andningsfrekvens",
+            "description": "*(en) *"
+          },
+          "gt0004": {
+            "id": "gt0004",
+            "text": "Hjärtfrekvens",
+            "description": "*(en) *"
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Systoliskt blodtryck",
+            "description": "*(en) *"
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Kroppstemperatur",
+            "description": "*(en) *"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Vakenhet",
+            "description": "*(en) *"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Urinproduktion/24 h",
+            "description": "*(en) *"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Total poäng",
+            "description": "*(en) *"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Andningsfrekvens",
+            "description": "*(en) Rate of respiration."
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "Puls",
+            "description": "*(en) The rate, measured in beats per minute."
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "Systoliskt blodtryck",
+            "description": "*(en) Peak systemic arterial blood pressure  - measured in systolic or contraction phase of the heart cycle."
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "text": "Kroppstemperatur",
+            "description": "*(en) The thermal situation of the person who is having the temperature taken."
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "text": "AVPU",
+            "description": "*(en) The observation of the patient's responsiveness."
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "Nytillkommen förvirring",
+            "description": "*(en) *"
+          },
+          "gt0022": {
+            "id": "gt0022",
+            "text": "Urinproduktion/24 h",
+            "description": "*(en) *"
+          },
+          "gt0023": {
+            "id": "gt0023",
+            "text": "Ange andningsfrekvens poäng till 3"
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "text": "Ange andningsfrekvens poäng till 2"
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "text": "Ange andningsfrekvens poäng till 1"
+          },
+          "gt0026": {
+            "id": "gt0026",
+            "text": "Ange hjärtfrekvens poäng till 3"
+          },
+          "gt0027": {
+            "id": "gt0027",
+            "text": "Ange hjärtfrekvens poäng till 2"
+          },
+          "gt0028": {
+            "id": "gt0028",
+            "text": "Ange hjärtfrekvens poäng till 1"
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "text": "Ange systoliskt blodtryck poäng till 3"
+          },
+          "gt0030": {
+            "id": "gt0030",
+            "text": "Ange systoliskt blodtryck poäng till 2"
+          },
+          "gt0031": {
+            "id": "gt0031",
+            "text": "Ange systoliskt blodtryck poäng till 1"
+          },
+          "gt0032": {
+            "id": "gt0032",
+            "text": "Ange kroppstemperatur poäng till 2"
+          },
+          "gt0033": {
+            "id": "gt0033",
+            "text": "Ange vakenhet poäng till 3"
+          },
+          "gt0034": {
+            "id": "gt0034",
+            "text": "Ange vakenhet poäng till 2"
+          },
+          "gt0035": {
+            "id": "gt0035",
+            "text": "Ange vakenhet poäng till 1"
+          },
+          "gt0036": {
+            "id": "gt0036",
+            "text": "Ange urinproduktion poäng till 3"
+          },
+          "gt0037": {
+            "id": "gt0037",
+            "text": "Ange urinproduktion poäng till 2"
+          },
+          "gt0038": {
+            "id": "gt0038",
+            "text": "Ange urinproduktion poäng till 1"
+          },
+          "gt0039": {
+            "id": "gt0039",
+            "text": "Ange total poäng"
+          },
+          "gt0040": {
+            "id": "gt0040",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0041": {
+            "id": "gt0041",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0042": {
+            "id": "gt0042",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0043": {
+            "id": "gt0043",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0044": {
+            "id": "gt0044",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0045": {
+            "id": "gt0045",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      },
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Modified Early Warning Score",
+            "description": "MEWS acts as a 'track and trigger' system (reaction system) that is used to provide an objective indication of the degree of disease in a patient, so that actions can be put in at the right time. The MEWS score must always lead to a decision to continue treatment plan. With MEWS-measurements and clear action plans, the possibility increases of both detecting and treating failing patients in time."
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "Respiratory Rate",
+            "description": "*"
+          },
+          "gt0004": {
+            "id": "gt0004",
+            "text": "Heart Rate",
+            "description": "*"
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Systolic Blood Pressure",
+            "description": "*"
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Temperature",
+            "description": "*"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Level of consciousness",
+            "description": "*"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Urine output/24 hr",
+            "description": "*"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Total score",
+            "description": "*"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Respiration rate",
+            "description": "Rate of respiration."
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "Pulse",
+            "description": "The rate, measured in beats per minute."
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "Systolic blood pressure",
+            "description": "Peak systemic arterial blood pressure  - measured in systolic or contraction phase of the heart cycle."
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "text": "Temperature",
+            "description": "The thermal situation of the person who is having the temperature taken."
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "text": "AVPU Observation",
+            "description": "The observation of the patient's responsiveness."
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "New Confusion",
+            "description": "*"
+          },
+          "gt0022": {
+            "id": "gt0022",
+            "text": "Total urine output/24 hr",
+            "description": "*"
+          },
+          "gt0023": {
+            "id": "gt0023",
+            "text": "Set respiratory points to 3"
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "text": "Set respiratory points to 2"
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "text": "Set respiratory points to 1"
+          },
+          "gt0026": {
+            "id": "gt0026",
+            "text": "Set heart rate points to 3"
+          },
+          "gt0027": {
+            "id": "gt0027",
+            "text": "Set heart rate points to 2"
+          },
+          "gt0028": {
+            "id": "gt0028",
+            "text": "Set heart rate points to 1"
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "text": "Set systolic blood pressure to 3"
+          },
+          "gt0030": {
+            "id": "gt0030",
+            "text": "Set systolic blood pressure to 2"
+          },
+          "gt0031": {
+            "id": "gt0031",
+            "text": "Set systolic blood pressure to 1"
+          },
+          "gt0032": {
+            "id": "gt0032",
+            "text": "Set temperature points to 2"
+          },
+          "gt0033": {
+            "id": "gt0033",
+            "text": "Set level of consciousness points to 3"
+          },
+          "gt0034": {
+            "id": "gt0034",
+            "text": "Set level of consciousness points to 2"
+          },
+          "gt0035": {
+            "id": "gt0035",
+            "text": "Set level of consciousness points to 1"
+          },
+          "gt0036": {
+            "id": "gt0036",
+            "text": "Set urine output points to 3"
+          },
+          "gt0037": {
+            "id": "gt0037",
+            "text": "Set urine output points to 2"
+          },
+          "gt0038": {
+            "id": "gt0038",
+            "text": "Set urine output points to 1"
+          },
+          "gt0039": {
+            "id": "gt0039",
+            "text": "Set total score"
+          },
+          "gt0040": {
+            "id": "gt0040",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0041": {
+            "id": "gt0041",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0042": {
+            "id": "gt0042",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0043": {
+            "id": "gt0043",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0044": {
+            "id": "gt0044",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0045": {
+            "id": "gt0045",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/MEWS.v1.2.test.yml
+++ b/gdl2/MEWS.v1.2.test.yml
@@ -1,0 +1,179 @@
+guidelines:
+  1: MEWS.v1.2
+test_cases:
+- id: confused patient, no RR set
+  input:
+    1:
+      gt0013|Pulse: 77,/min
+      gt0044|Event time: 2019-04-26T22:31Z
+      gt0015|Systolic blood pressure: 120,mm[Hg]
+      gt0043|Event time: 2019-04-26T22:31Z
+      gt0017|Temperature: 37,°C
+      gt0042|Event time: 2019-04-26T22:32Z
+      gt0019|AVPU Observation: local::at0008|Unresponsive|
+      gt0020|New Confusion: local::at0011|Present|
+      gt0041|Event time: 2019-04-26T22:32Z
+      gt0022|Total urine output/24 hr: 2000,ml
+      gt0040|Event time: 2019-04-26T22:32Z
+  expected_output:
+    1:
+      gt0008|Urine output/24 hr: 0|local::at0029|Approx. 1 500 ml|
+      gt0003|Respiratory Rate: 0|local::at0005|9 - 14 bpm|
+      gt0005|Systolic Blood Pressure: 0|local::at0015|101 - 199 mmHg|
+      gt0007|Level of consciousness: 3|local::at0027|Unresponsive|
+      gt0004|Heart Rate: 0|local::at0010|51 - 100 bpm|
+      gt0006|Temperature: 0|local::at0020|35 - 38.4 °C|
+      gt0009|Total score: 3
+- id: Same with RR 22/min
+  input:
+    1:
+      gt0011|Respiration rate: 22,/min
+      gt0045|Event time: 2019-04-26T22:39Z
+      gt0013|Pulse: 77,/min
+      gt0044|Event time: 2019-04-26T22:31Z
+      gt0015|Systolic blood pressure: 120,mm[Hg]
+      gt0043|Event time: 2019-04-26T22:31Z
+      gt0017|Temperature: 37,°C
+      gt0042|Event time: 2019-04-26T22:32Z
+      gt0019|AVPU Observation: local::at0008|Unresponsive|
+      gt0020|New Confusion: local::at0011|Present|
+      gt0041|Event time: 2019-04-26T22:32Z
+      gt0022|Total urine output/24 hr: 2000,ml
+      gt0040|Event time: 2019-04-26T22:32Z
+  expected_output:
+    1:
+      gt0008|Urine output/24 hr: 0|local::at0029|Approx. 1 500 ml|
+      gt0003|Respiratory Rate: 2|local::at0007|< 9 or 21 - 29 bpm|
+      gt0005|Systolic Blood Pressure: 0|local::at0015|101 - 199 mmHg|
+      gt0007|Level of consciousness: 3|local::at0027|Unresponsive|
+      gt0004|Heart Rate: 0|local::at0010|51 - 100 bpm|
+      gt0006|Temperature: 0|local::at0020|35 - 38.4 °C|
+      gt0009|Total score: 5
+
+- id: hypothermia and BP 90
+  input:
+    1:
+      gt0011|Respiration rate: 22,/min
+      gt0045|Event time: 2019-04-26T22:39Z
+      gt0013|Pulse: 77,/min
+      gt0044|Event time: 2019-04-26T22:31Z
+      gt0015|Systolic blood pressure: 90,mm[Hg]
+      gt0043|Event time: 2019-04-26T22:31Z
+      gt0017|Temperature: 34,°C
+      gt0042|Event time: 2019-04-26T22:32Z
+      gt0019|AVPU Observation: local::at0008|Unresponsive|
+      gt0020|New Confusion: local::at0011|Present|
+      gt0041|Event time: 2019-04-26T22:32Z
+      gt0022|Total urine output/24 hr: 2000,ml
+      gt0040|Event time: 2019-04-26T22:32Z
+  expected_output:
+    1:
+      gt0008|Urine output/24 hr: 0|local::at0029|Approx. 1 500 ml|
+      gt0003|Respiratory Rate: 2|local::at0007|< 9 or 21 - 29 bpm|
+      gt0005|Systolic Blood Pressure: 1|local::at0016|81 - 100 mmHg|
+      gt0007|Level of consciousness: 3|local::at0027|Unresponsive|
+      gt0004|Heart Rate: 0|local::at0010|51 - 100 bpm|
+      gt0006|Temperature: 2|local::at0022|< 35 or ≥ 38.5 °C|
+      gt0009|Total score: 8
+
+
+- id: HR not set, hypothermia, very low BP, consciousness pain
+  input:
+    1:
+      gt0011|Respiration rate: 22,/min
+      gt0045|Event time: 2019-04-26T22:39Z
+      gt0015|Systolic blood pressure: 78,mm[Hg]
+      gt0043|Event time: 2019-04-26T22:31Z
+      gt0017|Temperature: 34,°C
+      gt0042|Event time: 2019-04-26T22:32Z
+      gt0019|AVPU Observation: local::at0007|Pain|
+      gt0020|New Confusion: local::at0010|Absent|
+      gt0041|Event time: 2019-04-26T22:32Z
+      gt0022|Total urine output/24 hr: 2000,ml
+      gt0040|Event time: 2019-04-26T22:32Z
+  expected_output:
+    1:
+      gt0008|Urine output/24 hr: 0|local::at0029|Approx. 1 500 ml|
+      gt0003|Respiratory Rate: 2|local::at0007|< 9 or 21 - 29 bpm|
+      gt0005|Systolic Blood Pressure: 2|local::at0017|71 - 80 or ≥ 200 mmHg|
+      gt0007|Level of consciousness: 2|local::at0026|Pain|
+      gt0004|Heart Rate: 0|local::at0010|51 - 100 bpm|
+      gt0006|Temperature: 2|local::at0022|< 35 or ≥ 38.5 °C|
+      gt0009|Total score: 8
+
+- id: voice, HR below 50
+  input:
+    1:
+      gt0011|Respiration rate: 22,/min
+      gt0045|Event time: 2019-04-26T22:39Z
+      gt0013|Pulse: 48,/min
+      gt0044|Event time: 2019-04-27T22:46Z
+      gt0015|Systolic blood pressure: 78,mm[Hg]
+      gt0043|Event time: 2019-04-26T22:31Z
+      gt0017|Temperature: 34,°C
+      gt0042|Event time: 2019-04-26T22:32Z
+      gt0019|AVPU Observation: local::at0006|Voice|
+      gt0020|New Confusion: local::at0010|Absent|
+      gt0041|Event time: 2019-04-26T22:32Z
+      gt0022|Total urine output/24 hr: 2000,ml
+      gt0040|Event time: 2019-04-26T22:32Z
+  expected_output:
+    1:
+      gt0008|Urine output/24 hr: 0|local::at0029|Approx. 1 500 ml|
+      gt0003|Respiratory Rate: 2|local::at0007|< 9 or 21 - 29 bpm|
+      gt0005|Systolic Blood Pressure: 2|local::at0017|71 - 80 or ≥ 200 mmHg|
+      gt0007|Level of consciousness: 1|local::at0025|New confusion or Voice|
+      gt0004|Heart Rate: 1|local::at0011|41 - 50 or 101 - 110 bpm|
+      gt0006|Temperature: 2|local::at0022|< 35 or ≥ 38.5 °C|
+      gt0009|Total score: 8
+
+
+- id: extreme low HR and BP, confusion not set
+  input:
+    1:
+      gt0011|Respiration rate: 22,/min
+      gt0045|Event time: 2019-04-26T22:39Z
+      gt0013|Pulse: 37,/min
+      gt0044|Event time: 2019-04-27T22:46Z
+      gt0015|Systolic blood pressure: 69,mm[Hg]
+      gt0043|Event time: 2019-04-26T22:31Z
+      gt0017|Temperature: 39,°C
+      gt0042|Event time: 2019-04-26T22:32Z
+      gt0019|AVPU Observation: local::at0008|Unresponsive|
+      gt0041|Event time: 2019-04-26T22:32Z
+      gt0022|Total urine output/24 hr: 800,ml
+      gt0040|Event time: 2019-04-26T22:32Z
+  expected_output:
+    1:
+      gt0008|Urine output/24 hr: 1|local::at0030|Approx. 1 000 ml or > 2 500 ml|
+      gt0003|Respiratory Rate: 2|local::at0007|< 9 or 21 - 29 bpm|
+      gt0005|Systolic Blood Pressure: 3|local::at0018|≤ 70 mmHg|
+      gt0007|Level of consciousness: 3|local::at0027|Unresponsive|
+      gt0004|Heart Rate: 2|local::at0012|≤ 40 or 111 - 129 bpm|
+      gt0006|Temperature: 2|local::at0022|< 35 or ≥ 38.5 °C|
+      gt0009|Total score: 13
+
+- id: Temperature not set, respiratory rate low, alert, high BP, high HR
+  input:
+    1:
+      gt0011|Respiration rate: 8,/min
+      gt0045|Event time: 2019-04-26T22:39Z
+      gt0013|Pulse: 110,/min
+      gt0044|Event time: 2019-04-27T22:46Z
+      gt0015|Systolic blood pressure: 210,mm[Hg]
+      gt0043|Event time: 2019-04-26T22:31Z
+      gt0019|AVPU Observation: local::at0005|Alert|
+      gt0020|New Confusion: local::at0010|Absent|
+      gt0041|Event time: 2019-04-26T22:32Z
+      gt0022|Total urine output/24 hr: 3000,ml
+      gt0040|Event time: 2019-04-26T22:32Z
+  expected_output:
+    1:
+      gt0008|Urine output/24 hr: 1|local::at0030|Approx. 1 000 ml or > 2 500 ml|
+      gt0003|Respiratory Rate: 2|local::at0007|< 9 or 21 - 29 bpm|
+      gt0005|Systolic Blood Pressure: 2|local::at0017|71 - 80 or ≥ 200 mmHg|
+      gt0007|Level of consciousness: 0|local::at0024|Alert|
+      gt0004|Heart Rate: 1|local::at0011|41 - 50 or 101 - 110 bpm|
+      gt0006|Temperature: 0|local::at0020|35 - 38.4 °C|
+      gt0009|Total score: 6
+


### PR DESCRIPTION
Changes:
(1) Event time
(2) In MEWS.v2 temperature had to be referenced by its magnitude in "Set temperature points to 2" rule, otherwise, it was impossible to even read the file. It took some time though to find the source of error. In fact, the "°" sign is was messing up with the editor.