### PR TITLE
ABC stroke risk score migrated

### DIFF
--- a/gdl2/ABC_stroke_risk_score_Assessment.v1.gdl2.json
+++ b/gdl2/ABC_stroke_risk_score_Assessment.v1.gdl2.json
@@ -1,0 +1,876 @@
+{
+  "id": "ABC_stroke_risk_score_Assessment.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2016-11-20",
+      "name": "Eneimi Allwell-Brown",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "other_contributors": [
+      "Dennis Forslund",
+      "Jimmy Axelsson"
+    ],
+    "lifecycle_state": "Author draft",
+    "details": {
+      "en": {
+        "id": "en",
+        "purpose": "To determine the 1-year and 3-year predicted risk of stroke/SE in individuals with atrial fibrillation. ABC-stroke risk has been validated as having significantly higher accuracy than the CHA2DS2-VASc risk model, in part because the included biomarkers are dynamic (their values can increase or decrease over time) and are better indicators of subclinical cardiovascular dysfunction and vascular vulnerability.",
+        "keywords": [
+          "atrial fibrillation",
+          "stroke risk",
+          "systemic embolism risk"
+        ],
+        "use": "Use to determine the 1-year and 3-year risk of stroke/SE (gven as percentages, %) from calculated value of ABC-stroke score, based on a nomogram plot. Because the ABC-stroke score is dynamic, so is the ABC-stroke risk and so this assessment is useful in monitoring changes in the risk of future events (stroke or SE), as well as in the selection/personalization of antithrombotic therapy.\r\nAn ABC-stroke score less than 4.0 predicts a 3-year risk of stroke/SE less than 1%; while the presence of a prior stroke or TIA implies a minimum score of 5.5 and 3-year risk of stroke/SE greater than 1%.",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Hijazi Z, Lindbäck J, Alexander JH, Hanna M, Held C, Hylek EM, Lopes RD, Oldgren J, Siegbahn A, Stewart RA, White HD. The ABC (age, biomarkers, clinical history) stroke risk score: a biomarker-based risk score for predicting stroke in atrial fibrillation. European heart journal. 2016 May 21;37(20):1582-90."
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0002": {
+        "id": "gt0002",
+        "model_id": "openEHR-EHR-OBSERVATION.abc_stroke_risk_score.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.abc_stroke_risk_score.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0003": {
+            "id": "gt0003",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0009]"
+          }
+        }
+      },
+      "gt0004": {
+        "id": "gt0004",
+        "model_id": "openEHR-EHR-EVALUATION.abc_stroke_risk.v1",
+        "template_id": "openEHR-EHR-EVALUATION.abc_stroke_risk.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0005": {
+            "id": "gt0005",
+            "path": "/data[at0001]/items[at0002]"
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "path": "/data[at0001]/items[at0003]"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "path": "/data[at0001]/items[at0004]"
+          }
+        }
+      }
+    },
+    "rules": {
+      "gt0007": {
+        "id": "gt0007",
+        "priority": 48,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=4.5"
+        ],
+        "then": [
+          "$gt0008|Comment|='3-year risk of stroke/SE less than 1 %'",
+          "$gt0008|Comment|='1-year risk of stroke/SE less than 1 %'"
+        ]
+      },
+      "gt0009": {
+        "id": "gt0009",
+        "priority": 47,
+        "when": [
+          "$gt0003|ABC stroke risk score|>4.5",
+          "$gt0003|ABC stroke risk score|<=5"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=1.167,%",
+          "$gt0008|Comment|='1-year risk of stroke/SE less than 1 %'"
+        ]
+      },
+      "gt0010": {
+        "id": "gt0010",
+        "priority": 46,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=6",
+          "$gt0003|ABC stroke risk score|>5"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=1.35,%",
+          "$gt0008|Comment|='1-year risk of stroke/SE less than 1 %'"
+        ]
+      },
+      "gt0011": {
+        "id": "gt0011",
+        "priority": 45,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=7",
+          "$gt0003|ABC stroke risk score|>6"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=1.583,%",
+          "$gt0008|Comment|='1-year risk of stroke/SE less than 1 %'"
+        ]
+      },
+      "gt0012": {
+        "id": "gt0012",
+        "priority": 44,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=8",
+          "$gt0003|ABC stroke risk score|>7"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=1.8,%",
+          "$gt0008|Comment|='1-year risk of stroke/SE less than 1 %'"
+        ]
+      },
+      "gt0013": {
+        "id": "gt0013",
+        "priority": 43,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=9",
+          "$gt0003|ABC stroke risk score|>8"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=2,%",
+          "$gt0008|Comment|='1-year risk of stroke/SE less than 1 %'"
+        ]
+      },
+      "gt0014": {
+        "id": "gt0014",
+        "priority": 42,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=9.5",
+          "$gt0003|ABC stroke risk score|>9"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=2.3,%",
+          "$gt0008|Comment|='1-year risk of stroke/SE less than 1 %'"
+        ]
+      },
+      "gt0015": {
+        "id": "gt0015",
+        "priority": 41,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=10",
+          "$gt0003|ABC stroke risk score|>9.5"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=2.45,%",
+          "$gt0005|1-year risk of stroke/SE|=1,%"
+        ]
+      },
+      "gt0016": {
+        "id": "gt0016",
+        "priority": 40,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=10.5",
+          "$gt0003|ABC stroke risk score|>10"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=2.65,%",
+          "$gt0005|1-year risk of stroke/SE|=1.15,%"
+        ]
+      },
+      "gt0017": {
+        "id": "gt0017",
+        "priority": 39,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=11",
+          "$gt0003|ABC stroke risk score|>10.5"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=2.8,%",
+          "$gt0005|1-year risk of stroke/SE|=1.2,%"
+        ]
+      },
+      "gt0018": {
+        "id": "gt0018",
+        "priority": 38,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=11.5",
+          "$gt0003|ABC stroke risk score|>11"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=3,%",
+          "$gt0005|1-year risk of stroke/SE|=1.33,%"
+        ]
+      },
+      "gt0019": {
+        "id": "gt0019",
+        "priority": 37,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=12",
+          "$gt0003|ABC stroke risk score|>11.5"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=3.17,%",
+          "$gt0005|1-year risk of stroke/SE|=1.42,%"
+        ]
+      },
+      "gt0020": {
+        "id": "gt0020",
+        "priority": 36,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=12.5",
+          "$gt0003|ABC stroke risk score|>12"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=3.51,%",
+          "$gt0005|1-year risk of stroke/SE|=1.56,%"
+        ]
+      },
+      "gt0021": {
+        "id": "gt0021",
+        "priority": 35,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=13",
+          "$gt0003|ABC stroke risk score|>12.5"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=3.85,%",
+          "$gt0005|1-year risk of stroke/SE|=1.667,%"
+        ]
+      },
+      "gt0022": {
+        "id": "gt0022",
+        "priority": 34,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=13.5",
+          "$gt0003|ABC stroke risk score|>13"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=4.17,%",
+          "$gt0005|1-year risk of stroke/SE|=1.778,%"
+        ]
+      },
+      "gt0023": {
+        "id": "gt0023",
+        "priority": 33,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=14",
+          "$gt0003|ABC stroke risk score|>13.5"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=4.34,%",
+          "$gt0005|1-year risk of stroke/SE|=1.84,%"
+        ]
+      },
+      "gt0024": {
+        "id": "gt0024",
+        "priority": 32,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=14.5",
+          "$gt0003|ABC stroke risk score|>14"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=4.7,%",
+          "$gt0005|1-year risk of stroke/SE|=2,%"
+        ]
+      },
+      "gt0025": {
+        "id": "gt0025",
+        "priority": 31,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=15",
+          "$gt0003|ABC stroke risk score|>14.5"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=5,%",
+          "$gt0005|1-year risk of stroke/SE|=2.15,%"
+        ]
+      },
+      "gt0026": {
+        "id": "gt0026",
+        "priority": 30,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=15.5",
+          "$gt0003|ABC stroke risk score|>15"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=5.42,%",
+          "$gt0005|1-year risk of stroke/SE|=2.35,%"
+        ]
+      },
+      "gt0027": {
+        "id": "gt0027",
+        "priority": 29,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=16",
+          "$gt0003|ABC stroke risk score|>15.5"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=5.833,%",
+          "$gt0005|1-year risk of stroke/SE|=2.5,%"
+        ]
+      },
+      "gt0028": {
+        "id": "gt0028",
+        "priority": 28,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=16.5",
+          "$gt0003|ABC stroke risk score|>16"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=6.667,%",
+          "$gt0005|1-year risk of stroke/SE|=2.75,%"
+        ]
+      },
+      "gt0029": {
+        "id": "gt0029",
+        "priority": 27,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=17",
+          "$gt0003|ABC stroke risk score|>16.5"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=7.08,%",
+          "$gt0005|1-year risk of stroke/SE|=2.9,%"
+        ]
+      },
+      "gt0030": {
+        "id": "gt0030",
+        "priority": 26,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=17.5",
+          "$gt0003|ABC stroke risk score|>17"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=7.708,%",
+          "$gt0005|1-year risk of stroke/SE|=3.09,%"
+        ]
+      },
+      "gt0031": {
+        "id": "gt0031",
+        "priority": 25,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=18",
+          "$gt0003|ABC stroke risk score|>17.5"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=8.333,%",
+          "$gt0005|1-year risk of stroke/SE|=3.34,%"
+        ]
+      },
+      "gt0032": {
+        "id": "gt0032",
+        "priority": 24,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=18.5",
+          "$gt0003|ABC stroke risk score|>18"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=8.75,%",
+          "$gt0005|1-year risk of stroke/SE|=3.68,%"
+        ]
+      },
+      "gt0033": {
+        "id": "gt0033",
+        "priority": 23,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=19",
+          "$gt0003|ABC stroke risk score|>18.5"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=9.2,%",
+          "$gt0005|1-year risk of stroke/SE|=4,%"
+        ]
+      },
+      "gt0034": {
+        "id": "gt0034",
+        "priority": 22,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=19.5",
+          "$gt0003|ABC stroke risk score|>19"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=9.583,%",
+          "$gt0005|1-year risk of stroke/SE|=4.34,%"
+        ]
+      },
+      "gt0035": {
+        "id": "gt0035",
+        "priority": 21,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=20",
+          "$gt0003|ABC stroke risk score|>19.5"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=10.238,%",
+          "$gt0005|1-year risk of stroke/SE|=4.55,%"
+        ]
+      },
+      "gt0054": {
+        "id": "gt0054",
+        "priority": 20,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=20.5",
+          "$gt0003|ABC stroke risk score|>20"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=11.429,%",
+          "$gt0005|1-year risk of stroke/SE|=4.9,%"
+        ]
+      },
+      "gt0055": {
+        "id": "gt0055",
+        "priority": 19,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=21",
+          "$gt0003|ABC stroke risk score|>20.5"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=12.143,%",
+          "$gt0005|1-year risk of stroke/SE|=5.167,%"
+        ]
+      },
+      "gt0036": {
+        "id": "gt0036",
+        "priority": 18,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=21.5",
+          "$gt0003|ABC stroke risk score|>21"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=13.094,%",
+          "$gt0005|1-year risk of stroke/SE|=5.833,%"
+        ]
+      },
+      "gt0037": {
+        "id": "gt0037",
+        "priority": 17,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=22",
+          "$gt0003|ABC stroke risk score|>21.5"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=14.048,%",
+          "$gt0005|1-year risk of stroke/SE|=6.25,%"
+        ]
+      },
+      "gt0038": {
+        "id": "gt0038",
+        "priority": 16,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=22.5",
+          "$gt0003|ABC stroke risk score|>22"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=15,%",
+          "$gt0005|1-year risk of stroke/SE|=6.944,%"
+        ]
+      },
+      "gt0039": {
+        "id": "gt0039",
+        "priority": 15,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=23",
+          "$gt0003|ABC stroke risk score|>22.5"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=15.952,%",
+          "$gt0005|1-year risk of stroke/SE|=7.5,%"
+        ]
+      },
+      "gt0040": {
+        "id": "gt0040",
+        "priority": 14,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=23.5",
+          "$gt0003|ABC stroke risk score|>23"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=17.143,%",
+          "$gt0005|1-year risk of stroke/SE|=7.917,%"
+        ]
+      },
+      "gt0041": {
+        "id": "gt0041",
+        "priority": 13,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=24",
+          "$gt0003|ABC stroke risk score|>23.5"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=17.857,%",
+          "$gt0005|1-year risk of stroke/SE|=8.542,%"
+        ]
+      },
+      "gt0042": {
+        "id": "gt0042",
+        "priority": 12,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=24.5",
+          "$gt0003|ABC stroke risk score|>24"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=19.286,%",
+          "$gt0005|1-year risk of stroke/SE|=9.167,%"
+        ]
+      },
+      "gt0043": {
+        "id": "gt0043",
+        "priority": 11,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=25",
+          "$gt0003|ABC stroke risk score|>24.5"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=20.5,%",
+          "$gt0005|1-year risk of stroke/SE|=9.444,%"
+        ]
+      },
+      "gt0044": {
+        "id": "gt0044",
+        "priority": 10,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=25.5",
+          "$gt0003|ABC stroke risk score|>25"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=22.5,%",
+          "$gt0005|1-year risk of stroke/SE|=10,%"
+        ]
+      },
+      "gt0045": {
+        "id": "gt0045",
+        "priority": 9,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=26",
+          "$gt0003|ABC stroke risk score|>25.5"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=23.75,%",
+          "$gt0005|1-year risk of stroke/SE|=10.625,%"
+        ]
+      },
+      "gt0046": {
+        "id": "gt0046",
+        "priority": 8,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=26.5",
+          "$gt0003|ABC stroke risk score|>26"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=25.625,%",
+          "$gt0005|1-year risk of stroke/SE|=11.562,%"
+        ]
+      },
+      "gt0047": {
+        "id": "gt0047",
+        "priority": 7,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=27",
+          "$gt0003|ABC stroke risk score|>26.5"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=26.875",
+          "$gt0005|1-year risk of stroke/SE|=12.5,%"
+        ]
+      },
+      "gt0048": {
+        "id": "gt0048",
+        "priority": 6,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=27.5",
+          "$gt0003|ABC stroke risk score|>27"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=28.75,%",
+          "$gt0005|1-year risk of stroke/SE|=13.125,%"
+        ]
+      },
+      "gt0049": {
+        "id": "gt0049",
+        "priority": 5,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=28",
+          "$gt0003|ABC stroke risk score|>27.5"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=30,%",
+          "$gt0005|1-year risk of stroke/SE|=13.7,%"
+        ]
+      },
+      "gt0050": {
+        "id": "gt0050",
+        "priority": 4,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=28.5",
+          "$gt0003|ABC stroke risk score|>28"
+        ],
+        "then": [
+          "$gt0008|Comment|='3-year risk of stroke/SE greater than 30 %'",
+          "$gt0008|Comment|='1-year risk of stroke/SE greater than 15 %'"
+        ]
+      },
+      "gt0051": {
+        "id": "gt0051",
+        "priority": 3,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=29",
+          "$gt0003|ABC stroke risk score|>28.5"
+        ],
+        "then": [
+          "$gt0008|Comment|='3-year risk of stroke/SE greater than 30 %'",
+          "$gt0008|Comment|='1-year risk of stroke/SE greater than 15 %'"
+        ]
+      },
+      "gt0052": {
+        "id": "gt0052",
+        "priority": 2,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=29.5",
+          "$gt0003|ABC stroke risk score|>29"
+        ],
+        "then": [
+          "$gt0008|Comment|='3-year risk of stroke/SE greater than 30 %'",
+          "$gt0008|Comment|='1-year risk of stroke/SE greater than 15 %'"
+        ]
+      },
+      "gt0053": {
+        "id": "gt0053",
+        "priority": 1,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=30",
+          "$gt0003|ABC stroke risk score|>29.5"
+        ],
+        "then": [
+          "$gt0008|Comment|='3-year risk of stroke/SE greater than 30 %'",
+          "$gt0008|Comment|='1-year risk of stroke/SE greater than 15 %'"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "ABC Stroke Risk Assessment",
+            "description": "ABC-stroke risk assessment is the predicted risk of stroke/systemic embolism (SE) in individuals with atrial fibrillation. It is derived from the ABC-stroke score which is a biomarker-based risk score calculated from the sum of points on a nomogram assigned for the individual's age [A], plasma concentration of two biomarkers [B]: cTnT-hs (cardiac troponin-T high-sensitivity) and NT-proBNP (N-terminal fragment B-type natriuretic peptide), and clinical history [C] of prior stroke or transient ischaemic attack (TIA). The ABC-stroke score takes a value between 0.0 - 30.0, and it is from this score that a nomogram plot for ABC-stroke risk is used to predict the 1-year and 3-year risk of stroke or systemic embolism in individuals with atrial fibrillation. An ABC-stroke score less than 4.0 predicts a 3-year risk of stroke/SE less than 1%; while the presence of a prior stroke or TIA implies a minimum score of 5.5 and 3-year risk of stroke/SE greater than 1%."
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "ABC stroke risk score",
+            "description": "Sum total of points assigned based on the 4 (four) ABC stroke risk criteria."
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "1-year risk of stroke/SE",
+            "description": "Predicted risk of developing a stroke or systemic embolism within 1 year based on ABC stroke score calculation."
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "3-year risk of stroke/SE",
+            "description": "Predicted risk of developing a stroke or systemic embolism within 3 years based on ABC stroke score calculation."
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Estimate stroke risk when stroke score <=4.5"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Comment",
+            "description": "Additional information about the stroke risk prediction."
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Estimate stroke risk when stroke score <=5"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Estimate stroke risk when stroke score <=6"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Estimate stroke risk when stroke score <=7"
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "Estimate stroke risk when stroke score <=8"
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "Estimate stroke risk when stroke score <=9"
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "Estimate stroke risk when stroke score <=9.5"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "Estimate stroke risk when stroke score <=10"
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "Estimate stroke risk when stroke score <=10.5"
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "text": "Estimate stroke risk when stroke score <=11"
+          },
+          "gt0018": {
+            "id": "gt0018",
+            "text": "Estimate stroke risk when stroke score <=11.5"
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "text": "Estimate stroke risk when stroke score <=12"
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "Estimate stroke risk when stroke score <=12.5"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "text": "Estimate stroke risk when stroke score <=13"
+          },
+          "gt0022": {
+            "id": "gt0022",
+            "text": "Estimate stroke risk when stroke score <=13.5"
+          },
+          "gt0023": {
+            "id": "gt0023",
+            "text": "Estimate stroke risk when stroke score <=14"
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "text": "Estimate stroke risk when stroke score <=14.5"
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "text": "Estimate stroke risk when stroke score <=15"
+          },
+          "gt0026": {
+            "id": "gt0026",
+            "text": "Estimate stroke risk when stroke score <=15.5"
+          },
+          "gt0027": {
+            "id": "gt0027",
+            "text": "Estimate stroke risk when stroke score <=16"
+          },
+          "gt0028": {
+            "id": "gt0028",
+            "text": "Estimate stroke risk when stroke score <=16.5"
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "text": "Estimate stroke risk when stroke score <=17"
+          },
+          "gt0030": {
+            "id": "gt0030",
+            "text": "Estimate stroke risk when stroke score <=17.5"
+          },
+          "gt0031": {
+            "id": "gt0031",
+            "text": "Estimate stroke risk when stroke score <=18"
+          },
+          "gt0032": {
+            "id": "gt0032",
+            "text": "Estimate stroke risk when stroke score <=18.5"
+          },
+          "gt0033": {
+            "id": "gt0033",
+            "text": "Estimate stroke risk when stroke score <=19"
+          },
+          "gt0034": {
+            "id": "gt0034",
+            "text": "Estimate stroke risk when stroke score <=19.5"
+          },
+          "gt0035": {
+            "id": "gt0035",
+            "text": "Estimate stroke risk when stroke score <=20"
+          },
+          "gt0036": {
+            "id": "gt0036",
+            "text": "Estimate stroke risk when stroke score <=21.5"
+          },
+          "gt0037": {
+            "id": "gt0037",
+            "text": "Estimate stroke risk when stroke score <=22"
+          },
+          "gt0038": {
+            "id": "gt0038",
+            "text": "Estimate stroke risk when stroke score <=22.5"
+          },
+          "gt0039": {
+            "id": "gt0039",
+            "text": "Estimate stroke risk when stroke score <=23"
+          },
+          "gt0040": {
+            "id": "gt0040",
+            "text": "Estimate stroke risk when stroke score <=23.5"
+          },
+          "gt0041": {
+            "id": "gt0041",
+            "text": "Estimate stroke risk when stroke score <=24"
+          },
+          "gt0042": {
+            "id": "gt0042",
+            "text": "Estimate stroke risk when stroke score <=24.5"
+          },
+          "gt0043": {
+            "id": "gt0043",
+            "text": "Estimate stroke risk when stroke score <=25"
+          },
+          "gt0044": {
+            "id": "gt0044",
+            "text": "Estimate stroke risk when stroke score <=25.5"
+          },
+          "gt0045": {
+            "id": "gt0045",
+            "text": "Estimate stroke risk when stroke score <=26"
+          },
+          "gt0046": {
+            "id": "gt0046",
+            "text": "Estimate stroke risk when stroke score <=26.5"
+          },
+          "gt0047": {
+            "id": "gt0047",
+            "text": "Estimate stroke risk when stroke score <=27"
+          },
+          "gt0048": {
+            "id": "gt0048",
+            "text": "Estimate stroke risk when stroke score <=27.5"
+          },
+          "gt0049": {
+            "id": "gt0049",
+            "text": "Estimate stroke risk when stroke score <=28"
+          },
+          "gt0050": {
+            "id": "gt0050",
+            "text": "Estimate stroke risk when stroke score <=28.5"
+          },
+          "gt0051": {
+            "id": "gt0051",
+            "text": "Estimate stroke risk when stroke score <=29"
+          },
+          "gt0052": {
+            "id": "gt0052",
+            "text": "Estimate stroke risk when stroke score <=29.5"
+          },
+          "gt0053": {
+            "id": "gt0053",
+            "text": "Estimate stroke risk when stroke score <=30"
+          },
+          "gt0054": {
+            "id": "gt0054",
+            "text": "Estimate stroke risk when stroke score <=20.5"
+          },
+          "gt0055": {
+            "id": "gt0055",
+            "text": "Estimate stroke risk when stroke score <=21"
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/ABC_stroke_risk_score_Assessment.v1.test.yml
+++ b/gdl2/ABC_stroke_risk_score_Assessment.v1.test.yml
@@ -1,0 +1,260 @@
+guidelines:
+  1: ABC_stroke_risk_score_Assessment.v1
+test_cases:
+- id: 10
+  input:
+    1:
+      gt0003|ABC stroke risk score: 10,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 1,%
+      gt0006|3-year risk of stroke/SE: 2.45,%
+- id: 10.5
+  input:
+    1:
+      gt0003|ABC stroke risk score: 10.5,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 1.15,%
+      gt0006|3-year risk of stroke/SE: 2.65,%
+- id: 11
+  input:
+    1:
+      gt0003|ABC stroke risk score: 11,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 1.2,%
+      gt0006|3-year risk of stroke/SE: 2.8,%
+- id: 11.5
+  input:
+    1:
+      gt0003|ABC stroke risk score: 11.5,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 1.33,%
+      gt0006|3-year risk of stroke/SE: 3,%
+- id: 12
+  input:
+    1:
+      gt0003|ABC stroke risk score: 12,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 1.42,%
+      gt0006|3-year risk of stroke/SE: 3.17,%
+- id: 13
+  input:
+    1:
+      gt0003|ABC stroke risk score: 13,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 1.667,%
+      gt0006|3-year risk of stroke/SE: 3.85,%
+- id: 13.5
+  input:
+    1:
+      gt0003|ABC stroke risk score: 13.5,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 1.778,%
+      gt0006|3-year risk of stroke/SE: 4.17,%
+- id: 14
+  input:
+    1:
+      gt0003|ABC stroke risk score: 14,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 1.84,%
+      gt0006|3-year risk of stroke/SE: 4.34,%
+- id: 14.5
+  input:
+    1:
+      gt0003|ABC stroke risk score: 14.5,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 2,%
+      gt0006|3-year risk of stroke/SE: 4.7,%
+- id: 15
+  input:
+    1:
+      gt0003|ABC stroke risk score: 15,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 2.15,%
+      gt0006|3-year risk of stroke/SE: 5,%
+- id: 15.5
+  input:
+    1:
+      gt0003|ABC stroke risk score: 15.5,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 2.35,%
+      gt0006|3-year risk of stroke/SE: 5.42,%
+- id: 16
+  input:
+    1:
+      gt0003|ABC stroke risk score: 16,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 2.5,%
+      gt0006|3-year risk of stroke/SE: 5.833,%
+- id: 16.5
+  input:
+    1:
+      gt0003|ABC stroke risk score: 16.5,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 2.75,%
+      gt0006|3-year risk of stroke/SE: 6.667,%
+- id: 17
+  input:
+    1:
+      gt0003|ABC stroke risk score: 17,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 2.9,%
+      gt0006|3-year risk of stroke/SE: 7.08,%
+- id: 17.5
+  input:
+    1:
+      gt0003|ABC stroke risk score: 17.5,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 3.09,%
+      gt0006|3-year risk of stroke/SE: 7.708,%
+- id: 18
+  input:
+    1:
+      gt0003|ABC stroke risk score: 18,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 3.34,%
+      gt0006|3-year risk of stroke/SE: 8.333,%
+- id: 18.5
+  input:
+    1:
+      gt0003|ABC stroke risk score: 18.5,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 3.68,%
+      gt0006|3-year risk of stroke/SE: 8.75,%
+- id: 20
+  input:
+    1:
+      gt0003|ABC stroke risk score: 20,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 4.55,%
+      gt0006|3-year risk of stroke/SE: 10.238,%
+- id: 20.5
+  input:
+    1:
+      gt0003|ABC stroke risk score: 20.5,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 4.9,%
+      gt0006|3-year risk of stroke/SE: 11.429,%
+- id: 21
+  input:
+    1:
+      gt0003|ABC stroke risk score: 21,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 5.167,%
+      gt0006|3-year risk of stroke/SE: 12.143,%
+- id: 21.5
+  input:
+    1:
+      gt0003|ABC stroke risk score: 21.5,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 5.833,%
+      gt0006|3-year risk of stroke/SE: 13.094,%
+- id: 23
+  input:
+    1:
+      gt0003|ABC stroke risk score: 23,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 7.5,%
+      gt0006|3-year risk of stroke/SE: 15.952,%
+- id: 24.5
+  input:
+    1:
+      gt0003|ABC stroke risk score: 24.5,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 9.167,%
+      gt0006|3-year risk of stroke/SE: 19.286,%
+- id: 26
+  input:
+    1:
+      gt0003|ABC stroke risk score: 26,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 10.625,%
+      gt0006|3-year risk of stroke/SE: 23.75,%
+
+- id: 29
+  input:
+    1:
+      gt0003|ABC stroke risk score: 29,1
+  expected_output:
+    1:
+      gt0008|Comment: 1-year risk of stroke/SE greater than 15 %
+
+- id: 4
+  input:
+    1:
+      gt0003|ABC stroke risk score: 4,1
+  expected_output:
+    1:
+      gt0008|Comment: 1-year risk of stroke/SE less than 1 %
+- id: 5
+  input:
+    1:
+      gt0003|ABC stroke risk score: 5,1
+  expected_output:
+    1:
+      gt0006|3-year risk of stroke/SE: 1.167,%
+      gt0008|Comment: 1-year risk of stroke/SE less than 1 %
+- id: 6
+  input:
+    1:
+      gt0003|ABC stroke risk score: 6,1
+  expected_output:
+    1:
+      gt0006|3-year risk of stroke/SE: 1.35,%
+      gt0008|Comment: 1-year risk of stroke/SE less than 1 %
+- id: 7
+  input:
+    1:
+      gt0003|ABC stroke risk score: 7,1
+  expected_output:
+    1:
+      gt0006|3-year risk of stroke/SE: 1.583,%
+      gt0008|Comment: 1-year risk of stroke/SE less than 1 %
+- id: 8
+  input:
+    1:
+      gt0003|ABC stroke risk score: 8,1
+  expected_output:
+    1:
+      gt0006|3-year risk of stroke/SE: 1.8,%
+      gt0008|Comment: 1-year risk of stroke/SE less than 1 %
+- id: 9
+  input:
+    1:
+      gt0003|ABC stroke risk score: 9,1
+  expected_output:
+    1:
+      gt0006|3-year risk of stroke/SE: 2,%
+      gt0008|Comment: 1-year risk of stroke/SE less than 1 %
+- id: 9.5
+  input:
+    1:
+      gt0003|ABC stroke risk score: 9.5,1
+  expected_output:
+    1:
+      gt0006|3-year risk of stroke/SE: 2.3,%
+      gt0008|Comment: 1-year risk of stroke/SE less than 1 %
+

--- a/gdl2/ABC_stroke_risk_score_Assessment.v2.gdl2.json
+++ b/gdl2/ABC_stroke_risk_score_Assessment.v2.gdl2.json
@@ -1,0 +1,838 @@
+{
+  "id": "ABC_stroke_risk_score_Assessment.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2016-11-20",
+      "name": "Eneimi Allwell-Brown",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "other_contributors": [
+      "Dennis Forslund",
+      "Jimmy Axelsson"
+    ],
+    "lifecycle_state": "Author draft",
+    "details": {
+      "en": {
+        "id": "en",
+        "purpose": "To determine the 1-year and 3-year predicted risk of stroke/SE in individuals with atrial fibrillation. ABC-stroke risk has been validated as having significantly higher accuracy than the CHA2DS2-VASc risk model, in part because the included biomarkers are dynamic (their values can increase or decrease over time) and are better indicators of subclinical cardiovascular dysfunction and vascular vulnerability.",
+        "keywords": [
+          "atrial fibrillation",
+          "stroke risk",
+          "systemic embolism risk"
+        ],
+        "use": "Use to determine the 1-year and 3-year risk of stroke/SE (gven as percentages, %) from calculated value of ABC-stroke score, based on a nomogram plot. Because the ABC-stroke score is dynamic, so is the ABC-stroke risk and so this assessment is useful in monitoring changes in the risk of future events (stroke or SE), as well as in the selection/personalization of antithrombotic therapy.\r\nAn ABC-stroke score less than 4.0 predicts a 3-year risk of stroke/SE less than 1%; while the presence of a prior stroke or TIA implies a minimum score of 5.5 and 3-year risk of stroke/SE greater than 1%.",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Hijazi Z, Lindbäck J, Alexander JH, Hanna M, Held C, Hylek EM, Lopes RD, Oldgren J, Siegbahn A, Stewart RA, White HD. The ABC (age, biomarkers, clinical history) stroke risk score: a biomarker-based risk score for predicting stroke in atrial fibrillation. European heart journal. 2016 May 21;37(20):1582-90."
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0002": {
+        "id": "gt0002",
+        "model_id": "openEHR-EHR-OBSERVATION.abc_stroke_risk_score.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.abc_stroke_risk_score.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0003": {
+            "id": "gt0003",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0009]"
+          }
+        }
+      },
+      "gt0004": {
+        "id": "gt0004",
+        "model_id": "openEHR-EHR-EVALUATION.abc_stroke_risk.v1",
+        "template_id": "openEHR-EHR-EVALUATION.abc_stroke_risk.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0005": {
+            "id": "gt0005",
+            "path": "/data[at0001]/items[at0002]"
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "path": "/data[at0001]/items[at0003]"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "path": "/data[at0001]/items[at0004]"
+          }
+        }
+      }
+    },
+    "rules": {
+      "gt0007": {
+        "id": "gt0007",
+        "priority": 48,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=4.5"
+        ],
+        "then": [
+          "$gt0008|Comment|='1-year risk of stroke/SE less than 1 %, 3-year risk of stroke/SE less than 1 %'"
+        ]
+      },
+      "gt0009": {
+        "id": "gt0009",
+        "priority": 47,
+        "when": [
+          "$gt0003|ABC stroke risk score|>4.5",
+          "$gt0003|ABC stroke risk score|<=5"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=1.167,%",
+          "$gt0008|Comment|='1-year risk of stroke/SE less than 1 %'"
+        ]
+      },
+      "gt0010": {
+        "id": "gt0010",
+        "priority": 46,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=6",
+          "$gt0003|ABC stroke risk score|>5"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=1.35,%",
+          "$gt0008|Comment|='1-year risk of stroke/SE less than 1 %'"
+        ]
+      },
+      "gt0011": {
+        "id": "gt0011",
+        "priority": 45,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=7",
+          "$gt0003|ABC stroke risk score|>6"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=1.583,%",
+          "$gt0008|Comment|='1-year risk of stroke/SE less than 1 %'"
+        ]
+      },
+      "gt0012": {
+        "id": "gt0012",
+        "priority": 44,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=8",
+          "$gt0003|ABC stroke risk score|>7"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=1.8,%",
+          "$gt0008|Comment|='1-year risk of stroke/SE less than 1 %'"
+        ]
+      },
+      "gt0013": {
+        "id": "gt0013",
+        "priority": 43,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=9",
+          "$gt0003|ABC stroke risk score|>8"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=2,%",
+          "$gt0008|Comment|='1-year risk of stroke/SE less than 1 %'"
+        ]
+      },
+      "gt0014": {
+        "id": "gt0014",
+        "priority": 42,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=9.5",
+          "$gt0003|ABC stroke risk score|>9"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=2.3,%",
+          "$gt0008|Comment|='1-year risk of stroke/SE less than 1 %'"
+        ]
+      },
+      "gt0015": {
+        "id": "gt0015",
+        "priority": 41,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=10",
+          "$gt0003|ABC stroke risk score|>9.5"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=2.45,%",
+          "$gt0005|1-year risk of stroke/SE|=1,%"
+        ]
+      },
+      "gt0016": {
+        "id": "gt0016",
+        "priority": 40,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=10.5",
+          "$gt0003|ABC stroke risk score|>10"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=2.65,%",
+          "$gt0005|1-year risk of stroke/SE|=1.15,%"
+        ]
+      },
+      "gt0017": {
+        "id": "gt0017",
+        "priority": 39,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=11",
+          "$gt0003|ABC stroke risk score|>10.5"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=2.8,%",
+          "$gt0005|1-year risk of stroke/SE|=1.2,%"
+        ]
+      },
+      "gt0018": {
+        "id": "gt0018",
+        "priority": 38,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=11.5",
+          "$gt0003|ABC stroke risk score|>11"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=3,%",
+          "$gt0005|1-year risk of stroke/SE|=1.33,%"
+        ]
+      },
+      "gt0019": {
+        "id": "gt0019",
+        "priority": 37,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=12",
+          "$gt0003|ABC stroke risk score|>11.5"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=3.17,%",
+          "$gt0005|1-year risk of stroke/SE|=1.42,%"
+        ]
+      },
+      "gt0020": {
+        "id": "gt0020",
+        "priority": 36,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=12.5",
+          "$gt0003|ABC stroke risk score|>12"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=3.51,%",
+          "$gt0005|1-year risk of stroke/SE|=1.56,%"
+        ]
+      },
+      "gt0021": {
+        "id": "gt0021",
+        "priority": 35,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=13",
+          "$gt0003|ABC stroke risk score|>12.5"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=3.85,%",
+          "$gt0005|1-year risk of stroke/SE|=1.667,%"
+        ]
+      },
+      "gt0022": {
+        "id": "gt0022",
+        "priority": 34,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=13.5",
+          "$gt0003|ABC stroke risk score|>13"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=4.17,%",
+          "$gt0005|1-year risk of stroke/SE|=1.778,%"
+        ]
+      },
+      "gt0023": {
+        "id": "gt0023",
+        "priority": 33,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=14",
+          "$gt0003|ABC stroke risk score|>13.5"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=4.34,%",
+          "$gt0005|1-year risk of stroke/SE|=1.84,%"
+        ]
+      },
+      "gt0024": {
+        "id": "gt0024",
+        "priority": 32,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=14.5",
+          "$gt0003|ABC stroke risk score|>14"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=4.7,%",
+          "$gt0005|1-year risk of stroke/SE|=2,%"
+        ]
+      },
+      "gt0025": {
+        "id": "gt0025",
+        "priority": 31,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=15",
+          "$gt0003|ABC stroke risk score|>14.5"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=5,%",
+          "$gt0005|1-year risk of stroke/SE|=2.15,%"
+        ]
+      },
+      "gt0026": {
+        "id": "gt0026",
+        "priority": 30,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=15.5",
+          "$gt0003|ABC stroke risk score|>15"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=5.42,%",
+          "$gt0005|1-year risk of stroke/SE|=2.35,%"
+        ]
+      },
+      "gt0027": {
+        "id": "gt0027",
+        "priority": 29,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=16",
+          "$gt0003|ABC stroke risk score|>15.5"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=5.833,%",
+          "$gt0005|1-year risk of stroke/SE|=2.5,%"
+        ]
+      },
+      "gt0028": {
+        "id": "gt0028",
+        "priority": 28,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=16.5",
+          "$gt0003|ABC stroke risk score|>16"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=6.667,%",
+          "$gt0005|1-year risk of stroke/SE|=2.75,%"
+        ]
+      },
+      "gt0029": {
+        "id": "gt0029",
+        "priority": 27,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=17",
+          "$gt0003|ABC stroke risk score|>16.5"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=7.08,%",
+          "$gt0005|1-year risk of stroke/SE|=2.9,%"
+        ]
+      },
+      "gt0030": {
+        "id": "gt0030",
+        "priority": 26,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=17.5",
+          "$gt0003|ABC stroke risk score|>17"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=7.708,%",
+          "$gt0005|1-year risk of stroke/SE|=3.09,%"
+        ]
+      },
+      "gt0031": {
+        "id": "gt0031",
+        "priority": 25,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=18",
+          "$gt0003|ABC stroke risk score|>17.5"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=8.333,%",
+          "$gt0005|1-year risk of stroke/SE|=3.34,%"
+        ]
+      },
+      "gt0032": {
+        "id": "gt0032",
+        "priority": 24,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=18.5",
+          "$gt0003|ABC stroke risk score|>18"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=8.75,%",
+          "$gt0005|1-year risk of stroke/SE|=3.68,%"
+        ]
+      },
+      "gt0033": {
+        "id": "gt0033",
+        "priority": 23,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=19",
+          "$gt0003|ABC stroke risk score|>18.5"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=9.2,%",
+          "$gt0005|1-year risk of stroke/SE|=4,%"
+        ]
+      },
+      "gt0034": {
+        "id": "gt0034",
+        "priority": 22,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=19.5",
+          "$gt0003|ABC stroke risk score|>19"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=9.583,%",
+          "$gt0005|1-year risk of stroke/SE|=4.34,%"
+        ]
+      },
+      "gt0035": {
+        "id": "gt0035",
+        "priority": 21,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=20",
+          "$gt0003|ABC stroke risk score|>19.5"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=10.238,%",
+          "$gt0005|1-year risk of stroke/SE|=4.55,%"
+        ]
+      },
+      "gt0054": {
+        "id": "gt0054",
+        "priority": 20,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=20.5",
+          "$gt0003|ABC stroke risk score|>20"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=11.429,%",
+          "$gt0005|1-year risk of stroke/SE|=4.9,%"
+        ]
+      },
+      "gt0055": {
+        "id": "gt0055",
+        "priority": 19,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=21",
+          "$gt0003|ABC stroke risk score|>20.5"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=12.143,%",
+          "$gt0005|1-year risk of stroke/SE|=5.167,%"
+        ]
+      },
+      "gt0036": {
+        "id": "gt0036",
+        "priority": 18,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=21.5",
+          "$gt0003|ABC stroke risk score|>21"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=13.094,%",
+          "$gt0005|1-year risk of stroke/SE|=5.833,%"
+        ]
+      },
+      "gt0037": {
+        "id": "gt0037",
+        "priority": 17,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=22",
+          "$gt0003|ABC stroke risk score|>21.5"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=14.048,%",
+          "$gt0005|1-year risk of stroke/SE|=6.25,%"
+        ]
+      },
+      "gt0038": {
+        "id": "gt0038",
+        "priority": 16,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=22.5",
+          "$gt0003|ABC stroke risk score|>22"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=15,%",
+          "$gt0005|1-year risk of stroke/SE|=6.944,%"
+        ]
+      },
+      "gt0039": {
+        "id": "gt0039",
+        "priority": 15,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=23",
+          "$gt0003|ABC stroke risk score|>22.5"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=15.952,%",
+          "$gt0005|1-year risk of stroke/SE|=7.5,%"
+        ]
+      },
+      "gt0040": {
+        "id": "gt0040",
+        "priority": 14,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=23.5",
+          "$gt0003|ABC stroke risk score|>23"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=17.143,%",
+          "$gt0005|1-year risk of stroke/SE|=7.917,%"
+        ]
+      },
+      "gt0041": {
+        "id": "gt0041",
+        "priority": 13,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=24",
+          "$gt0003|ABC stroke risk score|>23.5"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=17.857,%",
+          "$gt0005|1-year risk of stroke/SE|=8.542,%"
+        ]
+      },
+      "gt0042": {
+        "id": "gt0042",
+        "priority": 12,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=24.5",
+          "$gt0003|ABC stroke risk score|>24"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=19.286,%",
+          "$gt0005|1-year risk of stroke/SE|=9.167,%"
+        ]
+      },
+      "gt0043": {
+        "id": "gt0043",
+        "priority": 11,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=25",
+          "$gt0003|ABC stroke risk score|>24.5"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=20.5,%",
+          "$gt0005|1-year risk of stroke/SE|=9.444,%"
+        ]
+      },
+      "gt0044": {
+        "id": "gt0044",
+        "priority": 10,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=25.5",
+          "$gt0003|ABC stroke risk score|>25"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=22.5,%",
+          "$gt0005|1-year risk of stroke/SE|=10,%"
+        ]
+      },
+      "gt0045": {
+        "id": "gt0045",
+        "priority": 9,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=26",
+          "$gt0003|ABC stroke risk score|>25.5"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=23.75,%",
+          "$gt0005|1-year risk of stroke/SE|=10.625,%"
+        ]
+      },
+      "gt0046": {
+        "id": "gt0046",
+        "priority": 8,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=26.5",
+          "$gt0003|ABC stroke risk score|>26"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=25.625,%",
+          "$gt0005|1-year risk of stroke/SE|=11.562,%"
+        ]
+      },
+      "gt0047": {
+        "id": "gt0047",
+        "priority": 7,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=27",
+          "$gt0003|ABC stroke risk score|>26.5"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=26.875",
+          "$gt0005|1-year risk of stroke/SE|=12.5,%"
+        ]
+      },
+      "gt0048": {
+        "id": "gt0048",
+        "priority": 6,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=27.5",
+          "$gt0003|ABC stroke risk score|>27"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=28.75,%",
+          "$gt0005|1-year risk of stroke/SE|=13.125,%"
+        ]
+      },
+      "gt0049": {
+        "id": "gt0049",
+        "priority": 5,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=28",
+          "$gt0003|ABC stroke risk score|>27.5"
+        ],
+        "then": [
+          "$gt0006|3-year risk of stroke/SE|=30,%",
+          "$gt0005|1-year risk of stroke/SE|=13.7,%"
+        ]
+      },
+      "gt0050": {
+        "id": "gt0050",
+        "priority": 4,
+        "when": [
+          "$gt0003|ABC stroke risk score|<=30",
+          "$gt0003|ABC stroke risk score|>28"
+        ],
+        "then": [
+          "$gt0008|Comment|='1-year risk of stroke/SE greater than 15 %, 3-year risk of stroke/SE greater than 30 %'"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "ABC Stroke Risk Assessment",
+            "description": "ABC-stroke risk assessment is the predicted risk of stroke/systemic embolism (SE) in individuals with atrial fibrillation. It is derived from the ABC-stroke score which is a biomarker-based risk score calculated from the sum of points on a nomogram assigned for the individual's age [A], plasma concentration of two biomarkers [B]: cTnT-hs (cardiac troponin-T high-sensitivity) and NT-proBNP (N-terminal fragment B-type natriuretic peptide), and clinical history [C] of prior stroke or transient ischaemic attack (TIA). The ABC-stroke score takes a value between 0.0 - 30.0, and it is from this score that a nomogram plot for ABC-stroke risk is used to predict the 1-year and 3-year risk of stroke or systemic embolism in individuals with atrial fibrillation. An ABC-stroke score less than 4.0 predicts a 3-year risk of stroke/SE less than 1%; while the presence of a prior stroke or TIA implies a minimum score of 5.5 and 3-year risk of stroke/SE greater than 1%."
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "ABC stroke risk score",
+            "description": "Sum total of points assigned based on the 4 (four) ABC stroke risk criteria."
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "1-year risk of stroke/SE",
+            "description": "Predicted risk of developing a stroke or systemic embolism within 1 year based on ABC stroke score calculation."
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "3-year risk of stroke/SE",
+            "description": "Predicted risk of developing a stroke or systemic embolism within 3 years based on ABC stroke score calculation."
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Estimate stroke risk when stroke score <=4.5"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Comment",
+            "description": "Additional information about the stroke risk prediction."
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Estimate stroke risk when stroke score <=5"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Estimate stroke risk when stroke score <=6"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Estimate stroke risk when stroke score <=7"
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "Estimate stroke risk when stroke score <=8"
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "Estimate stroke risk when stroke score <=9"
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "Estimate stroke risk when stroke score <=9.5"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "Estimate stroke risk when stroke score <=10"
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "Estimate stroke risk when stroke score <=10.5"
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "text": "Estimate stroke risk when stroke score <=11"
+          },
+          "gt0018": {
+            "id": "gt0018",
+            "text": "Estimate stroke risk when stroke score <=11.5"
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "text": "Estimate stroke risk when stroke score <=12"
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "Estimate stroke risk when stroke score <=12.5"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "text": "Estimate stroke risk when stroke score <=13"
+          },
+          "gt0022": {
+            "id": "gt0022",
+            "text": "Estimate stroke risk when stroke score <=13.5"
+          },
+          "gt0023": {
+            "id": "gt0023",
+            "text": "Estimate stroke risk when stroke score <=14"
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "text": "Estimate stroke risk when stroke score <=14.5"
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "text": "Estimate stroke risk when stroke score <=15"
+          },
+          "gt0026": {
+            "id": "gt0026",
+            "text": "Estimate stroke risk when stroke score <=15.5"
+          },
+          "gt0027": {
+            "id": "gt0027",
+            "text": "Estimate stroke risk when stroke score <=16"
+          },
+          "gt0028": {
+            "id": "gt0028",
+            "text": "Estimate stroke risk when stroke score <=16.5"
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "text": "Estimate stroke risk when stroke score <=17"
+          },
+          "gt0030": {
+            "id": "gt0030",
+            "text": "Estimate stroke risk when stroke score <=17.5"
+          },
+          "gt0031": {
+            "id": "gt0031",
+            "text": "Estimate stroke risk when stroke score <=18"
+          },
+          "gt0032": {
+            "id": "gt0032",
+            "text": "Estimate stroke risk when stroke score <=18.5"
+          },
+          "gt0033": {
+            "id": "gt0033",
+            "text": "Estimate stroke risk when stroke score <=19"
+          },
+          "gt0034": {
+            "id": "gt0034",
+            "text": "Estimate stroke risk when stroke score <=19.5"
+          },
+          "gt0035": {
+            "id": "gt0035",
+            "text": "Estimate stroke risk when stroke score <=20"
+          },
+          "gt0036": {
+            "id": "gt0036",
+            "text": "Estimate stroke risk when stroke score <=21.5"
+          },
+          "gt0037": {
+            "id": "gt0037",
+            "text": "Estimate stroke risk when stroke score <=22"
+          },
+          "gt0038": {
+            "id": "gt0038",
+            "text": "Estimate stroke risk when stroke score <=22.5"
+          },
+          "gt0039": {
+            "id": "gt0039",
+            "text": "Estimate stroke risk when stroke score <=23"
+          },
+          "gt0040": {
+            "id": "gt0040",
+            "text": "Estimate stroke risk when stroke score <=23.5"
+          },
+          "gt0041": {
+            "id": "gt0041",
+            "text": "Estimate stroke risk when stroke score <=24"
+          },
+          "gt0042": {
+            "id": "gt0042",
+            "text": "Estimate stroke risk when stroke score <=24.5"
+          },
+          "gt0043": {
+            "id": "gt0043",
+            "text": "Estimate stroke risk when stroke score <=25"
+          },
+          "gt0044": {
+            "id": "gt0044",
+            "text": "Estimate stroke risk when stroke score <=25.5"
+          },
+          "gt0045": {
+            "id": "gt0045",
+            "text": "Estimate stroke risk when stroke score <=26"
+          },
+          "gt0046": {
+            "id": "gt0046",
+            "text": "Estimate stroke risk when stroke score <=26.5"
+          },
+          "gt0047": {
+            "id": "gt0047",
+            "text": "Estimate stroke risk when stroke score <=27"
+          },
+          "gt0048": {
+            "id": "gt0048",
+            "text": "Estimate stroke risk when stroke score <=27.5"
+          },
+          "gt0049": {
+            "id": "gt0049",
+            "text": "Estimate stroke risk when stroke score <=28"
+          },
+          "gt0050": {
+            "id": "gt0050",
+            "text": "Estimate stroke risk when stroke score <=28.5"
+          },
+          "gt0051": {
+            "id": "gt0051",
+            "text": "Estimate stroke risk when stroke score <=29"
+          },
+          "gt0052": {
+            "id": "gt0052",
+            "text": "Estimate stroke risk when stroke score <=29.5"
+          },
+          "gt0053": {
+            "id": "gt0053",
+            "text": "Estimate stroke risk when stroke score <=30"
+          },
+          "gt0054": {
+            "id": "gt0054",
+            "text": "Estimate stroke risk when stroke score <=20.5"
+          },
+          "gt0055": {
+            "id": "gt0055",
+            "text": "Estimate stroke risk when stroke score <=21"
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/ABC_stroke_risk_score_Assessment.v2.test.yml
+++ b/gdl2/ABC_stroke_risk_score_Assessment.v2.test.yml
@@ -1,0 +1,260 @@
+guidelines:
+  1: ABC_stroke_risk_score_Assessment.v1
+test_cases:
+- id: 10
+  input:
+    1:
+      gt0003|ABC stroke risk score: 10,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 1,%
+      gt0006|3-year risk of stroke/SE: 2.45,%
+- id: 10.5
+  input:
+    1:
+      gt0003|ABC stroke risk score: 10.5,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 1.15,%
+      gt0006|3-year risk of stroke/SE: 2.65,%
+- id: 11
+  input:
+    1:
+      gt0003|ABC stroke risk score: 11,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 1.2,%
+      gt0006|3-year risk of stroke/SE: 2.8,%
+- id: 11.5
+  input:
+    1:
+      gt0003|ABC stroke risk score: 11.5,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 1.33,%
+      gt0006|3-year risk of stroke/SE: 3,%
+- id: 12
+  input:
+    1:
+      gt0003|ABC stroke risk score: 12,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 1.42,%
+      gt0006|3-year risk of stroke/SE: 3.17,%
+- id: 13
+  input:
+    1:
+      gt0003|ABC stroke risk score: 13,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 1.667,%
+      gt0006|3-year risk of stroke/SE: 3.85,%
+- id: 13.5
+  input:
+    1:
+      gt0003|ABC stroke risk score: 13.5,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 1.778,%
+      gt0006|3-year risk of stroke/SE: 4.17,%
+- id: 14
+  input:
+    1:
+      gt0003|ABC stroke risk score: 14,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 1.84,%
+      gt0006|3-year risk of stroke/SE: 4.34,%
+- id: 14.5
+  input:
+    1:
+      gt0003|ABC stroke risk score: 14.5,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 2,%
+      gt0006|3-year risk of stroke/SE: 4.7,%
+- id: 15
+  input:
+    1:
+      gt0003|ABC stroke risk score: 15,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 2.15,%
+      gt0006|3-year risk of stroke/SE: 5,%
+- id: 15.5
+  input:
+    1:
+      gt0003|ABC stroke risk score: 15.5,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 2.35,%
+      gt0006|3-year risk of stroke/SE: 5.42,%
+- id: 16
+  input:
+    1:
+      gt0003|ABC stroke risk score: 16,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 2.5,%
+      gt0006|3-year risk of stroke/SE: 5.833,%
+- id: 16.5
+  input:
+    1:
+      gt0003|ABC stroke risk score: 16.5,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 2.75,%
+      gt0006|3-year risk of stroke/SE: 6.667,%
+- id: 17
+  input:
+    1:
+      gt0003|ABC stroke risk score: 17,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 2.9,%
+      gt0006|3-year risk of stroke/SE: 7.08,%
+- id: 17.5
+  input:
+    1:
+      gt0003|ABC stroke risk score: 17.5,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 3.09,%
+      gt0006|3-year risk of stroke/SE: 7.708,%
+- id: 18
+  input:
+    1:
+      gt0003|ABC stroke risk score: 18,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 3.34,%
+      gt0006|3-year risk of stroke/SE: 8.333,%
+- id: 18.5
+  input:
+    1:
+      gt0003|ABC stroke risk score: 18.5,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 3.68,%
+      gt0006|3-year risk of stroke/SE: 8.75,%
+- id: 20
+  input:
+    1:
+      gt0003|ABC stroke risk score: 20,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 4.55,%
+      gt0006|3-year risk of stroke/SE: 10.238,%
+- id: 20.5
+  input:
+    1:
+      gt0003|ABC stroke risk score: 20.5,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 4.9,%
+      gt0006|3-year risk of stroke/SE: 11.429,%
+- id: 21
+  input:
+    1:
+      gt0003|ABC stroke risk score: 21,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 5.167,%
+      gt0006|3-year risk of stroke/SE: 12.143,%
+- id: 21.5
+  input:
+    1:
+      gt0003|ABC stroke risk score: 21.5,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 5.833,%
+      gt0006|3-year risk of stroke/SE: 13.094,%
+- id: 23
+  input:
+    1:
+      gt0003|ABC stroke risk score: 23,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 7.5,%
+      gt0006|3-year risk of stroke/SE: 15.952,%
+- id: 24.5
+  input:
+    1:
+      gt0003|ABC stroke risk score: 24.5,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 9.167,%
+      gt0006|3-year risk of stroke/SE: 19.286,%
+- id: 26
+  input:
+    1:
+      gt0003|ABC stroke risk score: 26,1
+  expected_output:
+    1:
+      gt0005|1-year risk of stroke/SE: 10.625,%
+      gt0006|3-year risk of stroke/SE: 23.75,%
+
+- id: 29
+  input:
+    1:
+      gt0003|ABC stroke risk score: 29,1
+  expected_output:
+    1:
+      gt0008|Comment: 1-year risk of stroke/SE greater than 15 %, 3-year risk of stroke/SE greater than 30 %
+
+- id: 4
+  input:
+    1:
+      gt0003|ABC stroke risk score: 4,1
+  expected_output:
+    1:
+      gt0008|Comment: 1-year risk of stroke/SE less than 1 %, 3-year risk of stroke/SE less than 1 %
+- id: 5
+  input:
+    1:
+      gt0003|ABC stroke risk score: 5,1
+  expected_output:
+    1:
+      gt0006|3-year risk of stroke/SE: 1.167,%
+      gt0008|Comment: 1-year risk of stroke/SE less than 1 %
+- id: 6
+  input:
+    1:
+      gt0003|ABC stroke risk score: 6,1
+  expected_output:
+    1:
+      gt0006|3-year risk of stroke/SE: 1.35,%
+      gt0008|Comment: 1-year risk of stroke/SE less than 1 %
+- id: 7
+  input:
+    1:
+      gt0003|ABC stroke risk score: 7,1
+  expected_output:
+    1:
+      gt0006|3-year risk of stroke/SE: 1.583,%
+      gt0008|Comment: 1-year risk of stroke/SE less than 1 %
+- id: 8
+  input:
+    1:
+      gt0003|ABC stroke risk score: 8,1
+  expected_output:
+    1:
+      gt0006|3-year risk of stroke/SE: 1.8,%
+      gt0008|Comment: 1-year risk of stroke/SE less than 1 %
+- id: 9
+  input:
+    1:
+      gt0003|ABC stroke risk score: 9,1
+  expected_output:
+    1:
+      gt0006|3-year risk of stroke/SE: 2,%
+      gt0008|Comment: 1-year risk of stroke/SE less than 1 %
+- id: 9.5
+  input:
+    1:
+      gt0003|ABC stroke risk score: 9.5,1
+  expected_output:
+    1:
+      gt0006|3-year risk of stroke/SE: 2.3,%
+      gt0008|Comment: 1-year risk of stroke/SE less than 1 %
+

--- a/gdl2/ABC_stroke_risk_score_Calculation.v1.gdl2.json
+++ b/gdl2/ABC_stroke_risk_score_Calculation.v1.gdl2.json
@@ -1,0 +1,1553 @@
+{
+  "id": "ABC_stroke_risk_score_Calculation.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2016-11-18",
+      "name": "Eneimi Allwell-Brown",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "other_contributors": [
+      "Dennis Forslund",
+      "Jimmy Axelsson"
+    ],
+    "lifecycle_state": "Author draft",
+    "details": {
+      "sv": {
+        "id": "sv",
+        "purpose": "Att hos patienter med förmaksflimmer med hjälp av ett nomogram-baserat system beräkna risken för stroke eller embolism på ett respektive tre års sikt. Till skillnad från CHA2DS2-VASc som använder irreversibla riskfaktorer, är ABC-stroke score mer dynamisk. Detta på grund av de inkluderade biomarkörerna som bidrar med möjlighet att kontinuerligt utvärdera och uppskatta även subklinisk kardiovaskulär dysfunktion. ",
+        "keywords": [
+          "förmaksflimmer",
+          "ABC",
+          "stroke"
+        ],
+        "use": "Använd för att beräkna ABC-stroke score som är ett nomogram-baserat system inkluderandes områdena A = ålder, B = plasmakoncentration av Troponin T och NT-proBNP samt C = tidigare genomgången stroke eller TIA (transitorisk ischemisk attack).\r\n\r\nReferensram för giltiga inputvärden:\r\nÅlder: 44-90 år\r\nTroponin T: 1-180 (ng/L)\r\nNT-proBNP: 25-5900 (ng/L)\r\n\r\nMaximala poängen uppgår till 30p och utvärderas på ett respektive tre års sikt, för risken att drabbas av stroke eller embolism. En poäng om mindre än 4p indikerar en risk under 1% över tre års sikt.  ",
+        "misuse": "Är ej avsedd att användas för patienter utan diagnosticerat förmaksflimmer.",
+        "copyright": "© Cambio Healthcare Systems"
+      },
+      "en": {
+        "id": "en",
+        "purpose": "Nomogram based calculation of the ABC-stroke risk score, for subsequent prediction of 1-year and 3-year risk of stroke or systemic embolism in individual's with atrial fibrillation. In contrast with CHA2DS2-VASc score that uses categorical irreversible risk factors, the ABC-stroke score includes specific cardiac-derived biomarkers that make it a more dynamic entity with continuous risk variables, more accurate, and providing more information about subclinical cardiovascular dysfunction and vascular vulnerability.",
+        "keywords": [
+          "atrial fibrillation",
+          "stroke risk",
+          "systemic embolism risk"
+        ],
+        "use": "Use to calculate the ABC-stroke score which is a nomogram based sum total of the points assigned for the presence or absence of a prior stroke/TIA in the individual, the age, and the plasma concentrations of the cardiac enzyme cTnT-hs and cardiac hormone NT-proBNP. \r\nValid age range = 44 - 90 (years)\r\nValid cTnT-hs range = 1 - 180 (ng/L)\r\nValid NT-proBNP range = 25 - 5900 (ng/L)\r\nABC-stroke score = (((cTnT-hs points + Age points) + NT-proBNP points) + Prior stroke or transient ischaemic attack points)\r\nMinimum ABC-stroke score = 0.0 and maximum = 30.0. The calculated score is further used to predict the 1-year and 3-year risk of stroke/SE. ",
+        "misuse": "Do not use this calculator if the individual does not have atrial fibrillation.",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Hijazi Z, Lindbäck J, Alexander JH, Hanna M, Held C, Hylek EM, Lopes RD, Oldgren J, Siegbahn A, Stewart RA, White HD. The ABC (age, biomarkers, clinical history) stroke risk score: a biomarker-based risk score for predicting stroke in atrial fibrillation. European heart journal. 2016 May 21;37(20):1582-90."
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0003": {
+        "id": "gt0003",
+        "model_id": "openEHR-EHR-OBSERVATION.history_prior_stroke_tia.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.history_prior_stroke_tia.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0004": {
+            "id": "gt0004",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0004]"
+          }
+        }
+      },
+      "gt0005": {
+        "id": "gt0005",
+        "model_id": "openEHR-EHR-OBSERVATION.abc_stroke_risk_score.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.abc_stroke_risk_score.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0006": {
+            "id": "gt0006",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0005]"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0007]"
+          },
+          "gt0033": {
+            "id": "gt0033",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0006]"
+          },
+          "gt0046": {
+            "id": "gt0046",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0008]"
+          },
+          "gt0082": {
+            "id": "gt0082",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0009]"
+          }
+        }
+      },
+      "gt0009": {
+        "id": "gt0009",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-cardiac_enzymes.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-cardiac_enzymes.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0010": {
+            "id": "gt0010",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0.91]"
+          },
+          "gt0084": {
+            "id": "gt0084",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0031": {
+        "id": "gt0031",
+        "model_id": "openEHR-EHR-OBSERVATION.basic_demographic.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.basic_demographic.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0032": {
+            "id": "gt0032",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0008]"
+          }
+        }
+      },
+      "gt0044": {
+        "id": "gt0044",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-cardiac_hormones.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-cardiac_hormones.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0045": {
+            "id": "gt0045",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0.94]"
+          },
+          "gt0083": {
+            "id": "gt0083",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      }
+    },
+    "rules": {
+      "gt0002": {
+        "id": "gt0002",
+        "priority": 67,
+        "when": [
+          "$gt0004|Prior stroke/TIA|==0|local::at0007|No|"
+        ],
+        "then": [
+          "$gt0006|Prior stroke or transient ischaemic attack points|=0"
+        ]
+      },
+      "gt0007": {
+        "id": "gt0007",
+        "priority": 66,
+        "when": [
+          "$gt0004|Prior stroke/TIA|==1|local::at0008|Yes|"
+        ],
+        "then": [
+          "$gt0006|Prior stroke or transient ischaemic attack points|=5.5"
+        ]
+      },
+      "gt0008": {
+        "id": "gt0008",
+        "priority": 65,
+        "when": [
+          "$gt0010|cTnT-hs concentration|<=1,nanogm/l"
+        ],
+        "then": [
+          "$gt0011|cTnT-hs points|=0"
+        ]
+      },
+      "gt0012": {
+        "id": "gt0012",
+        "priority": 64,
+        "when": [
+          "$gt0010|cTnT-hs concentration|<=2,nanogm/l",
+          "$gt0010|cTnT-hs concentration|>1,nanogm/l"
+        ],
+        "then": [
+          "$gt0011|cTnT-hs points|=0.75"
+        ]
+      },
+      "gt0013": {
+        "id": "gt0013",
+        "priority": 63,
+        "when": [
+          "$gt0010|cTnT-hs concentration|<=5,nanogm/l",
+          "$gt0010|cTnT-hs concentration|>2,nanogm/l"
+        ],
+        "then": [
+          "$gt0011|cTnT-hs points|=1.75"
+        ]
+      },
+      "gt0014": {
+        "id": "gt0014",
+        "priority": 62,
+        "when": [
+          "$gt0010|cTnT-hs concentration|<=7.5,nanogm/l",
+          "$gt0010|cTnT-hs concentration|>5,nanogm/l"
+        ],
+        "then": [
+          "$gt0011|cTnT-hs points|=2.125"
+        ]
+      },
+      "gt0015": {
+        "id": "gt0015",
+        "priority": 61,
+        "when": [
+          "$gt0010|cTnT-hs concentration|<=10,nanogm/l",
+          "$gt0010|cTnT-hs concentration|>7.5,nanogm/l"
+        ],
+        "then": [
+          "$gt0011|cTnT-hs points|=2.5"
+        ]
+      },
+      "gt0016": {
+        "id": "gt0016",
+        "priority": 60,
+        "when": [
+          "$gt0010|cTnT-hs concentration|<=15,nanogm/l",
+          "$gt0010|cTnT-hs concentration|>10,nanogm/l"
+        ],
+        "then": [
+          "$gt0011|cTnT-hs points|=2.812"
+        ]
+      },
+      "gt0017": {
+        "id": "gt0017",
+        "priority": 59,
+        "when": [
+          "$gt0010|cTnT-hs concentration|<=20,nanogm/l",
+          "$gt0010|cTnT-hs concentration|>15,nanogm/l"
+        ],
+        "then": [
+          "$gt0011|cTnT-hs points|=3.125"
+        ]
+      },
+      "gt0018": {
+        "id": "gt0018",
+        "priority": 58,
+        "when": [
+          "$gt0010|cTnT-hs concentration|<=25,nanogm/l",
+          "$gt0010|cTnT-hs concentration|>20,nanogm/l"
+        ],
+        "then": [
+          "$gt0011|cTnT-hs points|=3.438"
+        ]
+      },
+      "gt0019": {
+        "id": "gt0019",
+        "priority": 57,
+        "when": [
+          "$gt0010|cTnT-hs concentration|<=30,nanogm/l",
+          "$gt0010|cTnT-hs concentration|>25,nanogm/l"
+        ],
+        "then": [
+          "$gt0011|cTnT-hs points|=3.75"
+        ]
+      },
+      "gt0020": {
+        "id": "gt0020",
+        "priority": 56,
+        "when": [
+          "$gt0010|cTnT-hs concentration|<=39,nanogm/l",
+          "$gt0010|cTnT-hs concentration|>30,nanogm/l"
+        ],
+        "then": [
+          "$gt0011|cTnT-hs points|=3.95"
+        ]
+      },
+      "gt0021": {
+        "id": "gt0021",
+        "priority": 55,
+        "when": [
+          "$gt0010|cTnT-hs concentration|<=48,nanogm/l",
+          "$gt0010|cTnT-hs concentration|>39,nanogm/l"
+        ],
+        "then": [
+          "$gt0011|cTnT-hs points|=4.15"
+        ]
+      },
+      "gt0022": {
+        "id": "gt0022",
+        "priority": 54,
+        "when": [
+          "$gt0010|cTnT-hs concentration|<=57,nanogm/l",
+          "$gt0010|cTnT-hs concentration|>48,nanogm/l"
+        ],
+        "then": [
+          "$gt0011|cTnT-hs points|=4.35"
+        ]
+      },
+      "gt0023": {
+        "id": "gt0023",
+        "priority": 53,
+        "when": [
+          "$gt0010|cTnT-hs concentration|<=66,nanogm/l",
+          "$gt0010|cTnT-hs concentration|>57,nanogm/l"
+        ],
+        "then": [
+          "$gt0011|cTnT-hs points|=4.55"
+        ]
+      },
+      "gt0024": {
+        "id": "gt0024",
+        "priority": 52,
+        "when": [
+          "$gt0010|cTnT-hs concentration|<=75,nanogm/l",
+          "$gt0010|cTnT-hs concentration|>66,nanogm/l"
+        ],
+        "then": [
+          "$gt0011|cTnT-hs points|=4.75"
+        ]
+      },
+      "gt0025": {
+        "id": "gt0025",
+        "priority": 51,
+        "when": [
+          "$gt0010|cTnT-hs concentration|<=96,nanogm/l",
+          "$gt0010|cTnT-hs concentration|>75,nanogm/l"
+        ],
+        "then": [
+          "$gt0011|cTnT-hs points|=4.95"
+        ]
+      },
+      "gt0026": {
+        "id": "gt0026",
+        "priority": 50,
+        "when": [
+          "$gt0010|cTnT-hs concentration|<=117,nanogm/l",
+          "$gt0010|cTnT-hs concentration|>96,nanogm/l"
+        ],
+        "then": [
+          "$gt0011|cTnT-hs points|=5.15"
+        ]
+      },
+      "gt0027": {
+        "id": "gt0027",
+        "priority": 49,
+        "when": [
+          "$gt0010|cTnT-hs concentration|<=138,nanogm/l",
+          "$gt0010|cTnT-hs concentration|>117,nanogm/l"
+        ],
+        "then": [
+          "$gt0011|cTnT-hs points|=5.35"
+        ]
+      },
+      "gt0028": {
+        "id": "gt0028",
+        "priority": 48,
+        "when": [
+          "$gt0010|cTnT-hs concentration|<=159,nanogm/l",
+          "$gt0010|cTnT-hs concentration|>138,nanogm/l"
+        ],
+        "then": [
+          "$gt0011|cTnT-hs points|=5.55"
+        ]
+      },
+      "gt0029": {
+        "id": "gt0029",
+        "priority": 47,
+        "when": [
+          "$gt0010|cTnT-hs concentration|<=180,nanogm/l",
+          "$gt0010|cTnT-hs concentration|>159,nanogm/l"
+        ],
+        "then": [
+          "$gt0011|cTnT-hs points|=5.75"
+        ]
+      },
+      "gt0030": {
+        "id": "gt0030",
+        "priority": 46,
+        "when": [
+          "$gt0032|Birthdate|>=($currentDateTime-44,a)"
+        ],
+        "then": [
+          "$gt0033|Age points|=0"
+        ]
+      },
+      "gt0034": {
+        "id": "gt0034",
+        "priority": 45,
+        "when": [
+          "$gt0032|Birthdate|<($currentDateTime-44,a)",
+          "$gt0032|Birthdate|>=($currentDateTime-50,a)"
+        ],
+        "then": [
+          "$gt0033|Age points|=0.375"
+        ]
+      },
+      "gt0035": {
+        "id": "gt0035",
+        "priority": 44,
+        "when": [
+          "$gt0032|Birthdate|<($currentDateTime-50,a)",
+          "$gt0032|Birthdate|>=($currentDateTime-55,a)"
+        ],
+        "then": [
+          "$gt0033|Age points|=0.75"
+        ]
+      },
+      "gt0036": {
+        "id": "gt0036",
+        "priority": 43,
+        "when": [
+          "$gt0032|Birthdate|<($currentDateTime-55,a)",
+          "$gt0032|Birthdate|>=($currentDateTime-60,a)"
+        ],
+        "then": [
+          "$gt0033|Age points|=1.062"
+        ]
+      },
+      "gt0037": {
+        "id": "gt0037",
+        "priority": 42,
+        "when": [
+          "$gt0032|Birthdate|<($currentDateTime-60,a)",
+          "$gt0032|Birthdate|>=($currentDateTime-65,a)"
+        ],
+        "then": [
+          "$gt0033|Age points|=1.375"
+        ]
+      },
+      "gt0038": {
+        "id": "gt0038",
+        "priority": 41,
+        "when": [
+          "$gt0032|Birthdate|<($currentDateTime-65,a)",
+          "$gt0032|Birthdate|>=($currentDateTime-70,a)"
+        ],
+        "then": [
+          "$gt0033|Age points|=1.75"
+        ]
+      },
+      "gt0039": {
+        "id": "gt0039",
+        "priority": 40,
+        "when": [
+          "$gt0032|Birthdate|<($currentDateTime-70,a)",
+          "$gt0032|Birthdate|>=($currentDateTime-75,a)"
+        ],
+        "then": [
+          "$gt0033|Age points|=2.125"
+        ]
+      },
+      "gt0040": {
+        "id": "gt0040",
+        "priority": 39,
+        "when": [
+          "$gt0032|Birthdate|<($currentDateTime-75,a)",
+          "$gt0032|Birthdate|>=($currentDateTime-80,a)"
+        ],
+        "then": [
+          "$gt0033|Age points|=2.458"
+        ]
+      },
+      "gt0041": {
+        "id": "gt0041",
+        "priority": 38,
+        "when": [
+          "$gt0032|Birthdate|<($currentDateTime-80,a)",
+          "$gt0032|Birthdate|>=($currentDateTime-85,a)"
+        ],
+        "then": [
+          "$gt0033|Age points|=2.791"
+        ]
+      },
+      "gt0042": {
+        "id": "gt0042",
+        "priority": 37,
+        "when": [
+          "$gt0032|Birthdate|<($currentDateTime-85,a)",
+          "$gt0032|Birthdate|>=($currentDateTime-90,a)"
+        ],
+        "then": [
+          "$gt0033|Age points|=3.125"
+        ]
+      },
+      "gt0043": {
+        "id": "gt0043",
+        "priority": 36,
+        "when": [
+          "$gt0045|NT-proBNP concentration|<=25,nanogm/l"
+        ],
+        "then": [
+          "$gt0046|NT-proBNP points|=0"
+        ]
+      },
+      "gt0047": {
+        "id": "gt0047",
+        "priority": 35,
+        "when": [
+          "$gt0045|NT-proBNP concentration|<=30,nanogm/l",
+          "$gt0045|NT-proBNP concentration|>25,nanogm/l"
+        ],
+        "then": [
+          "$gt0046|NT-proBNP points|=0.263"
+        ]
+      },
+      "gt0048": {
+        "id": "gt0048",
+        "priority": 34,
+        "when": [
+          "$gt0045|NT-proBNP concentration|<=35,nanogm/l",
+          "$gt0045|NT-proBNP concentration|>30,nanogm/l"
+        ],
+        "then": [
+          "$gt0046|NT-proBNP points|=0.525"
+        ]
+      },
+      "gt0049": {
+        "id": "gt0049",
+        "priority": 33,
+        "when": [
+          "$gt0045|NT-proBNP concentration|<=40,nanogm/l",
+          "$gt0045|NT-proBNP concentration|>35,nanogm/l"
+        ],
+        "then": [
+          "$gt0046|NT-proBNP points|=0.787"
+        ]
+      },
+      "gt0050": {
+        "id": "gt0050",
+        "priority": 32,
+        "when": [
+          "$gt0045|NT-proBNP concentration|<=45,nanogm/l",
+          "$gt0045|NT-proBNP concentration|>40,nanogm/l"
+        ],
+        "then": [
+          "$gt0046|NT-proBNP points|=1.05"
+        ]
+      },
+      "gt0051": {
+        "id": "gt0051",
+        "priority": 31,
+        "when": [
+          "$gt0045|NT-proBNP concentration|<=50,nanogm/l",
+          "$gt0045|NT-proBNP concentration|>45,nanogm/l"
+        ],
+        "then": [
+          "$gt0046|NT-proBNP points|=1.312"
+        ]
+      },
+      "gt0052": {
+        "id": "gt0052",
+        "priority": 30,
+        "when": [
+          "$gt0045|NT-proBNP concentration|<=60,nanogm/l",
+          "$gt0045|NT-proBNP concentration|>50,nanogm/l"
+        ],
+        "then": [
+          "$gt0046|NT-proBNP points|=1.562"
+        ]
+      },
+      "gt0053": {
+        "id": "gt0053",
+        "priority": 29,
+        "when": [
+          "$gt0045|NT-proBNP concentration|<=70,nanogm/l",
+          "$gt0045|NT-proBNP concentration|>60,nanogm/l"
+        ],
+        "then": [
+          "$gt0046|NT-proBNP points|=1.812"
+        ]
+      },
+      "gt0054": {
+        "id": "gt0054",
+        "priority": 28,
+        "when": [
+          "$gt0045|NT-proBNP concentration|<=80,nanogm/l",
+          "$gt0045|NT-proBNP concentration|>70,nanogm/l"
+        ],
+        "then": [
+          "$gt0046|NT-proBNP points|=2.062"
+        ]
+      },
+      "gt0055": {
+        "id": "gt0055",
+        "priority": 27,
+        "when": [
+          "$gt0045|NT-proBNP concentration|<=90,nanogm/l",
+          "$gt0045|NT-proBNP concentration|>80,nanogm/l"
+        ],
+        "then": [
+          "$gt0046|NT-proBNP points|=2.312"
+        ]
+      },
+      "gt0056": {
+        "id": "gt0056",
+        "priority": 26,
+        "when": [
+          "$gt0045|NT-proBNP concentration|<=100,nanogm/l",
+          "$gt0045|NT-proBNP concentration|>90,nanogm/l"
+        ],
+        "then": [
+          "$gt0046|NT-proBNP points|=2.562"
+        ]
+      },
+      "gt0057": {
+        "id": "gt0057",
+        "priority": 25,
+        "when": [
+          "$gt0045|NT-proBNP concentration|<=125,nanogm/l",
+          "$gt0045|NT-proBNP concentration|>100,nanogm/l"
+        ],
+        "then": [
+          "$gt0046|NT-proBNP points|=2.875"
+        ]
+      },
+      "gt0058": {
+        "id": "gt0058",
+        "priority": 24,
+        "when": [
+          "$gt0045|NT-proBNP concentration|<=150,nanogm/l",
+          "$gt0045|NT-proBNP concentration|>125,nanogm/l"
+        ],
+        "then": [
+          "$gt0046|NT-proBNP points|=3.188"
+        ]
+      },
+      "gt0059": {
+        "id": "gt0059",
+        "priority": 23,
+        "when": [
+          "$gt0045|NT-proBNP concentration|<=175,nanogm/l",
+          "$gt0045|NT-proBNP concentration|>150,nanogm/l"
+        ],
+        "then": [
+          "$gt0046|NT-proBNP points|=3.5"
+        ]
+      },
+      "gt0060": {
+        "id": "gt0060",
+        "priority": 22,
+        "when": [
+          "$gt0045|NT-proBNP concentration|<=200,nanogm/l",
+          "$gt0045|NT-proBNP concentration|>175,nanogm/l"
+        ],
+        "then": [
+          "$gt0046|NT-proBNP points|=3.812"
+        ]
+      },
+      "gt0061": {
+        "id": "gt0061",
+        "priority": 21,
+        "when": [
+          "$gt0045|NT-proBNP concentration|<=250,nanogm/l",
+          "$gt0045|NT-proBNP concentration|>200,nanogm/l"
+        ],
+        "then": [
+          "$gt0046|NT-proBNP points|=4.141"
+        ]
+      },
+      "gt0062": {
+        "id": "gt0062",
+        "priority": 20,
+        "when": [
+          "$gt0045|NT-proBNP concentration|<=300,nanogm/l",
+          "$gt0045|NT-proBNP concentration|>250,nanogm/l"
+        ],
+        "then": [
+          "$gt0046|NT-proBNP points|=4.469"
+        ]
+      },
+      "gt0063": {
+        "id": "gt0063",
+        "priority": 19,
+        "when": [
+          "$gt0045|NT-proBNP concentration|<=350,nanogm/l",
+          "$gt0045|NT-proBNP concentration|>300,nanogm/l"
+        ],
+        "then": [
+          "$gt0046|NT-proBNP points|=4.797"
+        ]
+      },
+      "gt0064": {
+        "id": "gt0064",
+        "priority": 18,
+        "when": [
+          "$gt0045|NT-proBNP concentration|<=400,nanogm/l",
+          "$gt0045|NT-proBNP concentration|>350,nanogm/l"
+        ],
+        "then": [
+          "$gt0046|NT-proBNP points|=5.125"
+        ]
+      },
+      "gt0065": {
+        "id": "gt0065",
+        "priority": 17,
+        "when": [
+          "$gt0045|NT-proBNP concentration|<=500,nanogm/l",
+          "$gt0045|NT-proBNP concentration|>400,nanogm/l"
+        ],
+        "then": [
+          "$gt0046|NT-proBNP points|=5.438"
+        ]
+      },
+      "gt0066": {
+        "id": "gt0066",
+        "priority": 16,
+        "when": [
+          "$gt0045|NT-proBNP concentration|<=600,nanogm/l",
+          "$gt0045|NT-proBNP concentration|>500,nanogm/l"
+        ],
+        "then": [
+          "$gt0046|NT-proBNP points|=5.75"
+        ]
+      },
+      "gt0067": {
+        "id": "gt0067",
+        "priority": 15,
+        "when": [
+          "$gt0045|NT-proBNP concentration|<=700,nanogm/l",
+          "$gt0045|NT-proBNP concentration|>600,nanogm/l"
+        ],
+        "then": [
+          "$gt0046|NT-proBNP points|=6.062"
+        ]
+      },
+      "gt0068": {
+        "id": "gt0068",
+        "priority": 14,
+        "when": [
+          "$gt0045|NT-proBNP concentration|<=800,nanogm/l",
+          "$gt0045|NT-proBNP concentration|>700,nanogm/l"
+        ],
+        "then": [
+          "$gt0046|NT-proBNP points|=6.375"
+        ]
+      },
+      "gt0069": {
+        "id": "gt0069",
+        "priority": 13,
+        "when": [
+          "$gt0045|NT-proBNP concentration|<=975,nanogm/l",
+          "$gt0045|NT-proBNP concentration|>800,nanogm/l"
+        ],
+        "then": [
+          "$gt0046|NT-proBNP points|=6.656"
+        ]
+      },
+      "gt0070": {
+        "id": "gt0070",
+        "priority": 12,
+        "when": [
+          "$gt0045|NT-proBNP concentration|<=1150,nanogm/l",
+          "$gt0045|NT-proBNP concentration|>975,nanogm/l"
+        ],
+        "then": [
+          "$gt0046|NT-proBNP points|=6.938"
+        ]
+      },
+      "gt0071": {
+        "id": "gt0071",
+        "priority": 11,
+        "when": [
+          "$gt0045|NT-proBNP concentration|<=1325,nanogm/l",
+          "$gt0045|NT-proBNP concentration|>1150,nanogm/l"
+        ],
+        "then": [
+          "$gt0046|NT-proBNP points|=7.219"
+        ]
+      },
+      "gt0072": {
+        "id": "gt0072",
+        "priority": 10,
+        "when": [
+          "$gt0045|NT-proBNP concentration|<=1500,nanogm/l",
+          "$gt0045|NT-proBNP concentration|>1325,nanogm/l"
+        ],
+        "then": [
+          "$gt0046|NT-proBNP points|=7.5"
+        ]
+      },
+      "gt0073": {
+        "id": "gt0073",
+        "priority": 9,
+        "when": [
+          "$gt0045|NT-proBNP concentration|<=1875,nanogm/l",
+          "$gt0045|NT-proBNP concentration|>1500,nanogm/l"
+        ],
+        "then": [
+          "$gt0046|NT-proBNP points|=7.828"
+        ]
+      },
+      "gt0074": {
+        "id": "gt0074",
+        "priority": 8,
+        "when": [
+          "$gt0045|NT-proBNP concentration|<=2250,nanogm/l",
+          "$gt0045|NT-proBNP concentration|>1875,nanogm/l"
+        ],
+        "then": [
+          "$gt0046|NT-proBNP points|=8.156"
+        ]
+      },
+      "gt0075": {
+        "id": "gt0075",
+        "priority": 7,
+        "when": [
+          "$gt0045|NT-proBNP concentration|<=2625,nanogm/l",
+          "$gt0045|NT-proBNP concentration|>2250,nanogm/l"
+        ],
+        "then": [
+          "$gt0046|NT-proBNP points|=8.484"
+        ]
+      },
+      "gt0076": {
+        "id": "gt0076",
+        "priority": 6,
+        "when": [
+          "$gt0045|NT-proBNP concentration|<=3000,nanogm/l",
+          "$gt0045|NT-proBNP concentration|>2625,nanogm/l"
+        ],
+        "then": [
+          "$gt0046|NT-proBNP points|=8.812"
+        ]
+      },
+      "gt0077": {
+        "id": "gt0077",
+        "priority": 5,
+        "when": [
+          "$gt0045|NT-proBNP concentration|<=3725,nanogm/l",
+          "$gt0045|NT-proBNP concentration|>3000,nanogm/l"
+        ],
+        "then": [
+          "$gt0046|NT-proBNP points|=9.109"
+        ]
+      },
+      "gt0078": {
+        "id": "gt0078",
+        "priority": 4,
+        "when": [
+          "$gt0045|NT-proBNP concentration|<=4450,nanogm/l",
+          "$gt0045|NT-proBNP concentration|>3725,nanogm/l"
+        ],
+        "then": [
+          "$gt0046|NT-proBNP points|=9.406"
+        ]
+      },
+      "gt0079": {
+        "id": "gt0079",
+        "priority": 3,
+        "when": [
+          "$gt0045|NT-proBNP concentration|<=5175,nanogm/l",
+          "$gt0045|NT-proBNP concentration|>4450,nanogm/l"
+        ],
+        "then": [
+          "$gt0046|NT-proBNP points|=9.703"
+        ]
+      },
+      "gt0080": {
+        "id": "gt0080",
+        "priority": 2,
+        "when": [
+          "$gt0045|NT-proBNP concentration|<=5900,nanogm/l",
+          "$gt0045|NT-proBNP concentration|>5175,nanogm/l"
+        ],
+        "then": [
+          "$gt0046|NT-proBNP points|=10"
+        ]
+      },
+      "gt0081": {
+        "id": "gt0081",
+        "priority": 1,
+        "when": [
+          "$gt0010|cTnT-hs concentration|.unit=='nanogm/l'",
+          "$gt0045|NT-proBNP concentration|.unit=='nanogm/l'",
+          "$gt0045|NT-proBNP concentration|!=null",
+          "$gt0032|Birthdate|!=null",
+          "$gt0010|cTnT-hs concentration|!=null",
+          "$gt0004|Prior stroke/TIA|!=null"
+        ],
+        "then": [
+          "$gt0082|ABC stroke risk score|.precision=2",
+          "$gt0082|ABC stroke risk score|.magnitude=(($gt0011+$gt0033)+$gt0046)+$gt0006"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "sv": {
+        "id": "sv",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "ABC Stroke (Risk) Score ",
+            "description": "ABC-stroke score är ett verktyg för prognostisk utvärdering av framtida risk för stroke hos patienter med förmaksflimmer. Det baseras på ett nomogram 0.0-10.0 för vardera av följande områden; A = ålder, B = plasmakoncentration av Troponin T och NT-proBNP samt C = tidigare genomgången stroke eller TIA (transitorisk ischemisk attack). Maximala poängen uppgår till 30p och utvärderas på ett respektive tre års sikt, för risken att drabbas av stroke eller embolism. En poäng om mindre än 4p indikerar en risk under 1% över tre års sikt.  "
+          },
+          "gt0002": {
+            "id": "gt0002",
+            "text": "Ej tidigare genomgången stroke/TIA poäng"
+          },
+          "gt0004": {
+            "id": "gt0004",
+            "text": "Tidigare stroke/TIA",
+            "description": "*(en) Has the individual ever suffered a stroke or transient ischaemic attack?"
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Tidigare genomgången stroke/TIA poäng",
+            "description": "*(en) Points assigned based on the presence or absence of a prior history of stroke or TIA in the individual."
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Sätt tidigare stroke/TIA"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Sätt troponin T  <=1"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Troponin T koncentration",
+            "description": "*(en) Concentration of cardiac troponin-T high-sensitivity present in this sample."
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Troponin T poäng",
+            "description": "*(en) Points assigned based on the individual's plasma concentration of cardiac troponin-T high-sensitivity (or cardiac troponin-I high sensitivity)."
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "Sätt troponin T <=2"
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "Sätt troponin T  <=5"
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "Sätt troponin T  <=7.5"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "Sätt troponin T  <=10"
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "Sätt troponin T <=15"
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "text": "Sätt troponin T  <=20"
+          },
+          "gt0018": {
+            "id": "gt0018",
+            "text": "Sätt troponin T  <=25"
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "text": "Sätt troponin T  <=30"
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "Sätt troponin T  <=39"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "text": "Sätt troponin T  <=48"
+          },
+          "gt0022": {
+            "id": "gt0022",
+            "text": "Sätt troponin T  <=57"
+          },
+          "gt0023": {
+            "id": "gt0023",
+            "text": "Sätt troponin T <=66"
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "text": "Sätt troponin T  <=75"
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "text": "Sätt troponin T <=96"
+          },
+          "gt0026": {
+            "id": "gt0026",
+            "text": "Sätt troponin T  <=117"
+          },
+          "gt0027": {
+            "id": "gt0027",
+            "text": "Sätt troponin T  <=138"
+          },
+          "gt0028": {
+            "id": "gt0028",
+            "text": "Sätt troponin T  <=159"
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "text": "Sätt troponin T <=180"
+          },
+          "gt0030": {
+            "id": "gt0030",
+            "text": "Sätt ålder <=44 years"
+          },
+          "gt0032": {
+            "id": "gt0032",
+            "text": "Födelsedatum",
+            "description": "*(en) Date of birth of this individual."
+          },
+          "gt0033": {
+            "id": "gt0033",
+            "text": "Ålder poäng",
+            "description": "*(en) Points assigned based on the individual's age."
+          },
+          "gt0034": {
+            "id": "gt0034",
+            "text": "Sätt ålder 45-50 år"
+          },
+          "gt0035": {
+            "id": "gt0035",
+            "text": "Sätt ålder 51-55 år"
+          },
+          "gt0036": {
+            "id": "gt0036",
+            "text": "Sätt ålder 56-60 år"
+          },
+          "gt0037": {
+            "id": "gt0037",
+            "text": "Sätt ålder 61-65 år"
+          },
+          "gt0038": {
+            "id": "gt0038",
+            "text": "Sätt ålder 66-70 år"
+          },
+          "gt0039": {
+            "id": "gt0039",
+            "text": "Sätt ålder 71-75 år"
+          },
+          "gt0040": {
+            "id": "gt0040",
+            "text": "Sätt ålder 76-80 år"
+          },
+          "gt0041": {
+            "id": "gt0041",
+            "text": "Sätt ålder 81-85 år"
+          },
+          "gt0042": {
+            "id": "gt0042",
+            "text": "Sätt ålder 86-90 år"
+          },
+          "gt0043": {
+            "id": "gt0043",
+            "text": "Sätt proBNP <=25"
+          },
+          "gt0045": {
+            "id": "gt0045",
+            "text": "NT-proBNP koncentration",
+            "description": "*(en) Concentration of N-terminal fragment prohormone of brain natriuretic peptide in the sample."
+          },
+          "gt0046": {
+            "id": "gt0046",
+            "text": " NT-proBNP poäng",
+            "description": "*(en) Points assigned based on the individual's plasma concentration of N-terminal fragment B-type natriuretic peptide."
+          },
+          "gt0047": {
+            "id": "gt0047",
+            "text": "Sätt proBNP <=30"
+          },
+          "gt0048": {
+            "id": "gt0048",
+            "text": "Sätt proBNP <=35"
+          },
+          "gt0049": {
+            "id": "gt0049",
+            "text": "Sätt proBNP <=40"
+          },
+          "gt0050": {
+            "id": "gt0050",
+            "text": "Sätt proBNP <=45"
+          },
+          "gt0051": {
+            "id": "gt0051",
+            "text": "Sätt proBNP<=50"
+          },
+          "gt0052": {
+            "id": "gt0052",
+            "text": "Sätt proBNP <=60"
+          },
+          "gt0053": {
+            "id": "gt0053",
+            "text": "Sätt proBNP <=70"
+          },
+          "gt0054": {
+            "id": "gt0054",
+            "text": "Sätt proBNP <=80"
+          },
+          "gt0055": {
+            "id": "gt0055",
+            "text": "Sätt proBNP <=90"
+          },
+          "gt0056": {
+            "id": "gt0056",
+            "text": "Sätt proBNP <=100"
+          },
+          "gt0057": {
+            "id": "gt0057",
+            "text": "Sätt proBNP <=125"
+          },
+          "gt0058": {
+            "id": "gt0058",
+            "text": "Sätt proBNP <=150"
+          },
+          "gt0059": {
+            "id": "gt0059",
+            "text": "Sätt proBNP <=175"
+          },
+          "gt0060": {
+            "id": "gt0060",
+            "text": "Sätt proBNP <=200"
+          },
+          "gt0061": {
+            "id": "gt0061",
+            "text": "Sätt proBNP <=250"
+          },
+          "gt0062": {
+            "id": "gt0062",
+            "text": "Sätt proBNP <=300"
+          },
+          "gt0063": {
+            "id": "gt0063",
+            "text": "Sätt proBNP <=350"
+          },
+          "gt0064": {
+            "id": "gt0064",
+            "text": "Sätt proBNP <=400"
+          },
+          "gt0065": {
+            "id": "gt0065",
+            "text": "Sätt proBNP <=500"
+          },
+          "gt0066": {
+            "id": "gt0066",
+            "text": "Sätt proBNP <=600"
+          },
+          "gt0067": {
+            "id": "gt0067",
+            "text": "Sätt proBNP <=700"
+          },
+          "gt0068": {
+            "id": "gt0068",
+            "text": "Sätt proBNP <=800"
+          },
+          "gt0069": {
+            "id": "gt0069",
+            "text": "Sätt proBNP <=975"
+          },
+          "gt0070": {
+            "id": "gt0070",
+            "text": "Sätt proBNP <=1150"
+          },
+          "gt0071": {
+            "id": "gt0071",
+            "text": "Sätt proBNP <=1325"
+          },
+          "gt0072": {
+            "id": "gt0072",
+            "text": "Sätt proBNP <=1500"
+          },
+          "gt0073": {
+            "id": "gt0073",
+            "text": "Sätt proBNP <=1875"
+          },
+          "gt0074": {
+            "id": "gt0074",
+            "text": "Sätt proBNP <=2250"
+          },
+          "gt0075": {
+            "id": "gt0075",
+            "text": "Sätt proBNP <=2625"
+          },
+          "gt0076": {
+            "id": "gt0076",
+            "text": "Sätt proBNP <=3000"
+          },
+          "gt0077": {
+            "id": "gt0077",
+            "text": "Sätt proBNP <=3725"
+          },
+          "gt0078": {
+            "id": "gt0078",
+            "text": "Sätt proBNP <=4450"
+          },
+          "gt0079": {
+            "id": "gt0079",
+            "text": "Sätt proBNP <=5175"
+          },
+          "gt0080": {
+            "id": "gt0080",
+            "text": "Sätt proBNP <=5900"
+          },
+          "gt0081": {
+            "id": "gt0081",
+            "text": "Beräkna ABC stroke score (Total poäng)"
+          },
+          "gt0082": {
+            "id": "gt0082",
+            "text": "ABC stroke risk score",
+            "description": "*(en) Sum total of points assigned based on the 4 (four) ABC stroke risk criteria."
+          },
+          "gt0083": {
+            "id": "gt0083",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0084": {
+            "id": "gt0084",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      },
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "ABC Stroke (Risk) Score Calculator",
+            "description": "ABC-stroke score is a biomarker-based risk score for predicting stroke in individuals with atrial fibrillation. Points between 0.0 - 10.0 plotted on a nomogram are assigned to the individual based on each of A = the age (years), B = the plasma concentration of two biomarkers: cTnT-hs (cardiac troponin-T high-sensitivity) and NT-proBNP (N-terminal fragment B-type natriuretic peptide) both in ng/L, and C = a clinical history of prior stroke or transient ischaemic attack (TIA) answered as yes or no. The sum total of the points assigned for the four predictors is the ABC-stroke score and takes a value minimum = 0.0 and maximum = 30.0, and this score is used in predicting the 1-year and 3-year risk of stroke or systemic embolism (SE) in individuals with atrial fibrillation. An ABC-stroke score less than 4.0 predicts a 3-year risk of stroke/SE less than 1%; while the presence of a prior stroke or TIA implies a minimum score of 5.5 and 3-year risk of stroke/SE greater than 1%."
+          },
+          "gt0002": {
+            "id": "gt0002",
+            "text": "Set points for Prior stroke/TIA absent"
+          },
+          "gt0004": {
+            "id": "gt0004",
+            "text": "Prior stroke/TIA",
+            "description": "Has the individual ever suffered a stroke or transient ischaemic attack?"
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Prior stroke or transient ischaemic attack points",
+            "description": "Points assigned based on the presence or absence of a prior history of stroke or TIA in the individual."
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Set points for Prior stroke/TIA present"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Set points for cTnT <=1"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "cTnT-hs concentration",
+            "description": "Concentration of cardiac troponin-T high-sensitivity present in this sample."
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "cTnT-hs points",
+            "description": "Points assigned based on the individual's plasma concentration of cardiac troponin-T high-sensitivity (or cardiac troponin-I high sensitivity)."
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "Set points for cTnT <=2"
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "Set points for cTnT <=5"
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "Set points for cTnT <=7.5"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "Set points for cTnT <=10"
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "Set points for cTnT <=15"
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "text": "Set points for cTnT <=20"
+          },
+          "gt0018": {
+            "id": "gt0018",
+            "text": "Set points for cTnT <=25"
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "text": "Set points for cTnT <=30"
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "Set points for cTnT <=39"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "text": "Set points for cTnT <=48"
+          },
+          "gt0022": {
+            "id": "gt0022",
+            "text": "Set points for cTnT <=57"
+          },
+          "gt0023": {
+            "id": "gt0023",
+            "text": "Set points for cTnT <=66"
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "text": "Set points for cTnT <=75"
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "text": "Set points for cTnT <=96"
+          },
+          "gt0026": {
+            "id": "gt0026",
+            "text": "Set points for cTnT <=117"
+          },
+          "gt0027": {
+            "id": "gt0027",
+            "text": "Set points for cTnT <=138"
+          },
+          "gt0028": {
+            "id": "gt0028",
+            "text": "Set points for cTnT <=159"
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "text": "Set points for cTnT <=180"
+          },
+          "gt0030": {
+            "id": "gt0030",
+            "text": "Set points for Age <=44 years"
+          },
+          "gt0032": {
+            "id": "gt0032",
+            "text": "Birthdate",
+            "description": "Date of birth of this individual."
+          },
+          "gt0033": {
+            "id": "gt0033",
+            "text": "Age points",
+            "description": "Points assigned based on the individual's age."
+          },
+          "gt0034": {
+            "id": "gt0034",
+            "text": "Set points for Age 45-50 years"
+          },
+          "gt0035": {
+            "id": "gt0035",
+            "text": "Set points for Age 51-55 years"
+          },
+          "gt0036": {
+            "id": "gt0036",
+            "text": "Set points for Age 56-60 years"
+          },
+          "gt0037": {
+            "id": "gt0037",
+            "text": "Set points for Age 61-65 years"
+          },
+          "gt0038": {
+            "id": "gt0038",
+            "text": "Set points for Age 66-70 years"
+          },
+          "gt0039": {
+            "id": "gt0039",
+            "text": "Set points for Age 71-75 years"
+          },
+          "gt0040": {
+            "id": "gt0040",
+            "text": "Set points for Age 76-80 years"
+          },
+          "gt0041": {
+            "id": "gt0041",
+            "text": "Set points for Age 81-85 years"
+          },
+          "gt0042": {
+            "id": "gt0042",
+            "text": "Set points for Age 86-90 years"
+          },
+          "gt0043": {
+            "id": "gt0043",
+            "text": "Set points for proBNP <=25"
+          },
+          "gt0045": {
+            "id": "gt0045",
+            "text": "NT-proBNP concentration",
+            "description": "Concentration of N-terminal fragment prohormone of brain natriuretic peptide in the sample."
+          },
+          "gt0046": {
+            "id": "gt0046",
+            "text": "NT-proBNP points",
+            "description": "Points assigned based on the individual's plasma concentration of N-terminal fragment B-type natriuretic peptide."
+          },
+          "gt0047": {
+            "id": "gt0047",
+            "text": "Set points for proBNP <=30"
+          },
+          "gt0048": {
+            "id": "gt0048",
+            "text": "Set points for proBNP <=35"
+          },
+          "gt0049": {
+            "id": "gt0049",
+            "text": "Set points for proBNP <=40"
+          },
+          "gt0050": {
+            "id": "gt0050",
+            "text": "Set points for proBNP <=45"
+          },
+          "gt0051": {
+            "id": "gt0051",
+            "text": "Set points for proBNP <=50"
+          },
+          "gt0052": {
+            "id": "gt0052",
+            "text": "Set points for proBNP <=60"
+          },
+          "gt0053": {
+            "id": "gt0053",
+            "text": "Set points for proBNP <=70"
+          },
+          "gt0054": {
+            "id": "gt0054",
+            "text": "Set points for proBNP <=80"
+          },
+          "gt0055": {
+            "id": "gt0055",
+            "text": "Set points for proBNP <=90"
+          },
+          "gt0056": {
+            "id": "gt0056",
+            "text": "Set points for proBNP <=100"
+          },
+          "gt0057": {
+            "id": "gt0057",
+            "text": "Set points for proBNP <=125"
+          },
+          "gt0058": {
+            "id": "gt0058",
+            "text": "Set points for proBNP <=150"
+          },
+          "gt0059": {
+            "id": "gt0059",
+            "text": "Set points for proBNP <=175"
+          },
+          "gt0060": {
+            "id": "gt0060",
+            "text": "Set points for proBNP <=200"
+          },
+          "gt0061": {
+            "id": "gt0061",
+            "text": "Set points for proBNP <=250"
+          },
+          "gt0062": {
+            "id": "gt0062",
+            "text": "Set points for proBNP <=300"
+          },
+          "gt0063": {
+            "id": "gt0063",
+            "text": "Set points for proBNP <=350"
+          },
+          "gt0064": {
+            "id": "gt0064",
+            "text": "Set points for proBNP <=400"
+          },
+          "gt0065": {
+            "id": "gt0065",
+            "text": "Set points for proBNP <=500"
+          },
+          "gt0066": {
+            "id": "gt0066",
+            "text": "Set points for proBNP <=600"
+          },
+          "gt0067": {
+            "id": "gt0067",
+            "text": "Set points for proBNP <=700"
+          },
+          "gt0068": {
+            "id": "gt0068",
+            "text": "Set points for proBNP <=800"
+          },
+          "gt0069": {
+            "id": "gt0069",
+            "text": "Set points for proBNP <=975"
+          },
+          "gt0070": {
+            "id": "gt0070",
+            "text": "Set points for proBNP <=1150"
+          },
+          "gt0071": {
+            "id": "gt0071",
+            "text": "Set points for proBNP <=1325"
+          },
+          "gt0072": {
+            "id": "gt0072",
+            "text": "Set points for proBNP <=1500"
+          },
+          "gt0073": {
+            "id": "gt0073",
+            "text": "Set points for proBNP <=1875"
+          },
+          "gt0074": {
+            "id": "gt0074",
+            "text": "Set points for proBNP <=2250"
+          },
+          "gt0075": {
+            "id": "gt0075",
+            "text": "Set points for proBNP <=2625"
+          },
+          "gt0076": {
+            "id": "gt0076",
+            "text": "Set points for proBNP <=3000"
+          },
+          "gt0077": {
+            "id": "gt0077",
+            "text": "Set points for proBNP <=3725"
+          },
+          "gt0078": {
+            "id": "gt0078",
+            "text": "Set points for proBNP <=4450"
+          },
+          "gt0079": {
+            "id": "gt0079",
+            "text": "Set points for proBNP <=5175"
+          },
+          "gt0080": {
+            "id": "gt0080",
+            "text": "Set points for proBNP <=5900"
+          },
+          "gt0081": {
+            "id": "gt0081",
+            "text": "Calculate ABC stroke score (Total points)"
+          },
+          "gt0082": {
+            "id": "gt0082",
+            "text": "ABC stroke risk score",
+            "description": "Sum total of points assigned based on the 4 (four) ABC stroke risk criteria."
+          },
+          "gt0083": {
+            "id": "gt0083",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0084": {
+            "id": "gt0084",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/ABC_stroke_risk_score_Calculation.v1.test.yml
+++ b/gdl2/ABC_stroke_risk_score_Calculation.v1.test.yml
@@ -1,0 +1,482 @@
+guidelines:
+  1: ABC_stroke_risk_score_Calculation.v1
+test_cases:
+- id: had stroke
+  input:
+    1:
+      gt0004|Prior stroke/TIA: 1|local::at0008|Yes|
+      gt0010|cTnT-hs concentration: 32,nanogm/l
+      gt0084|Event time: 2019-04-29T23:51Z
+      gt0032|Birthdate: 1950-04-28T23:51Z
+      gt0045|NT-proBNP concentration: 99,nanogm/l
+      gt0083|Event time: 2019-04-29T23:55Z
+  expected_output:
+    1:
+      gt0082|ABC stroke risk score: 13.76
+      gt0011|cTnT-hs points: 3.95
+      gt0006|Prior stroke or transient ischaemic attack points: 5.5
+      gt0033|Age points: 1.75
+      gt0046|NT-proBNP points: 2.562
+
+- id: no troponin
+  input:
+    1:
+      gt0004|Prior stroke/TIA: 0|local::at0007|No|
+      gt0010|cTnT-hs concentration: 0.1,nanogm/l
+      gt0084|Event time: 2019-04-29T23:51Z
+      gt0032|Birthdate: 1950-04-30T23:51Z
+      gt0045|NT-proBNP concentration: 0,nanogm/l
+      gt0083|Event time: 2019-04-29T23:55Z
+  expected_output:
+    1:
+      gt0082|ABC stroke risk score: 1.75
+      gt0011|cTnT-hs points: 0
+      gt0006|Prior stroke or transient ischaemic attack points: 0
+      gt0033|Age points: 1.75
+      gt0046|NT-proBNP points: 0
+
+- id: Troponin rel. low
+  input:
+    1:
+      gt0004|Prior stroke/TIA: 0|local::at0007|No|
+      gt0010|cTnT-hs concentration: 3,nanogm/l
+      gt0084|Event time: 2019-04-29T23:51Z
+      gt0032|Birthdate: 1950-04-30T23:51Z
+      gt0045|NT-proBNP concentration: 0,nanogm/l
+      gt0083|Event time: 2019-04-29T23:55Z
+  expected_output:
+    1:
+      gt0082|ABC stroke risk score: 3.50
+      gt0011|cTnT-hs points: 1.75
+      gt0006|Prior stroke or transient ischaemic attack points: 0
+      gt0033|Age points: 1.75
+      gt0046|NT-proBNP points: 0
+
+- id: Troponin 10 ng
+  input:
+    1:
+      gt0004|Prior stroke/TIA: 0|local::at0007|No|
+      gt0010|cTnT-hs concentration: 10,nanogm/l
+      gt0084|Event time: 2019-04-29T23:51Z
+      gt0032|Birthdate: 1950-04-30T23:51Z
+      gt0045|NT-proBNP concentration: 0,nanogm/l
+      gt0083|Event time: 2019-04-29T23:55Z
+  expected_output:
+    1:
+      gt0082|ABC stroke risk score: 4.25
+      gt0011|cTnT-hs points: 2.5
+      gt0006|Prior stroke or transient ischaemic attack points: 0
+      gt0033|Age points: 1.75
+      gt0046|NT-proBNP points: 0
+
+- id: Troponin 50 ng
+  input:
+    1:
+      gt0004|Prior stroke/TIA: 0|local::at0007|No|
+      gt0010|cTnT-hs concentration: 50,nanogm/l
+      gt0084|Event time: 2019-04-29T23:51Z
+      gt0032|Birthdate: 1950-04-30T23:51Z
+      gt0045|NT-proBNP concentration: 0,nanogm/l
+      gt0083|Event time: 2019-04-29T23:55Z
+  expected_output:
+    1:
+      gt0082|ABC stroke risk score: 6.10
+      gt0011|cTnT-hs points: 4.35
+      gt0006|Prior stroke or transient ischaemic attack points: 0
+      gt0033|Age points: 1.75
+      gt0046|NT-proBNP points: 0
+
+- id: Troponin 100 ng
+  input:
+    1:
+      gt0004|Prior stroke/TIA: 0|local::at0007|No|
+      gt0010|cTnT-hs concentration: 100,nanogm/l
+      gt0084|Event time: 2019-04-29T23:51Z
+      gt0032|Birthdate: 1950-04-30T23:51Z
+      gt0045|NT-proBNP concentration: 0,nanogm/l
+      gt0083|Event time: 2019-04-29T23:55Z
+  expected_output:
+    1:
+      gt0082|ABC stroke risk score: 6.90
+      gt0011|cTnT-hs points: 5.15
+      gt0006|Prior stroke or transient ischaemic attack points: 0
+      gt0033|Age points: 1.75
+      gt0046|NT-proBNP points: 0
+
+- id: Troponin 140 ng
+  input:
+    1:
+      gt0004|Prior stroke/TIA: 0|local::at0007|No|
+      gt0010|cTnT-hs concentration: 140,nanogm/l
+      gt0084|Event time: 2019-04-29T23:51Z
+      gt0032|Birthdate: 1950-04-30T23:51Z
+      gt0045|NT-proBNP concentration: 0,nanogm/l
+      gt0083|Event time: 2019-04-29T23:55Z
+  expected_output:
+    1:
+      gt0082|ABC stroke risk score: 7.30
+      gt0011|cTnT-hs points: 5.55
+      gt0006|Prior stroke or transient ischaemic attack points: 0
+      gt0033|Age points: 1.75
+      gt0046|NT-proBNP points: 0
+
+- id:  NT-proBNP 20
+  input:
+    1:
+      gt0004|Prior stroke/TIA: 0|local::at0007|No|
+      gt0010|cTnT-hs concentration: 33,nanogm/l
+      gt0084|Event time: 2019-04-29T23:51Z
+      gt0032|Birthdate: 1950-04-30T23:51Z
+      gt0045|NT-proBNP concentration: 20,nanogm/l
+      gt0083|Event time: 2019-04-29T23:55Z
+  expected_output:
+    1:
+      gt0082|ABC stroke risk score: 5.70
+      gt0011|cTnT-hs points: 3.95
+      gt0006|Prior stroke or transient ischaemic attack points: 0
+      gt0033|Age points: 1.75
+      gt0046|NT-proBNP points: 0
+
+- id:  NT-proBNP 36
+  input:
+    1:
+      gt0004|Prior stroke/TIA: 0|local::at0007|No|
+      gt0010|cTnT-hs concentration: 33,nanogm/l
+      gt0084|Event time: 2019-04-29T23:51Z
+      gt0032|Birthdate: 1950-04-30T23:51Z
+      gt0045|NT-proBNP concentration: 36,nanogm/l
+      gt0083|Event time: 2019-04-29T23:55Z
+  expected_output:
+    1:
+      gt0082|ABC stroke risk score: 6.49
+      gt0011|cTnT-hs points: 3.95
+      gt0006|Prior stroke or transient ischaemic attack points: 0
+      gt0033|Age points: 1.75
+      gt0046|NT-proBNP points: 0.787
+
+
+- id:  NT-proBNP 50
+  input:
+    1:
+      gt0004|Prior stroke/TIA: 0|local::at0007|No|
+      gt0010|cTnT-hs concentration: 33,nanogm/l
+      gt0084|Event time: 2019-04-29T23:51Z
+      gt0032|Birthdate: 1950-04-30T23:51Z
+      gt0045|NT-proBNP concentration: 50,nanogm/l
+      gt0083|Event time: 2019-04-29T23:55Z
+  expected_output:
+    1:
+      gt0082|ABC stroke risk score: 7.01
+      gt0011|cTnT-hs points: 3.95
+      gt0006|Prior stroke or transient ischaemic attack points: 0
+      gt0033|Age points: 1.75
+      gt0046|NT-proBNP points: 1.312
+
+- id:  NT-proBNP 70
+  input:
+    1:
+      gt0004|Prior stroke/TIA: 0|local::at0007|No|
+      gt0010|cTnT-hs concentration: 33,nanogm/l
+      gt0084|Event time: 2019-04-29T23:51Z
+      gt0032|Birthdate: 1950-04-30T23:51Z
+      gt0045|NT-proBNP concentration: 70,nanogm/l
+      gt0083|Event time: 2019-04-29T23:55Z
+  expected_output:
+    1:
+      gt0082|ABC stroke risk score: 7.51
+      gt0011|cTnT-hs points: 3.95
+      gt0006|Prior stroke or transient ischaemic attack points: 0
+      gt0033|Age points: 1.75
+      gt0046|NT-proBNP points: 1.812
+
+- id:  NT-proBNP 100
+  input:
+    1:
+      gt0004|Prior stroke/TIA: 0|local::at0007|No|
+      gt0010|cTnT-hs concentration: 33,nanogm/l
+      gt0084|Event time: 2019-04-29T23:51Z
+      gt0032|Birthdate: 1950-04-30T23:51Z
+      gt0045|NT-proBNP concentration: 100,nanogm/l
+      gt0083|Event time: 2019-04-29T23:55Z
+  expected_output:
+    1:
+      gt0082|ABC stroke risk score: 8.26
+      gt0011|cTnT-hs points: 3.95
+      gt0006|Prior stroke or transient ischaemic attack points: 0
+      gt0033|Age points: 1.75
+      gt0046|NT-proBNP points: 2.562
+
+- id:  NT-proBNP 200
+  input:
+    1:
+      gt0004|Prior stroke/TIA: 0|local::at0007|No|
+      gt0010|cTnT-hs concentration: 33,nanogm/l
+      gt0084|Event time: 2019-04-29T23:51Z
+      gt0032|Birthdate: 1950-04-30T23:51Z
+      gt0045|NT-proBNP concentration: 200,nanogm/l
+      gt0083|Event time: 2019-04-29T23:55Z
+  expected_output:
+    1:
+      gt0082|ABC stroke risk score: 9.51
+      gt0011|cTnT-hs points: 3.95
+      gt0006|Prior stroke or transient ischaemic attack points: 0
+      gt0033|Age points: 1.75
+      gt0046|NT-proBNP points: 3.812
+
+- id:  NT-proBNP 360
+  input:
+    1:
+      gt0004|Prior stroke/TIA: 0|local::at0007|No|
+      gt0010|cTnT-hs concentration: 33,nanogm/l
+      gt0084|Event time: 2019-04-29T23:51Z
+      gt0032|Birthdate: 1950-04-30T23:51Z
+      gt0045|NT-proBNP concentration: 360,nanogm/l
+      gt0083|Event time: 2019-04-29T23:55Z
+  expected_output:
+    1:
+      gt0082|ABC stroke risk score: 10.82
+      gt0011|cTnT-hs points: 3.95
+      gt0006|Prior stroke or transient ischaemic attack points: 0
+      gt0033|Age points: 1.75
+      gt0046|NT-proBNP points: 5.125
+
+
+- id:  NT-proBNP 500
+  input:
+    1:
+      gt0004|Prior stroke/TIA: 0|local::at0007|No|
+      gt0010|cTnT-hs concentration: 33,nanogm/l
+      gt0084|Event time: 2019-04-29T23:51Z
+      gt0032|Birthdate: 1950-04-30T23:51Z
+      gt0045|NT-proBNP concentration: 500,nanogm/l
+      gt0083|Event time: 2019-04-29T23:55Z
+  expected_output:
+    1:
+      gt0082|ABC stroke risk score: 11.14
+      gt0011|cTnT-hs points: 3.95
+      gt0006|Prior stroke or transient ischaemic attack points: 0
+      gt0033|Age points: 1.75
+      gt0046|NT-proBNP points: 5.438
+
+- id:  NT-proBNP 700
+  input:
+    1:
+      gt0004|Prior stroke/TIA: 0|local::at0007|No|
+      gt0010|cTnT-hs concentration: 33,nanogm/l
+      gt0084|Event time: 2019-04-29T23:51Z
+      gt0032|Birthdate: 1950-04-30T23:51Z
+      gt0045|NT-proBNP concentration: 700,nanogm/l
+      gt0083|Event time: 2019-04-29T23:55Z
+  expected_output:
+    1:
+      gt0082|ABC stroke risk score: 11.76
+      gt0011|cTnT-hs points: 3.95
+      gt0006|Prior stroke or transient ischaemic attack points: 0
+      gt0033|Age points: 1.75
+      gt0046|NT-proBNP points: 6.062
+
+- id:  NT-proBNP 1000
+  input:
+    1:
+      gt0004|Prior stroke/TIA: 0|local::at0007|No|
+      gt0010|cTnT-hs concentration: 33,nanogm/l
+      gt0084|Event time: 2019-04-29T23:51Z
+      gt0032|Birthdate: 1950-04-30T23:51Z
+      gt0045|NT-proBNP concentration: 1000,nanogm/l
+      gt0083|Event time: 2019-04-29T23:55Z
+  expected_output:
+    1:
+      gt0082|ABC stroke risk score: 12.64
+      gt0011|cTnT-hs points: 3.95
+      gt0006|Prior stroke or transient ischaemic attack points: 0
+      gt0033|Age points: 1.75
+      gt0046|NT-proBNP points: 6.938
+
+- id:  NT-proBNP 3000
+  input:
+    1:
+      gt0004|Prior stroke/TIA: 0|local::at0007|No|
+      gt0010|cTnT-hs concentration: 33,nanogm/l
+      gt0084|Event time: 2019-04-29T23:51Z
+      gt0032|Birthdate: 1950-04-30T23:51Z
+      gt0045|NT-proBNP concentration: 3000,nanogm/l
+      gt0083|Event time: 2019-04-29T23:55Z
+  expected_output:
+    1:
+      gt0082|ABC stroke risk score: 14.51
+      gt0011|cTnT-hs points: 3.95
+      gt0006|Prior stroke or transient ischaemic attack points: 0
+      gt0033|Age points: 1.75
+      gt0046|NT-proBNP points: 8.812
+
+
+- id: age less than 45
+  input:
+    1:
+      gt0004|Prior stroke/TIA: 0|local::at0007|No|
+      gt0010|cTnT-hs concentration: 33,nanogm/l
+      gt0084|Event time: 2019-04-29T23:51Z
+      gt0032|Birthdate: 1994-04-30T23:51Z
+      gt0045|NT-proBNP concentration: 70,nanogm/l
+      gt0083|Event time: 2019-04-29T23:55Z
+  expected_output:
+    1:
+      gt0082|ABC stroke risk score: 5.76
+      gt0011|cTnT-hs points: 3.95
+      gt0006|Prior stroke or transient ischaemic attack points: 0
+      gt0033|Age points: 0
+      gt0046|NT-proBNP points: 1.812
+- id: age 45-50
+  input:
+    1:
+      gt0004|Prior stroke/TIA: 0|local::at0007|No|
+      gt0010|cTnT-hs concentration: 33,nanogm/l
+      gt0084|Event time: 2019-04-29T23:51Z
+      gt0032|Birthdate: 1970-04-30T23:51Z
+      gt0045|NT-proBNP concentration: 70,nanogm/l
+      gt0083|Event time: 2019-04-29T23:55Z
+  expected_output:
+    1:
+      gt0082|ABC stroke risk score: 6.14
+      gt0011|cTnT-hs points: 3.95
+      gt0006|Prior stroke or transient ischaemic attack points: 0
+      gt0033|Age points: 0.375
+      gt0046|NT-proBNP points: 1.812
+
+- id: age 50-55
+  input:
+    1:
+      gt0004|Prior stroke/TIA: 0|local::at0007|No|
+      gt0010|cTnT-hs concentration: 33,nanogm/l
+      gt0084|Event time: 2019-04-29T23:51Z
+      gt0032|Birthdate: 1964-12-20T23:51Z
+      gt0045|NT-proBNP concentration: 70,nanogm/l
+      gt0083|Event time: 2019-04-29T23:55Z
+  expected_output:
+    1:
+      gt0082|ABC stroke risk score: 6.51
+      gt0011|cTnT-hs points: 3.95
+      gt0006|Prior stroke or transient ischaemic attack points: 0
+      gt0033|Age points: 0.75
+      gt0046|NT-proBNP points: 1.812
+
+- id: age 55-60
+  input:
+    1:
+      gt0004|Prior stroke/TIA: 0|local::at0007|No|
+      gt0010|cTnT-hs concentration: 33,nanogm/l
+      gt0084|Event time: 2019-04-29T23:51Z
+      gt0032|Birthdate: 1959-11-30T23:51Z
+      gt0045|NT-proBNP concentration: 70,nanogm/l
+      gt0083|Event time: 2019-04-29T23:55Z
+  expected_output:
+    1:
+      gt0082|ABC stroke risk score: 6.82
+      gt0011|cTnT-hs points: 3.95
+      gt0006|Prior stroke or transient ischaemic attack points: 0
+      gt0033|Age points: 1.062
+      gt0046|NT-proBNP points: 1.812
+
+- id: age 60-64
+  input:
+    1:
+      gt0004|Prior stroke/TIA: 0|local::at0007|No|
+      gt0010|cTnT-hs concentration: 33,nanogm/l
+      gt0084|Event time: 2019-04-29T23:51Z
+      gt0032|Birthdate: 1954-11-30T23:51Z
+      gt0045|NT-proBNP concentration: 70,nanogm/l
+      gt0083|Event time: 2019-04-29T23:55Z
+  expected_output:
+    1:
+      gt0082|ABC stroke risk score: 7.14
+      gt0011|cTnT-hs points: 3.95
+      gt0006|Prior stroke or transient ischaemic attack points: 0
+      gt0033|Age points: 1.375
+      gt0046|NT-proBNP points: 1.812
+- id: age 65-70
+  input:
+    1:
+      gt0004|Prior stroke/TIA: 0|local::at0007|No|
+      gt0010|cTnT-hs concentration: 33,nanogm/l
+      gt0084|Event time: 2019-04-29T23:51Z
+      gt0032|Birthdate: 1949-11-30T23:51Z
+      gt0045|NT-proBNP concentration: 70,nanogm/l
+      gt0083|Event time: 2019-04-29T23:55Z
+  expected_output:
+    1:
+      gt0082|ABC stroke risk score: 7.51
+      gt0011|cTnT-hs points: 3.95
+      gt0006|Prior stroke or transient ischaemic attack points: 0
+      gt0033|Age points: 1.75
+      gt0046|NT-proBNP points: 1.812
+- id: age 71-75
+  input:
+    1:
+      gt0004|Prior stroke/TIA: 0|local::at0007|No|
+      gt0010|cTnT-hs concentration: 33,nanogm/l
+      gt0084|Event time: 2019-04-29T23:51Z
+      gt0032|Birthdate: 1949-04-27T23:51Z
+      gt0045|NT-proBNP concentration: 70,nanogm/l
+      gt0083|Event time: 2019-04-29T23:55Z
+  expected_output:
+    1:
+      gt0082|ABC stroke risk score: 7.89
+      gt0011|cTnT-hs points: 3.95
+      gt0006|Prior stroke or transient ischaemic attack points: 0
+      gt0033|Age points: 2.125
+      gt0046|NT-proBNP points: 1.812
+
+
+- id: age 76-80
+  input:
+    1:
+      gt0004|Prior stroke/TIA: 0|local::at0007|No|
+      gt0010|cTnT-hs concentration: 33,nanogm/l
+      gt0084|Event time: 2019-04-29T23:51Z
+      gt0032|Birthdate: 1944-04-27T23:51Z
+      gt0045|NT-proBNP concentration: 70,nanogm/l
+      gt0083|Event time: 2019-04-29T23:55Z
+  expected_output:
+    1:
+      gt0082|ABC stroke risk score: 8.22
+      gt0011|cTnT-hs points: 3.95
+      gt0006|Prior stroke or transient ischaemic attack points: 0
+      gt0033|Age points: 2.458
+      gt0046|NT-proBNP points: 1.812
+
+
+- id: age 81-85
+  input:
+    1:
+      gt0004|Prior stroke/TIA: 0|local::at0007|No|
+      gt0010|cTnT-hs concentration: 33,nanogm/l
+      gt0084|Event time: 2019-04-29T23:51Z
+      gt0032|Birthdate: 1939-04-27T23:51Z
+      gt0045|NT-proBNP concentration: 70,nanogm/l
+      gt0083|Event time: 2019-04-29T23:55Z
+  expected_output:
+    1:
+      gt0082|ABC stroke risk score: 8.55
+      gt0011|cTnT-hs points: 3.95
+      gt0006|Prior stroke or transient ischaemic attack points: 0
+      gt0033|Age points: 2.791
+      gt0046|NT-proBNP points: 1.812
+
+
+
+- id: age 86-90
+  input:
+    1:
+      gt0004|Prior stroke/TIA: 0|local::at0007|No|
+      gt0010|cTnT-hs concentration: 33,nanogm/l
+      gt0084|Event time: 2019-04-29T23:51Z
+      gt0032|Birthdate: 1934-04-27T23:51Z
+      gt0045|NT-proBNP concentration: 70,nanogm/l
+      gt0083|Event time: 2019-04-29T23:55Z
+  expected_output:
+    1:
+      gt0082|ABC stroke risk score: 8.89
+      gt0011|cTnT-hs points: 3.95
+      gt0006|Prior stroke or transient ischaemic attack points: 0
+      gt0033|Age points: 3.125
+      gt0046|NT-proBNP points: 1.812


### PR DESCRIPTION
Two versions of assessment guideline has been created.
for version 1 changes:
(1) event time
(2) output->input
for version 2:
for score <=4 and >=28 new rules were created because originally it reassigned the comment variable, therefore only one of the risk scores were visible.