### PR TITLE
SOFA and qSOFA migrated

### DIFF
--- a/gdl2/SOFA.v1.gdl2.json
+++ b/gdl2/SOFA.v1.gdl2.json
@@ -1,0 +1,1306 @@
+{
+  "id": "SOFA.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2016-01-03",
+      "name": "Syeeda S Farruque",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "other_contributors": [
+      "Dennis Forslund",
+      "Jimmy Axelsson",
+      "Eneimi Allwell-Brown"
+    ],
+    "lifecycle_state": "Author draft",
+    "details": {
+      "sv": {
+        "id": "sv",
+        "purpose": "Att förutsäga mortalitet hos patient som vårdas på intensivvårdsavdelning. Poängen beräknas fortlöpande med 24h-intervall från initial bedömning till utskrivning. Registrering görs med hänsyn till det senaste dygnet.",
+        "keywords": [
+          "SOFA",
+          "IVA",
+          "Sequential organ failure assessment",
+          "mortalitet",
+          "organsvikt",
+          "intensivvård"
+        ],
+        "use": "Varje individuell parameter poängsätts med 0-4p där 0 indikerar antingen normalvärde eller att aktuellt värde saknas eller av någon anledning ej är tillämpligt. \r\n\r\nSystemet har flera möjliga tillämpningar:\r\n - Parametrarna kan användas för utvärdering av respektive organsystem.\r\n - Totala poängsumman kan användas för att uppskatta prognos för den specifika dagen\r\n - Totala summan av de värst drabbade parametrarna kan användas för att utvärdera hela vårdtiden\r\n\r\nDe sex parametrarna inkluderar:\r\n- Respiration\r\n- Koagulation\r\n- Lever\r\n- Neurologi\r\n- Hjärt-kärl\r\n- Njure \r\n\r\nTotal poäng uppgår till maximalt 24p och tolkas med avseende på mortalitet enligt:\r\n                                 \r\n0-6p = <10%\r\n7-9p =15-20%\r\n10-12p = 40-50%\r\n13-14p = 50-60%\r\n15p = >80%\r\n15-24p = >90%\r\n",
+        "misuse": "SOFA är endast en uppskattning och är ej avsedd för att påverka medicinsk handläggning eller utvärdera intervention.",
+        "copyright": "© Cambio Healthcare Systems"
+      },
+      "en": {
+        "id": "en",
+        "purpose": "The SOFA helps to predict mortality across 6 organ systems which is calculated every 24 hrs from the initial assessment at admission until the patient is discharged. The worst results of each measured parameter is recorded during the previous 24 hrs.",
+        "keywords": [
+          "SOFA",
+          "ICU",
+          "Sequential organ failure assessment",
+          "mortality",
+          "organ failure"
+        ],
+        "use": "The individual scores for each of the 6 organ domains range from 0 to 4 (0 usually relating to normal values or N/A where they are not part of the scoring).\n\nEach individual domain score can be used to assess that particular domain's organ dysfunction\n\nOr, the total sum of scores can be used to assess prognosis on a single ICU day\n\nOr the total sum of the worst scores can be used to evaluate the whole ICU period.\n\nDomains are: \n\nRespiration\nCoagulation\nLiver\nNeurological\nCardiovascular\nRenal\n\nThe SOFA scores ranges from 0 to 24\n\nScore interpretations are according to the MAX SOFA scores:\n\nSOFA score     Mortality\n0-6                   <10%\n7-9                   15-20%\n10-12                40-50%\n13-14                50-60%\n15                      >80%\n15-24                >90%\n",
+        "misuse": "The SOFA is not designed to accurately predict mortality (and was initially aimed only to ICU mortality specifically)",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Ref. 1: Vincent JL, Moreno R, Takala J, et al. The SOFA (Sepsis-related Organ Failure Assessment) score to describe organ dysfunction/failure. On behalf of the Working Group on Sepsis-Related Problems of the European Society of Intensive Care Medicine. In: Vol 22. 1996:707–710.\r\n\r\nRef. 2: Vincent JL, de Mendonça A, Cantraine F, et al. Use of the SOFA score to assess the incidence of organ dysfunction/failure in intensive care units: results of a multicenter, prospective study. Working group on \\\"sepsis-related problems\\\" of the European Society of Intensive Care Medicine. Crit Care Med. 1998;26(11):1793–1800.\r\n\r\nRef. 3: Kratz A, Ferraro M, Sluss PM, et al: Case records of the Massachusetts General Hospital: laboratory values. N Engl J Med 2004; 351(15):1549-1563."
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0002": {
+        "id": "gt0002",
+        "model_id": "openEHR-EHR-OBSERVATION.blood_pressure.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.blood_pressure.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0003": {
+            "id": "gt0003",
+            "path": "/data[at0001]/events[at0006]/data[at0003]/items[at1006]"
+          },
+          "gt0081": {
+            "id": "gt0081",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0004": {
+        "id": "gt0004",
+        "model_id": "openEHR-EHR-OBSERVATION.calculated_urine_output.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.calculated_urine_output.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0005": {
+            "id": "gt0005",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0005]"
+          },
+          "gt0082": {
+            "id": "gt0082",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0006": {
+        "id": "gt0006",
+        "model_id": "openEHR-EHR-OBSERVATION.glasgow_coma_scale.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.glasgow_coma_scale.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0007": {
+            "id": "gt0007",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0026]"
+          },
+          "gt0083": {
+            "id": "gt0083",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0009": {
+        "id": "gt0009",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-bilirubin.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-bilirubin.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0010": {
+            "id": "gt0010",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0091]"
+          },
+          "gt0084": {
+            "id": "gt0084",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0011": {
+        "id": "gt0011",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-blood_gases.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-blood_gases.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0012": {
+            "id": "gt0012",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.11]"
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0.94]"
+          },
+          "gt0088": {
+            "id": "gt0088",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0014": {
+        "id": "gt0014",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test_creatinine.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test_creatinine.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0015": {
+            "id": "gt0015",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0005]"
+          },
+          "gt0085": {
+            "id": "gt0085",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0016": {
+        "id": "gt0016",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-full_blood_count.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-full_blood_count.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0017": {
+            "id": "gt0017",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.12]"
+          },
+          "gt0086": {
+            "id": "gt0086",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0018": {
+        "id": "gt0018",
+        "model_id": "openEHR-EHR-OBSERVATION.sequential_organ_failure_assessment.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.sequential_organ_failure_assessment.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0023": {
+            "id": "gt0023",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0008]"
+          },
+          "gt0087": {
+            "id": "gt0087",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0026": {
+        "id": "gt0026",
+        "model_id": "openEHR-EHR-OBSERVATION.sequential_organ_failure_assessment.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.sequential_organ_failure_assessment.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0028": {
+            "id": "gt0028",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0005]"
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0006]"
+          },
+          "gt0030": {
+            "id": "gt0030",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0007]"
+          },
+          "gt0031": {
+            "id": "gt0031",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0008]"
+          },
+          "gt0032": {
+            "id": "gt0032",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0009]"
+          },
+          "gt0033": {
+            "id": "gt0033",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0010]"
+          },
+          "gt0034": {
+            "id": "gt0034",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0004]"
+          },
+          "gt0038": {
+            "id": "gt0038",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0042]"
+          }
+        }
+      }
+    },
+    "rules": {
+      "gt0036": {
+        "id": "gt0036",
+        "priority": 35,
+        "when": [
+          "$gt0028|Platlets score|==null",
+          "$gt0029|GCS score|==null",
+          "$gt0030|BR score|==null",
+          "$gt0031|MAP or admin of vasopressors required|==null",
+          "$gt0032|Creatinine or urine output|==null",
+          "$gt0034|PF ratio/carrico index score|==null"
+        ],
+        "then": [
+          "$gt0028|Platlets score|=0|local::at0036|N/A|",
+          "$gt0029|GCS score|=0|local::at0031|N/A|",
+          "$gt0030|BR score|=0|local::at0026|N/A|",
+          "$gt0031|MAP or admin of vasopressors required|=0|local::at0016|No hypotension|",
+          "$gt0032|Creatinine or urine output|=0|local::at0021|<1.2 [<106]|",
+          "$gt0034|PF ratio/carrico index score|=0|local::at0041|N/A|"
+        ]
+      },
+      "gt0037": {
+        "id": "gt0037",
+        "priority": 34,
+        "when": [
+          "$gt0013|FiO2|.unit=='%'",
+          "$gt0012|PaO2 (mmHg)|.unit=='mm[Hg]'",
+          "$gt0013|FiO2|!=null",
+          "$gt0012|PaO2 (mmHg)|!=null"
+        ],
+        "then": [
+          "$gt0038|Carrico/PF|.magnitude=($gt0012.magnitude/$gt0013.magnitude)*100",
+          "$gt0038|Carrico/PF|.unit='mm[Hg]'"
+        ]
+      },
+      "gt0047": {
+        "id": "gt0047",
+        "priority": 33,
+        "when": [
+          "$gt0038|Carrico/PF|.magnitude>400"
+        ],
+        "then": [
+          "$gt0034|PF ratio/carrico index score|=0|local::at0041|N/A|"
+        ]
+      },
+      "gt0039": {
+        "id": "gt0039",
+        "priority": 32,
+        "when": [
+          "$gt0038|Carrico/PF|.magnitude>300",
+          "$gt0038|Carrico/PF|.magnitude<=400"
+        ],
+        "then": [
+          "$gt0034|PF ratio/carrico index score|=1|local::at0012|<400|"
+        ]
+      },
+      "gt0040": {
+        "id": "gt0040",
+        "priority": 31,
+        "when": [
+          "$gt0038|Carrico/PF|.magnitude>200",
+          "$gt0038|Carrico/PF|.magnitude<=300"
+        ],
+        "then": [
+          "$gt0034|PF ratio/carrico index score|=2|local::at0013|<300|"
+        ]
+      },
+      "gt0041": {
+        "id": "gt0041",
+        "priority": 30,
+        "when": [
+          "$gt0038|Carrico/PF|.magnitude>100",
+          "$gt0038|Carrico/PF|.magnitude<=200"
+        ],
+        "then": [
+          "$gt0034|PF ratio/carrico index score|=3|local::at0014|<200 and mechanically ventilated|"
+        ]
+      },
+      "gt0042": {
+        "id": "gt0042",
+        "priority": 29,
+        "when": [
+          "$gt0038|Carrico/PF|.magnitude<=100"
+        ],
+        "then": [
+          "$gt0034|PF ratio/carrico index score|=4|local::at0015|<100 and mechanically ventilated|"
+        ]
+      },
+      "gt0043": {
+        "id": "gt0043",
+        "priority": 28,
+        "when": [
+          "$gt0017|Platelet count (10*9/L)|.magnitude>=100",
+          "$gt0017|Platelet count (10*9/L)|.magnitude<150",
+          "$gt0017|Platelet count (10*9/L)|.unit=='10*9/l'",
+          "$gt0017|Platelet count (10*9/L)|!=null"
+        ],
+        "then": [
+          "$gt0028|Platlets score|=1|local::at0037|<150|"
+        ]
+      },
+      "gt0044": {
+        "id": "gt0044",
+        "priority": 27,
+        "when": [
+          "$gt0017|Platelet count (10*9/L)|.magnitude<100",
+          "$gt0017|Platelet count (10*9/L)|.magnitude>=50",
+          "$gt0017|Platelet count (10*9/L)|.unit=='10*9/l'",
+          "$gt0017|Platelet count (10*9/L)|!=null"
+        ],
+        "then": [
+          "$gt0028|Platlets score|=2|local::at0038|<100|"
+        ]
+      },
+      "gt0045": {
+        "id": "gt0045",
+        "priority": 26,
+        "when": [
+          "$gt0017|Platelet count (10*9/L)|.magnitude>=20",
+          "$gt0017|Platelet count (10*9/L)|.magnitude<50",
+          "$gt0017|Platelet count (10*9/L)|!=null",
+          "$gt0017|Platelet count (10*9/L)|.unit=='10*9/l'"
+        ],
+        "then": [
+          "$gt0028|Platlets score|=3|local::at0039|<50|"
+        ]
+      },
+      "gt0046": {
+        "id": "gt0046",
+        "priority": 25,
+        "when": [
+          "$gt0017|Platelet count (10*9/L)|!=null",
+          "$gt0017|Platelet count (10*9/L)|.magnitude<20",
+          "$gt0017|Platelet count (10*9/L)|.unit=='10*9/l'"
+        ],
+        "then": [
+          "$gt0028|Platlets score|=4|local::at0040|<20|"
+        ]
+      },
+      "gt0048": {
+        "id": "gt0048",
+        "priority": 24,
+        "when": [
+          "$gt0017|Platelet count (10*9/L)|.magnitude>=150",
+          "$gt0017|Platelet count (10*9/L)|.unit=='10*9/l'",
+          "$gt0017|Platelet count (10*9/L)|!=null"
+        ],
+        "then": [
+          "$gt0028|Platlets score|=0|local::at0036|N/A|"
+        ]
+      },
+      "gt0049": {
+        "id": "gt0049",
+        "priority": 23,
+        "when": [
+          "$gt0007|GCS Total score|<=14",
+          "$gt0007|GCS Total score|>=13",
+          "$gt0007|GCS Total score|!=null"
+        ],
+        "then": [
+          "$gt0029|GCS score|=1|local::at0032|13-14|"
+        ]
+      },
+      "gt0050": {
+        "id": "gt0050",
+        "priority": 22,
+        "when": [
+          "$gt0007|GCS Total score|<=12",
+          "$gt0007|GCS Total score|>=10",
+          "$gt0007|GCS Total score|!=null"
+        ],
+        "then": [
+          "$gt0029|GCS score|=2|local::at0033|10-12|"
+        ]
+      },
+      "gt0051": {
+        "id": "gt0051",
+        "priority": 21,
+        "when": [
+          "$gt0007|GCS Total score|<=9",
+          "$gt0007|GCS Total score|>=6",
+          "$gt0007|GCS Total score|!=null"
+        ],
+        "then": [
+          "$gt0029|GCS score|=3|local::at0034|6-9|"
+        ]
+      },
+      "gt0052": {
+        "id": "gt0052",
+        "priority": 20,
+        "when": [
+          "$gt0007|GCS Total score|<6",
+          "$gt0007|GCS Total score|!=null"
+        ],
+        "then": [
+          "$gt0029|GCS score|=4|local::at0035|<6|"
+        ]
+      },
+      "gt0053": {
+        "id": "gt0053",
+        "priority": 19,
+        "when": [
+          "$gt0007|GCS Total score|>=15",
+          "$gt0007|GCS Total score|!=null"
+        ],
+        "then": [
+          "$gt0029|GCS score|=0|local::at0031|N/A|"
+        ]
+      },
+      "gt0054": {
+        "id": "gt0054",
+        "priority": 18,
+        "when": [
+          "$gt0010|Total Bilirubin (mg/dL)|.magnitude>=1.2",
+          "$gt0010|Total Bilirubin (mg/dL)|.magnitude<2.0",
+          "$gt0010|Total Bilirubin (mg/dL)|.unit=='mg/dl'",
+          "$gt0010|Total Bilirubin (mg/dL)|!=null"
+        ],
+        "then": [
+          "$gt0030|BR score|=1|local::at0027|1.2–1.9 [>20-32]|"
+        ]
+      },
+      "gt0055": {
+        "id": "gt0055",
+        "priority": 17,
+        "when": [
+          "$gt0010|Total Bilirubin (mg/dL)|.magnitude<6.0",
+          "$gt0010|Total Bilirubin (mg/dL)|.magnitude>=2.0",
+          "$gt0010|Total Bilirubin (mg/dL)|.unit=='mg/dl'",
+          "$gt0010|Total Bilirubin (mg/dL)|!=null"
+        ],
+        "then": [
+          "$gt0030|BR score|=2|local::at0028|2.0–5.9 [33-101]|"
+        ]
+      },
+      "gt0056": {
+        "id": "gt0056",
+        "priority": 16,
+        "when": [
+          "$gt0010|Total Bilirubin (mg/dL)|.magnitude<12.0",
+          "$gt0010|Total Bilirubin (mg/dL)|.magnitude>=6.0",
+          "$gt0010|Total Bilirubin (mg/dL)|.unit=='mg/dl'",
+          "$gt0010|Total Bilirubin (mg/dL)|!=null"
+        ],
+        "then": [
+          "$gt0030|BR score|=3|local::at0029|6.0–11.9 [102-204]|"
+        ]
+      },
+      "gt0057": {
+        "id": "gt0057",
+        "priority": 15,
+        "when": [
+          "$gt0010|Total Bilirubin (mg/dL)|.magnitude>=12.0",
+          "$gt0010|Total Bilirubin (mg/dL)|.unit=='mg/dl'",
+          "$gt0010|Total Bilirubin (mg/dL)|!=null"
+        ],
+        "then": [
+          "$gt0030|BR score|=4|local::at0030|>12.0 [>204]|"
+        ]
+      },
+      "gt0058": {
+        "id": "gt0058",
+        "priority": 14,
+        "when": [
+          "$gt0010|Total Bilirubin (mg/dL)|.magnitude<1.2",
+          "$gt0010|Total Bilirubin (mg/dL)|.unit=='mg/dl'",
+          "$gt0010|Total Bilirubin (mg/dL)|!=null"
+        ],
+        "then": [
+          "$gt0030|BR score|=0|local::at0026|N/A|"
+        ]
+      },
+      "gt0077": {
+        "id": "gt0077",
+        "priority": 13,
+        "when": [
+          "$gt0005|Total urine output/24 hr|>=200,ml/24hr",
+          "$gt0005|Total urine output/24 hr|<500,ml/24hr"
+        ],
+        "then": [
+          "$gt0032|Creatinine or urine output|=3|local::at0024|3.5–4.9 [302-433] (or < 500 ml/d)|"
+        ]
+      },
+      "gt0078": {
+        "id": "gt0078",
+        "priority": 12,
+        "when": [
+          "$gt0005|Total urine output/24 hr|<200,ml/24hr"
+        ],
+        "then": [
+          "$gt0032|Creatinine or urine output|=4|local::at0025|>5.0 [>433] (or <200 ml/d)|"
+        ]
+      },
+      "gt0059": {
+        "id": "gt0059",
+        "priority": 11,
+        "when": [
+          "!fired($gt0078)",
+          "!fired($gt0077)",
+          "$gt0015|Creatinine Result|<106"
+        ],
+        "then": [
+          "$gt0032|Creatinine or urine output|=0|local::at0021|<1.2 [<106]|"
+        ]
+      },
+      "gt0060": {
+        "id": "gt0060",
+        "priority": 10,
+        "when": [
+          "!fired($gt0078)",
+          "!fired($gt0077)",
+          "$gt0015|Creatinine Result|>=106",
+          "$gt0015|Creatinine Result|<=168"
+        ],
+        "then": [
+          "$gt0032|Creatinine or urine output|=1|local::at0022|1.2–1.9 [106-168]|"
+        ]
+      },
+      "gt0061": {
+        "id": "gt0061",
+        "priority": 9,
+        "when": [
+          "!fired($gt0078)",
+          "!fired($gt0077)",
+          "$gt0015|Creatinine Result|<=301",
+          "$gt0015|Creatinine Result|>=169"
+        ],
+        "then": [
+          "$gt0032|Creatinine or urine output|=2|local::at0023|2.0–3.4 [169-301]|"
+        ]
+      },
+      "gt0062": {
+        "id": "gt0062",
+        "priority": 8,
+        "when": [
+          "!fired($gt0078)",
+          "!fired($gt0077)",
+          "$gt0015|Creatinine Result|>=302",
+          "$gt0015|Creatinine Result|<=433"
+        ],
+        "then": [
+          "$gt0032|Creatinine or urine output|=3|local::at0024|3.5–4.9 [302-433] (or < 500 ml/d)|"
+        ]
+      },
+      "gt0063": {
+        "id": "gt0063",
+        "priority": 7,
+        "when": [
+          "!fired($gt0078)",
+          "!fired($gt0077)",
+          "$gt0015|Creatinine Result|>433"
+        ],
+        "then": [
+          "$gt0032|Creatinine or urine output|=4|local::at0025|>5.0 [>433] (or <200 ml/d)|"
+        ]
+      },
+      "gt0068": {
+        "id": "gt0068",
+        "priority": 6,
+        "when": [
+          "$gt0023|MAP or admin of vasopressors required|==4|local::at0020|dop >15 OR epi >0.1 OR nor >0.1|"
+        ],
+        "then": [
+          "$gt0031|MAP or admin of vasopressors required|=4|local::at0020|dop >15 OR epi >0.1 OR nor >0.1|"
+        ]
+      },
+      "gt0067": {
+        "id": "gt0067",
+        "priority": 5,
+        "when": [
+          "$gt0023|MAP or admin of vasopressors required|==3|local::at0019|dop >5 OR epi =< 0.1 ORnor <= 0.1|"
+        ],
+        "then": [
+          "$gt0031|MAP or admin of vasopressors required|=3|local::at0019|dop >5 OR epi =< 0.1 ORnor <= 0.1|"
+        ]
+      },
+      "gt0066": {
+        "id": "gt0066",
+        "priority": 4,
+        "when": [
+          "$gt0023|MAP or admin of vasopressors required|==2|local::at0018|dop =< 5 or dob (any dose)|"
+        ],
+        "then": [
+          "$gt0031|MAP or admin of vasopressors required|=2|local::at0018|dop =< 5 or dob (any dose)|"
+        ]
+      },
+      "gt0079": {
+        "id": "gt0079",
+        "priority": 3,
+        "when": [
+          "!fired($gt0068)",
+          "!fired($gt0067)",
+          "!fired($gt0066)",
+          "$gt0003|Mean arterial pressure|<70,mm[Hg]"
+        ],
+        "then": [
+          "$gt0031|MAP or admin of vasopressors required|=1|local::at0017|MAP< 70 mmHg|"
+        ]
+      },
+      "gt0080": {
+        "id": "gt0080",
+        "priority": 2,
+        "when": [
+          "!fired($gt0068)",
+          "!fired($gt0067)",
+          "!fired($gt0066)",
+          "$gt0003|Mean arterial pressure|>=70,mm[Hg]"
+        ],
+        "then": [
+          "$gt0031|MAP or admin of vasopressors required|=0|local::at0016|No hypotension|"
+        ]
+      },
+      "gt0076": {
+        "id": "gt0076",
+        "priority": 1,
+        "then": [
+          "$gt0033|Total score|.magnitude=(((($gt0028.value+$gt0029.value)+$gt0032.value)+$gt0034.value)+$gt0030.value)+$gt0031.value"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "sv": {
+        "id": "sv",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "SOFA",
+            "description": "SOFA: Sequential Organ Failure Assessment - ett poängsystem utvecklat European Society of Intensive Care Medicine för uppskattning av mortalitet hos patienter som vårdas på intensivvårdsavdelning. "
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "Medelartärtryck",
+            "description": "*(en) The average arterial pressure that occurs over the entire course of the heart contraction and relaxation cycle."
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Dygnsdiures",
+            "description": "*(en) *"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "GCS poäng",
+            "description": "*(en) The sum of the ordinal scores recorded for each of the three component responses."
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Ögonöppning (E)",
+            "description": "*(en) Best response of eyes to test stimulus."
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Totalt Bilirubin (mg/dL)",
+            "description": "*(en) Total Bilirubin measures the sum of both unconjugated and conjugated Bilirubin."
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "PaO2 (mmHg)",
+            "description": "*(en) The oxygen pressure in the arterial blood."
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "FiO2",
+            "description": "*(en) Fractionally inspired/inhaled Oxygen as a percentage. The percentage of O2 in the air breathed"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "Kreatinin",
+            "description": "*(en) *"
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "text": "Trombocyter (10*9/L)",
+            "description": "*(en) The number of platelets per litre"
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "text": "PF ration/carrico index score",
+            "description": "*(en) PaO2/FiO2 is ration of arterial partial pressure of O2 to the fractional inspired O2 (O2 concentration in air delivered as a percentage). At sea level this is above 400mmHg (some say over 500mmHg but we shall use the lower threshold value)."
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "Trombocyter poäng",
+            "description": "*(en) Platlet score - x10^3/muL"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "text": "GCS poäng",
+            "description": "*(en) Glasgow Coma Scale score"
+          },
+          "gt0022": {
+            "id": "gt0022",
+            "text": "Bilirubin - poäng",
+            "description": "*(en) Total Bilirubin score - (mg/dl) [μmol/L]"
+          },
+          "gt0023": {
+            "id": "gt0023",
+            "text": "Medelartärtryck (MAP) alt behov av vasopressor",
+            "description": "*(en) Mean Arterial Pressure or administration of vasopressors required"
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "text": "Kreatinin eller dygnsdiures",
+            "description": "*(en) Creatinine (mg/dl) [μmol/L] (or urine output - mL/day)"
+          },
+          "gt0027": {
+            "id": "gt0027",
+            "text": "PF ration/carrico index score",
+            "description": "*(en) PaO2/FiO2 is ration of arterial partial pressure of O2 to the fractional inspired O2 (O2 concentration in air delivered as a percentage). At sea level this is above 400mmHg (some say over 500mmHg but we shall use the lower threshold value)."
+          },
+          "gt0028": {
+            "id": "gt0028",
+            "text": "Trombocyter poäng",
+            "description": "*(en) Platlet score - x10^3/muL"
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "text": "GCS poäng",
+            "description": "*(en) Glasgow Coma Scale score"
+          },
+          "gt0030": {
+            "id": "gt0030",
+            "text": "Bilirubin - poäng",
+            "description": "*(en) Total Bilirubin score - (mg/dl) [μmol/L]"
+          },
+          "gt0031": {
+            "id": "gt0031",
+            "text": "Medelartärtryck (MAP) alt behov av vasopressor",
+            "description": "*(en) Mean Arterial Pressure or administration of vasopressors required"
+          },
+          "gt0032": {
+            "id": "gt0032",
+            "text": "Kreatinin eller dygnsdiures",
+            "description": "*(en) Creatinine (mg/dl) [μmol/L] (or urine output - mL/day)"
+          },
+          "gt0033": {
+            "id": "gt0033",
+            "text": "Total poäng",
+            "description": "*(en) Total score"
+          },
+          "gt0034": {
+            "id": "gt0034",
+            "text": "PF ratio/carrico index score",
+            "description": "*(en) PaO2/FiO2 is ration of arterial partial pressure of O2 to the fractional inspired O2 (O2 concentration in air delivered as a percentage). At sea level this is above 400mmHg (some say over 500mmHg but we shall use the lower threshold value)."
+          },
+          "gt0035": {
+            "id": "gt0035",
+            "text": "PF ratio/carrico index score",
+            "description": "*(en) PaO2/FiO2 is ration of arterial partial pressure of O2 to the fractional inspired O2 (O2 concentration in air delivered as a percentage). At sea level this is above 400mmHg (some say over 500mmHg but we shall use the lower threshold value)."
+          },
+          "gt0036": {
+            "id": "gt0036",
+            "text": "Standard"
+          },
+          "gt0037": {
+            "id": "gt0037",
+            "text": "CDS PF"
+          },
+          "gt0038": {
+            "id": "gt0038",
+            "text": "Carrico/PF",
+            "description": "*(en) Calculation value of the Carrico/PF ratio of PaO2/FiO2"
+          },
+          "gt0039": {
+            "id": "gt0039",
+            "text": "CDS PF <400"
+          },
+          "gt0040": {
+            "id": "gt0040",
+            "text": "CDS PF <300"
+          },
+          "gt0041": {
+            "id": "gt0041",
+            "text": "CDS PF <200"
+          },
+          "gt0042": {
+            "id": "gt0042",
+            "text": "CDS PF <100"
+          },
+          "gt0043": {
+            "id": "gt0043",
+            "text": "CDS trombocyter <150"
+          },
+          "gt0044": {
+            "id": "gt0044",
+            "text": "CDS trombocyter <100"
+          },
+          "gt0045": {
+            "id": "gt0045",
+            "text": "CDS trombocyter <50"
+          },
+          "gt0046": {
+            "id": "gt0046",
+            "text": "CDS trombocyter <20"
+          },
+          "gt0047": {
+            "id": "gt0047",
+            "text": "CDS PF  >=400"
+          },
+          "gt0048": {
+            "id": "gt0048",
+            "text": "CDS trombocyter >=150"
+          },
+          "gt0049": {
+            "id": "gt0049",
+            "text": "CDS GCS 13-14"
+          },
+          "gt0050": {
+            "id": "gt0050",
+            "text": "CDS GCS 10-12"
+          },
+          "gt0051": {
+            "id": "gt0051",
+            "text": "CDS GCS 6-9"
+          },
+          "gt0052": {
+            "id": "gt0052",
+            "text": "CDS GCS <6"
+          },
+          "gt0053": {
+            "id": "gt0053",
+            "text": "CDS GCS >=15"
+          },
+          "gt0054": {
+            "id": "gt0054",
+            "text": "CDS bilirubin 1.2-1.9"
+          },
+          "gt0055": {
+            "id": "gt0055",
+            "text": "CDS bilirubin 2.0-5.9"
+          },
+          "gt0056": {
+            "id": "gt0056",
+            "text": "CDS bilirubin 6.0-11.9"
+          },
+          "gt0057": {
+            "id": "gt0057",
+            "text": "CDS bilirubin >12.0"
+          },
+          "gt0058": {
+            "id": "gt0058",
+            "text": "CDS bilirubin <1.2"
+          },
+          "gt0059": {
+            "id": "gt0059",
+            "text": "CDS kreatinin (micromols/L) <106"
+          },
+          "gt0060": {
+            "id": "gt0060",
+            "text": "CDS kreatinin (micromols/L)  106-168"
+          },
+          "gt0061": {
+            "id": "gt0061",
+            "text": "CDS kreatinin (micromols/L)  169-301"
+          },
+          "gt0062": {
+            "id": "gt0062",
+            "text": "CDS kreatinin (micromols/L)  302-433 or <500ml/day urine output"
+          },
+          "gt0063": {
+            "id": "gt0063",
+            "text": "CDS kreatinin (micromols/L) >433 or <200 urine output"
+          },
+          "gt0066": {
+            "id": "gt0066",
+            "text": "CDS Medelartärtryck (MAP) alt behov av vasopressor - 2p"
+          },
+          "gt0067": {
+            "id": "gt0067",
+            "text": "CDS Medelartärtryck (MAP) alt behov av vasopressor score - 3p"
+          },
+          "gt0068": {
+            "id": "gt0068",
+            "text": "CDS Medelartärtryck (MAP) alt behov av vasopressor - 4p"
+          },
+          "gt0076": {
+            "id": "gt0076",
+            "text": "Beräkna total poäng"
+          },
+          "gt0077": {
+            "id": "gt0077"
+          },
+          "gt0078": {
+            "id": "gt0078"
+          },
+          "gt0079": {
+            "id": "gt0079"
+          },
+          "gt0080": {
+            "id": "gt0080"
+          },
+          "gt0081": {
+            "id": "gt0081",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0082": {
+            "id": "gt0082",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0083": {
+            "id": "gt0083",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0084": {
+            "id": "gt0084",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0085": {
+            "id": "gt0085",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0086": {
+            "id": "gt0086",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0087": {
+            "id": "gt0087",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0088": {
+            "id": "gt0088",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      },
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Sequential Organ Failure Assessment",
+            "description": "SOFA: Sequential Organ Failure Assessment - A scoring system developed by the European Society of Intensive Care Medicine that provides an indicator of mortality and morbidity prognosis among ICU patients."
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "Mean arterial pressure",
+            "description": "The average arterial pressure that occurs over the entire course of the heart contraction and relaxation cycle."
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Total urine output/24 hr",
+            "description": "*"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "GCS Total score",
+            "description": "The sum of the ordinal scores recorded for each of the three component responses."
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Best eye response (E)",
+            "description": "Best response of eyes to test stimulus."
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Total Bilirubin (mg/dL)",
+            "description": "Total Bilirubin measures the sum of both unconjugated and conjugated Bilirubin."
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "PaO2 (mmHg)",
+            "description": "The oxygen pressure in the arterial blood."
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "FiO2",
+            "description": "Fractionally inspired/inhaled Oxygen as a percentage. The percentage of O2 in the air breathed"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "Creatinine Result",
+            "description": "*"
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "text": "Platelet count (10*9/L)",
+            "description": "The number of platelets per litre"
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "text": "PF ration/carrico index score",
+            "description": "PaO2/FiO2 is ration of arterial partial pressure of O2 to the fractional inspired O2 (O2 concentration in air delivered as a percentage). At sea level this is above 400mmHg (some say over 500mmHg but we shall use the lower threshold value)."
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "Platlets score",
+            "description": "Platlet score - x10^3/muL"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "text": "GCS score",
+            "description": "Glasgow Coma Scale score"
+          },
+          "gt0022": {
+            "id": "gt0022",
+            "text": "BR score",
+            "description": "Total Bilirubin score - (mg/dl) [μmol/L]"
+          },
+          "gt0023": {
+            "id": "gt0023",
+            "text": "MAP or admin of vasopressors required",
+            "description": "Mean Arterial Pressure or administration of vasopressors required"
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "text": "Creatinine or urine output",
+            "description": "Creatinine (mg/dl) [μmol/L] (or urine output - mL/day)"
+          },
+          "gt0027": {
+            "id": "gt0027",
+            "text": "PF ration/carrico index score",
+            "description": "PaO2/FiO2 is ration of arterial partial pressure of O2 to the fractional inspired O2 (O2 concentration in air delivered as a percentage). At sea level this is above 400mmHg (some say over 500mmHg but we shall use the lower threshold value)."
+          },
+          "gt0028": {
+            "id": "gt0028",
+            "text": "Platlets score",
+            "description": "Platlet score - x10^3/muL"
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "text": "GCS score",
+            "description": "Glasgow Coma Scale score"
+          },
+          "gt0030": {
+            "id": "gt0030",
+            "text": "BR score",
+            "description": "Total Bilirubin score - (mg/dl) [μmol/L]"
+          },
+          "gt0031": {
+            "id": "gt0031",
+            "text": "MAP or admin of vasopressors required",
+            "description": "Mean Arterial Pressure or administration of vasopressors required"
+          },
+          "gt0032": {
+            "id": "gt0032",
+            "text": "Creatinine or urine output",
+            "description": "Creatinine (mg/dl) [μmol/L] (or urine output - mL/day)"
+          },
+          "gt0033": {
+            "id": "gt0033",
+            "text": "Total score",
+            "description": "Total score"
+          },
+          "gt0034": {
+            "id": "gt0034",
+            "text": "PF ratio/carrico index score",
+            "description": "PaO2/FiO2 is ration of arterial partial pressure of O2 to the fractional inspired O2 (O2 concentration in air delivered as a percentage). At sea level this is above 400mmHg (some say over 500mmHg but we shall use the lower threshold value)."
+          },
+          "gt0035": {
+            "id": "gt0035",
+            "text": "PF ratio/carrico index score",
+            "description": "PaO2/FiO2 is ration of arterial partial pressure of O2 to the fractional inspired O2 (O2 concentration in air delivered as a percentage). At sea level this is above 400mmHg (some say over 500mmHg but we shall use the lower threshold value)."
+          },
+          "gt0036": {
+            "id": "gt0036",
+            "text": "Set Default"
+          },
+          "gt0037": {
+            "id": "gt0037",
+            "text": "Set PF"
+          },
+          "gt0038": {
+            "id": "gt0038",
+            "text": "Carrico/PF",
+            "description": "Calculation value of the Carrico/PF ratio of PaO2/FiO2"
+          },
+          "gt0039": {
+            "id": "gt0039",
+            "text": "Set PF score <=400"
+          },
+          "gt0040": {
+            "id": "gt0040",
+            "text": "Set PF score <=300"
+          },
+          "gt0041": {
+            "id": "gt0041",
+            "text": "Set PF score <=200"
+          },
+          "gt0042": {
+            "id": "gt0042",
+            "text": "Set PF score <=100"
+          },
+          "gt0043": {
+            "id": "gt0043",
+            "text": "Set Platlets <150"
+          },
+          "gt0044": {
+            "id": "gt0044",
+            "text": "Set Platlets <100"
+          },
+          "gt0045": {
+            "id": "gt0045",
+            "text": "Set platlets <50"
+          },
+          "gt0046": {
+            "id": "gt0046",
+            "text": "Set platlets <20"
+          },
+          "gt0047": {
+            "id": "gt0047",
+            "text": "Set PF score >400"
+          },
+          "gt0048": {
+            "id": "gt0048",
+            "text": "Set Platlets >=150"
+          },
+          "gt0049": {
+            "id": "gt0049",
+            "text": "Set GCS 13-14"
+          },
+          "gt0050": {
+            "id": "gt0050",
+            "text": "Set GCS 10-12"
+          },
+          "gt0051": {
+            "id": "gt0051",
+            "text": "Set GCS 6-9"
+          },
+          "gt0052": {
+            "id": "gt0052",
+            "text": "Set GCS <6"
+          },
+          "gt0053": {
+            "id": "gt0053",
+            "text": "Set GCS >=15"
+          },
+          "gt0054": {
+            "id": "gt0054",
+            "text": "Set BR 1.2-1.9"
+          },
+          "gt0055": {
+            "id": "gt0055",
+            "text": "Set BR 2.0-5.9"
+          },
+          "gt0056": {
+            "id": "gt0056",
+            "text": "Set BR 6.0-11.9"
+          },
+          "gt0057": {
+            "id": "gt0057",
+            "text": "Set BR >12.0"
+          },
+          "gt0058": {
+            "id": "gt0058",
+            "text": "Set BR <1.2"
+          },
+          "gt0059": {
+            "id": "gt0059",
+            "text": "Set Creatinine (micromols/L) <106"
+          },
+          "gt0060": {
+            "id": "gt0060",
+            "text": "Set Creatinine (micromols/L)  106-168"
+          },
+          "gt0061": {
+            "id": "gt0061",
+            "text": "Set Creatinine (micromols/L)  169-301"
+          },
+          "gt0062": {
+            "id": "gt0062",
+            "text": "Set Creatinine (micromols/L)  302-433"
+          },
+          "gt0063": {
+            "id": "gt0063",
+            "text": "Set Creatinine (micromols/L) >433"
+          },
+          "gt0066": {
+            "id": "gt0066",
+            "text": "Set vp score 2"
+          },
+          "gt0067": {
+            "id": "gt0067",
+            "text": "Set vp score 3"
+          },
+          "gt0068": {
+            "id": "gt0068",
+            "text": "Set vp score 4"
+          },
+          "gt0076": {
+            "id": "gt0076",
+            "text": "Calculate Total score"
+          },
+          "gt0077": {
+            "id": "gt0077",
+            "text": "Set urine output <500ml/day"
+          },
+          "gt0078": {
+            "id": "gt0078",
+            "text": "Set urine output <200ml/day"
+          },
+          "gt0079": {
+            "id": "gt0079",
+            "text": "MAP <70 mmHg"
+          },
+          "gt0080": {
+            "id": "gt0080",
+            "text": "MAP >70 mmHg"
+          },
+          "gt0081": {
+            "id": "gt0081",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0082": {
+            "id": "gt0082",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0083": {
+            "id": "gt0083",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0084": {
+            "id": "gt0084",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0085": {
+            "id": "gt0085",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0086": {
+            "id": "gt0086",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0087": {
+            "id": "gt0087",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0088": {
+            "id": "gt0088",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/SOFA.v1.test.yml
+++ b/gdl2/SOFA.v1.test.yml
@@ -285,16 +285,14 @@ test_cases:
       gt0085|Event time: 2019-05-23T15:01Z
       gt0017|Platelet count (10*9/L): 15,10*9/l
       gt0086|Event time: 2019-05-22T14:40Z
-      gt0023|MAP or admin of vasopressors required: 2|local::at0018|dop =< 5 or dob\
-        \ (any dose)|
+      gt0023|MAP or admin of vasopressors required: 2|local::at0018|dop =< 5 or dob (any dose)|
       gt0087|Event time: 2019-05-23T15:17Z
   expected_output:
     1:
       gt0029|GCS score: 0|local::at0031|N/A|
       gt0034|PF ratio/carrico index score: 0|local::at0041|N/A|
       gt0033|Total score: 11
-      gt0031|MAP or admin of vasopressors required: 2|local::at0018|dop =< 5 or dob\
-        \ (any dose)|
+      gt0031|MAP or admin of vasopressors required: 2|local::at0018|dop =< 5 or dob (any dose)|
       gt0038|Carrico/PF: 476,mm[Hg]
       gt0030|BR score: 4|local::at0030|>12.0 [>204]|
       gt0028|Platlets score: 4|local::at0040|<20|
@@ -305,18 +303,18 @@ test_cases:
   input:
     1:
       gt0005|Total urine output/24 hr: 510,ml/24hr
-      gt0082|Event time: 2019-05-23T14:56Z
+      gt0082|Event time: 2019-06-17T09:48+02:00[Europe/Stockholm]
       gt0007|GCS Total score: 16
-      gt0083|Event time: 2019-05-22T14:42Z
+      gt0083|Event time: 2019-06-17T09:48+02:00[Europe/Stockholm]
       gt0010|Total Bilirubin (mg/dL): 12,mg/dl
-      gt0084|Event time: 2019-05-23T14:43Z
+      gt0084|Event time: 2019-06-17T09:48+02:00[Europe/Stockholm]
       gt0012|PaO2 (mmHg): 100,mm[Hg]
       gt0013|FiO2: 21,%
-      gt0088|Event time: 2019-05-20T14:30Z
-      gt0015|Creatinine Result: 168.2,µmol/l
-      gt0085|Event time: 2019-05-23T15:01Z
+      gt0088|Event time: 2019-06-17T09:48+02:00[Europe/Stockholm]
+      gt0015|Creatinine Result: 168,µmol/l
+      gt0085|Event time: 2019-06-17T09:49+02:00[Europe/Stockholm]
       gt0017|Platelet count (10*9/L): 15,10*9/l
-      gt0086|Event time: 2019-05-22T14:40Z
+      gt0086|Event time: 2019-06-17T09:49+02:00[Europe/Stockholm]
   expected_output:
     1:
       gt0029|GCS score: 0|local::at0031|N/A|

--- a/gdl2/SOFA.v1.test.yml
+++ b/gdl2/SOFA.v1.test.yml
@@ -1,0 +1,329 @@
+guidelines:
+  1: SOFA.v1
+test_cases:
+- id: Default
+  input:
+    1: {}
+  expected_output:
+    1:
+      gt0029|GCS score: 0|local::at0031|N/A|
+      gt0034|PF ratio/carrico index score: 0|local::at0041|N/A|
+      gt0033|Total score: 0
+      gt0031|MAP or admin of vasopressors required: 0|local::at0016|No hypotension|
+      gt0030|BR score: 0|local::at0026|N/A|
+      gt0028|Platlets score: 0|local::at0036|N/A|
+      gt0032|Creatinine or urine output: 0|local::at0021|<1.2 [<106]|
+
+- id: Normal PF
+  input:
+    1:
+      gt0012|PaO2 (mmHg): 100,mm[Hg]
+      gt0013|FiO2: 21,%
+      gt0088|Event time: 2019-05-20T14:30Z
+  expected_output:
+    1:
+      gt0029|GCS score: 0|local::at0031|N/A|
+      gt0034|PF ratio/carrico index score: 0|local::at0041|N/A|
+      gt0033|Total score: 0
+      gt0031|MAP or admin of vasopressors required: 0|local::at0016|No hypotension|
+      gt0038|Carrico/PF: 476,mm[Hg]
+      gt0030|BR score: 0|local::at0026|N/A|
+      gt0028|Platlets score: 0|local::at0036|N/A|
+      gt0032|Creatinine or urine output: 0|local::at0021|<1.2 [<106]|
+
+- id: score 2
+  input:
+    1:
+      gt0007|GCS Total score: 14
+      gt0083|Event time: 2019-05-22T14:42Z
+      gt0010|Total Bilirubin (mg/dL): 1,mg/dl
+      gt0084|Event time: 2019-05-23T14:43Z
+      gt0012|PaO2 (mmHg): 100,mm[Hg]
+      gt0013|FiO2: 21,%
+      gt0088|Event time: 2019-05-20T14:30Z
+      gt0017|Platelet count (10*9/L): 140,10*9/l
+      gt0086|Event time: 2019-05-22T14:40Z
+  expected_output:
+    1:
+      gt0029|GCS score: 1|local::at0032|13-14|
+      gt0034|PF ratio/carrico index score: 0|local::at0041|N/A|
+      gt0033|Total score: 2
+      gt0031|MAP or admin of vasopressors required: 0|local::at0016|No hypotension|
+      gt0038|Carrico/PF: 476,mm[Hg]
+      gt0030|BR score: 0|local::at0026|N/A|
+      gt0028|Platlets score: 1|local::at0037|<150|
+      gt0032|Creatinine or urine output: 0|local::at0021|<1.2 [<106]|
+
+- id: score 5 platelets, gcs, bilirubin
+  input:
+    1:
+      gt0007|GCS Total score: 12
+      gt0083|Event time: 2019-05-22T14:42Z
+      gt0010|Total Bilirubin (mg/dL): 1.3,mg/dl
+      gt0084|Event time: 2019-05-23T14:43Z
+      gt0012|PaO2 (mmHg): 100,mm[Hg]
+      gt0013|FiO2: 21,%
+      gt0088|Event time: 2019-05-20T14:30Z
+      gt0017|Platelet count (10*9/L): 90,10*9/l
+      gt0086|Event time: 2019-05-22T14:40Z
+  expected_output:
+    1:
+      gt0029|GCS score: 2|local::at0033|10-12|
+      gt0034|PF ratio/carrico index score: 0|local::at0041|N/A|
+      gt0033|Total score: 5
+      gt0031|MAP or admin of vasopressors required: 0|local::at0016|No hypotension|
+      gt0038|Carrico/PF: 476,mm[Hg]
+      gt0030|BR score: 1|local::at0027|1.2–1.9 [>20-32]|
+      gt0028|Platlets score: 2|local::at0038|<100|
+      gt0032|Creatinine or urine output: 0|local::at0021|<1.2 [<106]|
+
+- id:  score 8 platelets, gcs, bilirubin
+  input:
+    1:
+      gt0007|GCS Total score: 9
+      gt0083|Event time: 2019-05-22T14:42Z
+      gt0010|Total Bilirubin (mg/dL): 2,mg/dl
+      gt0084|Event time: 2019-05-23T14:43Z
+      gt0012|PaO2 (mmHg): 100,mm[Hg]
+      gt0013|FiO2: 21,%
+      gt0088|Event time: 2019-05-20T14:30Z
+      gt0017|Platelet count (10*9/L): 45,10*9/l
+      gt0086|Event time: 2019-05-22T14:40Z
+  expected_output:
+    1:
+      gt0029|GCS score: 3|local::at0034|6-9|
+      gt0034|PF ratio/carrico index score: 0|local::at0041|N/A|
+      gt0033|Total score: 8
+      gt0031|MAP or admin of vasopressors required: 0|local::at0016|No hypotension|
+      gt0038|Carrico/PF: 476,mm[Hg]
+      gt0030|BR score: 2|local::at0028|2.0–5.9 [33-101]|
+      gt0028|Platlets score: 3|local::at0039|<50|
+      gt0032|Creatinine or urine output: 0|local::at0021|<1.2 [<106]|
+
+- id:  score 11 platelets, gcs, bilirubin
+  input:
+    1:
+      gt0007|GCS Total score: 5
+      gt0083|Event time: 2019-05-22T14:42Z
+      gt0010|Total Bilirubin (mg/dL): 6,mg/dl
+      gt0084|Event time: 2019-05-23T14:43Z
+      gt0012|PaO2 (mmHg): 100,mm[Hg]
+      gt0013|FiO2: 21,%
+      gt0088|Event time: 2019-05-20T14:30Z
+      gt0017|Platelet count (10*9/L): 15,10*9/l
+      gt0086|Event time: 2019-05-22T14:40Z
+  expected_output:
+    1:
+      gt0029|GCS score: 4|local::at0035|<6|
+      gt0034|PF ratio/carrico index score: 0|local::at0041|N/A|
+      gt0033|Total score: 11
+      gt0031|MAP or admin of vasopressors required: 0|local::at0016|No hypotension|
+      gt0038|Carrico/PF: 476,mm[Hg]
+      gt0030|BR score: 3|local::at0029|6.0–11.9 [102-204]|
+      gt0028|Platlets score: 4|local::at0040|<20|
+      gt0032|Creatinine or urine output: 0|local::at0021|<1.2 [<106]|
+
+
+
+- id: platelets>150
+  input:
+    1:
+      gt0012|PaO2 (mmHg): 100,mm[Hg]
+      gt0013|FiO2: 21,%
+      gt0088|Event time: 2019-05-20T14:30Z
+      gt0017|Platelet count (10*9/L): 160,10*9/l
+      gt0086|Event time: 2019-05-22T14:40Z
+  expected_output:
+    1:
+      gt0029|GCS score: 0|local::at0031|N/A|
+      gt0034|PF ratio/carrico index score: 0|local::at0041|N/A|
+      gt0033|Total score: 0
+      gt0031|MAP or admin of vasopressors required: 0|local::at0016|No hypotension|
+      gt0038|Carrico/PF: 476,mm[Hg]
+      gt0030|BR score: 0|local::at0026|N/A|
+      gt0028|Platlets score: 0|local::at0036|N/A|
+      gt0032|Creatinine or urine output: 0|local::at0021|<1.2 [<106]|
+
+
+- id: pf<=400
+  input:
+    1:
+      gt0012|PaO2 (mmHg): 100,mm[Hg]
+      gt0013|FiO2: 33,%
+      gt0088|Event time: 2019-05-20T14:30Z
+  expected_output:
+    1:
+      gt0029|GCS score: 0|local::at0031|N/A|
+      gt0034|PF ratio/carrico index score: 1|local::at0012|<400|
+      gt0033|Total score: 1
+      gt0031|MAP or admin of vasopressors required: 0|local::at0016|No hypotension|
+      gt0038|Carrico/PF: 303,mm[Hg]
+      gt0030|BR score: 0|local::at0026|N/A|
+      gt0028|Platlets score: 0|local::at0036|N/A|
+      gt0032|Creatinine or urine output: 0|local::at0021|<1.2 [<106]|
+
+- id: pf <=300
+  input:
+    1:
+      gt0012|PaO2 (mmHg): 95,mm[Hg]
+      gt0013|FiO2: 33,%
+      gt0088|Event time: 2019-05-20T14:30Z
+  expected_output:
+    1:
+      gt0029|GCS score: 0|local::at0031|N/A|
+      gt0034|PF ratio/carrico index score: 2|local::at0013|<300|
+      gt0033|Total score: 2
+      gt0031|MAP or admin of vasopressors required: 0|local::at0016|No hypotension|
+      gt0038|Carrico/PF: 288,mm[Hg]
+      gt0030|BR score: 0|local::at0026|N/A|
+      gt0028|Platlets score: 0|local::at0036|N/A|
+      gt0032|Creatinine or urine output: 0|local::at0021|<1.2 [<106]|
+
+- id: pf<=200
+  input:
+    1:
+      gt0012|PaO2 (mmHg): 75,mm[Hg]
+      gt0013|FiO2: 38,%
+      gt0088|Event time: 2019-05-20T14:30Z
+  expected_output:
+    1:
+      gt0029|GCS score: 0|local::at0031|N/A|
+      gt0034|PF ratio/carrico index score: 3|local::at0014|<200 and mechanically ventilated|
+      gt0033|Total score: 3
+      gt0031|MAP or admin of vasopressors required: 0|local::at0016|No hypotension|
+      gt0038|Carrico/PF: 197,mm[Hg]
+      gt0030|BR score: 0|local::at0026|N/A|
+      gt0028|Platlets score: 0|local::at0036|N/A|
+      gt0032|Creatinine or urine output: 0|local::at0021|<1.2 [<106]|
+
+- id: pf<=100
+  input:
+    1:
+      gt0012|PaO2 (mmHg): 50,mm[Hg]
+      gt0013|FiO2: 50,%
+      gt0088|Event time: 2019-05-20T14:30Z
+  expected_output:
+    1:
+      gt0029|GCS score: 0|local::at0031|N/A|
+      gt0034|PF ratio/carrico index score: 4|local::at0015|<100 and mechanically ventilated|
+      gt0033|Total score: 4
+      gt0031|MAP or admin of vasopressors required: 0|local::at0016|No hypotension|
+      gt0038|Carrico/PF: 100,mm[Hg]
+      gt0030|BR score: 0|local::at0026|N/A|
+      gt0028|Platlets score: 0|local::at0036|N/A|
+      gt0032|Creatinine or urine output: 0|local::at0021|<1.2 [<106]|
+
+- id: BR high, urine<500ml
+  input:
+    1:
+      gt0005|Total urine output/24 hr: 490,ml/24hr
+      gt0082|Event time: 2019-05-23T14:56Z
+      gt0007|GCS Total score: 16
+      gt0083|Event time: 2019-05-22T14:42Z
+      gt0010|Total Bilirubin (mg/dL): 12,mg/dl
+      gt0084|Event time: 2019-05-23T14:43Z
+      gt0012|PaO2 (mmHg): 100,mm[Hg]
+      gt0013|FiO2: 21,%
+      gt0088|Event time: 2019-05-20T14:30Z
+      gt0017|Platelet count (10*9/L): 15,10*9/l
+      gt0086|Event time: 2019-05-22T14:40Z
+  expected_output:
+    1:
+      gt0029|GCS score: 0|local::at0031|N/A|
+      gt0034|PF ratio/carrico index score: 0|local::at0041|N/A|
+      gt0033|Total score: 11
+      gt0031|MAP or admin of vasopressors required: 0|local::at0016|No hypotension|
+      gt0038|Carrico/PF: 476,mm[Hg]
+      gt0030|BR score: 4|local::at0030|>12.0 [>204]|
+      gt0028|Platlets score: 4|local::at0040|<20|
+      gt0032|Creatinine or urine output: 3|local::at0024|3.5–4.9 [302-433] (or < 500 ml/d)|
+
+
+
+- id: Normal creatinine
+  input:
+    1:
+      gt0005|Total urine output/24 hr: 510,ml/24hr
+      gt0082|Event time: 2019-05-23T14:56Z
+      gt0007|GCS Total score: 16
+      gt0083|Event time: 2019-05-22T14:42Z
+      gt0010|Total Bilirubin (mg/dL): 12,mg/dl
+      gt0084|Event time: 2019-05-23T14:43Z
+      gt0012|PaO2 (mmHg): 100,mm[Hg]
+      gt0013|FiO2: 21,%
+      gt0088|Event time: 2019-05-20T14:30Z
+      gt0015|Creatinine Result: 100,µmol/l
+      gt0085|Event time: 2019-05-23T15:01Z
+      gt0017|Platelet count (10*9/L): 15,10*9/l
+      gt0086|Event time: 2019-05-22T14:40Z
+  expected_output:
+    1:
+      gt0029|GCS score: 0|local::at0031|N/A|
+      gt0034|PF ratio/carrico index score: 0|local::at0041|N/A|
+      gt0033|Total score: 8
+      gt0031|MAP or admin of vasopressors required: 0|local::at0016|No hypotension|
+      gt0038|Carrico/PF: 476,mm[Hg]
+      gt0030|BR score: 4|local::at0030|>12.0 [>204]|
+      gt0028|Platlets score: 4|local::at0040|<20|
+      gt0032|Creatinine or urine output: 0|local::at0021|<1.2 [<106]|
+
+- id: MAP, vp
+  input:
+    1:
+      gt0003|Mean arterial pressure: 60,mm[Hg]
+      gt0081|Event time: 2019-05-23T15:16Z
+      gt0005|Total urine output/24 hr: 510,ml/24hr
+      gt0082|Event time: 2019-05-23T14:56Z
+      gt0007|GCS Total score: 16
+      gt0083|Event time: 2019-05-22T14:42Z
+      gt0010|Total Bilirubin (mg/dL): 12,mg/dl
+      gt0084|Event time: 2019-05-23T14:43Z
+      gt0012|PaO2 (mmHg): 100,mm[Hg]
+      gt0013|FiO2: 21,%
+      gt0088|Event time: 2019-05-20T14:30Z
+      gt0015|Creatinine Result: 168,µmol/l
+      gt0085|Event time: 2019-05-23T15:01Z
+      gt0017|Platelet count (10*9/L): 15,10*9/l
+      gt0086|Event time: 2019-05-22T14:40Z
+      gt0023|MAP or admin of vasopressors required: 2|local::at0018|dop =< 5 or dob\
+        \ (any dose)|
+      gt0087|Event time: 2019-05-23T15:17Z
+  expected_output:
+    1:
+      gt0029|GCS score: 0|local::at0031|N/A|
+      gt0034|PF ratio/carrico index score: 0|local::at0041|N/A|
+      gt0033|Total score: 11
+      gt0031|MAP or admin of vasopressors required: 2|local::at0018|dop =< 5 or dob\
+        \ (any dose)|
+      gt0038|Carrico/PF: 476,mm[Hg]
+      gt0030|BR score: 4|local::at0030|>12.0 [>204]|
+      gt0028|Platlets score: 4|local::at0040|<20|
+      gt0032|Creatinine or urine output: 1|local::at0022|1.2–1.9 [106-168]|
+
+
+- id: creatinie at the threshold
+  input:
+    1:
+      gt0005|Total urine output/24 hr: 510,ml/24hr
+      gt0082|Event time: 2019-05-23T14:56Z
+      gt0007|GCS Total score: 16
+      gt0083|Event time: 2019-05-22T14:42Z
+      gt0010|Total Bilirubin (mg/dL): 12,mg/dl
+      gt0084|Event time: 2019-05-23T14:43Z
+      gt0012|PaO2 (mmHg): 100,mm[Hg]
+      gt0013|FiO2: 21,%
+      gt0088|Event time: 2019-05-20T14:30Z
+      gt0015|Creatinine Result: 168.2,µmol/l
+      gt0085|Event time: 2019-05-23T15:01Z
+      gt0017|Platelet count (10*9/L): 15,10*9/l
+      gt0086|Event time: 2019-05-22T14:40Z
+  expected_output:
+    1:
+      gt0029|GCS score: 0|local::at0031|N/A|
+      gt0034|PF ratio/carrico index score: 0|local::at0041|N/A|
+      gt0033|Total score: 9
+      gt0031|MAP or admin of vasopressors required: 0|local::at0016|No hypotension|
+      gt0038|Carrico/PF: 476,mm[Hg]
+      gt0030|BR score: 4|local::at0030|>12.0 [>204]|
+      gt0028|Platlets score: 4|local::at0040|<20|
+      gt0032|Creatinine or urine output: 1|local::at0022|1.2–1.9 [106-168]|

--- a/gdl2/SOFA_Interpretation.v1.gdl2.json
+++ b/gdl2/SOFA_Interpretation.v1.gdl2.json
@@ -1,0 +1,258 @@
+{
+  "id": "SOFA_Interpretation.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2017-03-05",
+      "name": "Syeeda S Farruque",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "other_contributors": [
+      "Dennis Forslund",
+      "Jimmy Axelsson"
+    ],
+    "lifecycle_state": "Author draft",
+    "details": {
+      "sv": {
+        "id": "sv",
+        "purpose": "Att utvärdera poäng genererad i enlighet med SOFA: Sequential Organ Failure Assessment - ett poängsystem utvecklat European Society of Intensive Care Medicine för uppskattning av mortalitet hos patienter som vårdas på intensivvårdsavdelning.",
+        "keywords": [
+          "SOFA",
+          "mortalitet",
+          "Sequential Organ Failure Assessment",
+          "intensivvård",
+          "organsvikt",
+          "IVA"
+        ],
+        "use": "Använd för att utvärdera poäng genererad i enlighet med SOFA: Sequential Organ Failure Assessment - ett poängsystem utvecklat European Society of Intensive Care Medicine för uppskattning av mortalitet hos patienter som vårdas på intensivvårdsavdelning.\r\n\r\nTotal poäng uppgår till maximalt 24p och tolkas med avseende på mortalitet enligt:\r\n                                 \r\n0-6p = <10%\r\n7-9p =15-20%\r\n10-12p = 40-50%\r\n13-14p = 50-60%\r\n15p = >80%\r\n15-24p = >90%",
+        "misuse": "SOFA är endast en uppskattning och är ej avsedd för att påverka medicinsk handläggning eller utvärdera intervention.",
+        "copyright": "© Cambio Healthcare Systems"
+      },
+      "en": {
+        "id": "en",
+        "purpose": "The SOFA helps to predict mortality across 6 organ systems which is calculated every 24 hrs from the initial assessment at admission until the patient is discharged. The worst results of each measured parameter is recorded during the previous 24 hrs.",
+        "keywords": [
+          "ICU",
+          "SOFA",
+          "Sequential Organ Failure Assessment",
+          "mortality"
+        ],
+        "use": "Score interpretations are according to the MAX SOFA scores:\r\n\r\nSOFA score     Mortality\r\n0-6                   <10%\r\n7-9                   15-20%\r\n10-12                40-50%\r\n13-14                50-60%\r\n15                      >80%\r\n16-24                >90%",
+        "misuse": "The SOFA is not designed to accurately predict mortality (and was initially aimed only to ICU mortality specifically)",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Ref. 1: Vincent JL, Moreno R, Takala J, et al. The SOFA (Sepsis-related Organ Failure Assessment) score to describe organ dysfunction/failure. On behalf of the Working Group on Sepsis-Related Problems of the European Society of Intensive Care Medicine. In: Vol 22. 1996:707–710.\r\n\r\nRef. 2: Vincent JL, de Mendonça A, Cantraine F, et al. Use of the SOFA score to assess the incidence of organ dysfunction/failure in intensive care units: results of a multicenter, prospective study. Working group on \\\"sepsis-related problems\\\" of the European Society of Intensive Care Medicine. Crit Care Med. 1998;26(11):1793–1800.\r\n\r\nRef. 3: Kratz A, Ferraro M, Sluss PM, et al: Case records of the Massachusetts General Hospital: laboratory values. N Engl J Med 2004; 351(15):1549-1563."
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0003": {
+        "id": "gt0003",
+        "model_id": "openEHR-EHR-OBSERVATION.sequential_organ_failure_assessment.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.sequential_organ_failure_assessment.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0006": {
+            "id": "gt0006",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0010]"
+          }
+        }
+      },
+      "gt0004": {
+        "id": "gt0004",
+        "model_id": "openEHR-EHR-EVALUATION.sequential_organ_failure_assessment_interpretation.v1",
+        "template_id": "openEHR-EHR-EVALUATION.sequential_organ_failure_assessment_interpretation.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0005": {
+            "id": "gt0005",
+            "path": "/data[at0001]/items[at0002]"
+          }
+        }
+      }
+    },
+    "rules": {
+      "gt0009": {
+        "id": "gt0009",
+        "priority": 6,
+        "when": [
+          "$gt0006|Total score|<=6"
+        ],
+        "then": [
+          "$gt0005|Mortality percentage|=0|local::at0003|<10 % mortality|"
+        ]
+      },
+      "gt0010": {
+        "id": "gt0010",
+        "priority": 5,
+        "when": [
+          "$gt0006|Total score|<=9",
+          "$gt0006|Total score|>=7"
+        ],
+        "then": [
+          "$gt0005|Mortality percentage|=1|local::at0004|15-20% mortality|"
+        ]
+      },
+      "gt0011": {
+        "id": "gt0011",
+        "priority": 4,
+        "when": [
+          "$gt0006|Total score|<=12",
+          "$gt0006|Total score|>=10"
+        ],
+        "then": [
+          "$gt0005|Mortality percentage|=2|local::at0005|40-50% mortality|"
+        ]
+      },
+      "gt0012": {
+        "id": "gt0012",
+        "priority": 3,
+        "when": [
+          "$gt0006|Total score|<=14",
+          "$gt0006|Total score|>=13"
+        ],
+        "then": [
+          "$gt0005|Mortality percentage|=3|local::at0006|50-60% mortality|"
+        ]
+      },
+      "gt0013": {
+        "id": "gt0013",
+        "priority": 2,
+        "when": [
+          "$gt0006|Total score|==15"
+        ],
+        "then": [
+          "$gt0005|Mortality percentage|=4|local::at0007|> 80% mortality|"
+        ]
+      },
+      "gt0014": {
+        "id": "gt0014",
+        "priority": 1,
+        "when": [
+          "$gt0006|Total score|>=16",
+          "$gt0006|Total score|<=24"
+        ],
+        "then": [
+          "$gt0005|Mortality percentage|=5|local::at0008|> 90% mortality|"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "sv": {
+        "id": "sv",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Sequential Organ Failure Assessment utvärdering",
+            "description": "Utvärdering av poäng genererad i enlighet med SOFA: Sequential Organ Failure Assessment - ett poängsystem utvecklat European Society of Intensive Care Medicine för uppskattning av mortalitet hos patienter som vårdas på intensivvårdsavdelning."
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Mortalitet",
+            "description": "*(en) Score interpretation mortality percentages"
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Total poäng",
+            "description": "*(en) Total score"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Total poäng",
+            "description": "*(en) Total score"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "CDS poäng"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "CDS SOFA score 0-6"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "CDS SOFA score 7-9"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "CDS SOFA score 10-12"
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "CDS SOFA score 13-14"
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "CDS SOFA score 15"
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "CDS SOFA score 16-24"
+          }
+        }
+      },
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "SOFA Interpretation",
+            "description": "SOFA: Sequential Organ Failure Assessment - A scoring system developed by the European Society of Intensive Care Medicine that provides an indicator of mortality and morbidity prognosis among ICU patients."
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Mortality percentage",
+            "description": "Score interpretation mortality percentages"
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Total score",
+            "description": "Total score"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Total score",
+            "description": "Total score"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "set score"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Set SOFA score 0-6"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Set SOFA score 7-9"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Set SOFA score 10-12"
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "Set SOFA score 13-14"
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "Set SOFA score 15"
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "Set SOFA score 16-24"
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/SOFA_Interpretation.v1.test.yml
+++ b/gdl2/SOFA_Interpretation.v1.test.yml
@@ -1,0 +1,45 @@
+guidelines:
+  1: SOFA_Interpretation.v1
+test_cases:
+- id: Low
+  input:
+    1:
+      gt0006|Total score: 3
+  expected_output:
+    1:
+      gt0005|Mortality percentage: 0|local::at0003|<10 % mortality|
+- id: 15-20%
+  input:
+    1:
+      gt0006|Total score: 7
+  expected_output:
+    1:
+      gt0005|Mortality percentage: 1|local::at0004|15-20% mortality|
+- id: 40-50%
+  input:
+    1:
+      gt0006|Total score: 10
+  expected_output:
+    1:
+      gt0005|Mortality percentage: 2|local::at0005|40-50% mortality|
+- id: 50-60%
+  input:
+    1:
+      gt0006|Total score: 13
+  expected_output:
+    1:
+      gt0005|Mortality percentage: 3|local::at0006|50-60% mortality|
+- id: sofa 15
+  input:
+    1:
+      gt0006|Total score: 15
+  expected_output:
+    1:
+      gt0005|Mortality percentage: 4|local::at0007|> 80% mortality|
+- id: sofa 16
+  input:
+    1:
+      gt0006|Total score: 16
+  expected_output:
+    1:
+      gt0005|Mortality percentage: 5|local::at0008|> 90% mortality|

--- a/gdl2/qSOFA.v1.gdl2.json
+++ b/gdl2/qSOFA.v1.gdl2.json
@@ -1,0 +1,365 @@
+{
+  "id": "qSOFA.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2016-07-06",
+      "name": "Jimmy Axelsson",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "other_contributors": [
+      "Dennis Forslund"
+    ],
+    "lifecycle_state": "Author draft",
+    "details": {
+      "sv": {
+        "id": "sv",
+        "purpose": "Att bland icke intensivvårdade patienter med förmodad infektionssjukdom identifiera de med hög risk för negativt utfall.",
+        "keywords": [
+          "qSOFA",
+          "Infektion",
+          "Sepsis",
+          "Hypotension",
+          "Medvetandegrad",
+          "Andningsfrekvens"
+        ],
+        "use": "Använd för att bland icke intensivvårdade patienter med förmodad infektionssjukdom identifiera de med hög risk för negativt utfall.\r\n\r\nqSOFA är en akronym för quick Sepsis Related Organ Failure Assessment, och utgörs av tre komponenter; förändrad medvetandegrad (GCS<15), förhöjd andningsfrekvens (≥22/min) och systoliskt blodtryck≤100 mmHg. Varje enskild faktor bidrar med en poäng, och genererar en total poäng mellan 0-3.\r\n\r\nqSOFA är en förenklad version av SOFA-protokollet, och innehåller endast tre kliniska kriterier samt ”förändrad medvetandegrad” istället för GCS≤13.\r\n\r\nTotal poäng ≥2 indikerar hög risk för dålig prognos, mätt i mortalitet och IVA-vård ≥3 dagar. Patienter i denna kategori bör utredas för organsvikt (inklusive laktatnivå). Vidare bör det fullständiga SOFA-protokollet tillämpas på dessa patienter. Intervention i form av standardbehandling för sepsis bör initieras.\r\n\r\nTotal poäng <2 associeras inte med hög risk för negativt utfall, men kan inte användas för uteslutning. Om klinisk misstanke om sepsis föreligger, bör patienter i denna kategori monitoreras och utvärderas kontinuerligt. Klinisk bedömning avgör eventuell behandling. \r\n\r\nKontinuerlig utvärdering med hjälp av qSOFA kan utföras för att detektera förändringar av prognostiskt värde.\r\n",
+        "misuse": "Använd ej för att utesluta sepsis. Total poäng <2 associeras inte med hög risk för negativt utfall, men kan inte användas för uteslutning. Om klinisk misstanke om sepsis föreligger, bör patienter i denna kategori monitoreras och utvärderas kontinuerligt. Klinisk bedömning avgör eventuell behandling. Kontinuerlig utvärdering med hjälp av qSOFA kan detektera förändringar av prognostiskt värde.",
+        "copyright": "Cambio Healthcare Systems"
+      },
+      "en": {
+        "id": "en",
+        "purpose": "To identify patients with confirmed or suspected infection with high risk for poor outcome outside of the intensive care unit.",
+        "keywords": [
+          "qSOFA",
+          "Mental state",
+          "Respiration rate",
+          "Sepsis",
+          "Infection",
+          "Hypotension"
+        ],
+        "use": "Use to evaluate the risk of poor outcome in patients with confirmed or suspected infection outside of the intensive care unit (ICU).\r\n\r\nqSOFA is an acronym for quick Sepsis Related Organ Failure Assessment. It is can be used bedside to assess the risk of poor outcome in patients with suspected or confirmed infection outside the ICU. qSOFA consists of three criteria: altered mental state (GCS<15), fast respiratory rate (≥22 breaths per min), and low blood pressure (SBP≤100 mmHg). Each criteria is worth one point, thus the maximum qSOFA Score is 3. \r\n\r\nThe qSOFA protocol is a markedly simplified version of the SOFA protocol. qSOFA uses only its three clinical criteria and uses \\\"altered mental status\\\" instead of GCS≤13.\r\n\r\nA qSOFA score of ≥2 is indicative of a high risk of poor prognosis (mortality or ICU stay of ≥3 days). Patients with qSOFA score of ≥2 should be assessed for organ dysfunction (this includes lactate levels). Furthermore, the SOFA Score should be calculated for these patients and the standard interventions for sepsis should be used as treatment. \r\n\r\nA qSOFA score of <2 is not associated with a high risk of poor prognosis, but it does not suggest that the subject of care is not a high risk patient. If sepsis is still suspected when the qSOFA score is <2, continue monitoration and evaluation of the patient. Initiate standard treatment if needed.\r\n\r\nSerial qSOFA assessments can be performed to detect changes in prognosis.",
+        "misuse": "Do not use to rule out sepsis. If sepsis is still suspected when the qSOFA score is <2, continue monitoration and evaluation of the patient. Initiate standard treatment if needed. Conduct qSOFA assessments regularly in order to detect changes in prognosis.",
+        "copyright": "Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Singer M, Deutschman CS, Seymour C, et al. The Third International Consensus Definitions for Sepsis and Septic Shock (Sepsis-3). JAMA. 2016;315(8):801-810. doi:10.1001/jama.2016.0287.\r\n\r\nShankar-Hari M, Phillips GS, Levy ML, et al. Developing a New Definition and Assessing New Clinical Criteria for Septic Shock: For the Third International Consensus Definitions for Sepsis and Septic Shock (Sepsis-3). JAMA. 2016;315(8):775-787. doi:10.1001/jama.2016.0289.\r\n\r\nSeymour CW, Liu VX, Iwashyna TJ, et al. Assessment of Clinical Criteria for Sepsis: For the Third International Consensus Definitions for Sepsis and Septic Shock (Sepsis-3). JAMA. 2016;315(8):762-774. doi:10.1001/jama.2016.02"
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0002": {
+        "id": "gt0002",
+        "model_id": "openEHR-EHR-OBSERVATION.qsofa.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.qsofa.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0003": {
+            "id": "gt0003",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0004]"
+          },
+          "gt0004": {
+            "id": "gt0004",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0005]"
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0006]"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0007": {
+        "id": "gt0007",
+        "model_id": "openEHR-EHR-OBSERVATION.qsofa.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.qsofa.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0008": {
+            "id": "gt0008",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0007]"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0004]"
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0005]"
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0006]"
+          }
+        }
+      },
+      "gt0017": {
+        "id": "gt0017",
+        "model_id": "openEHR-EHR-EVALUATION.qsofa_assessment.v1",
+        "template_id": "openEHR-EHR-EVALUATION.qsofa_assessment.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0018": {
+            "id": "gt0018",
+            "path": "/data[at0001]/items[at0003]"
+          }
+        }
+      }
+    },
+    "rules": {
+      "gt0009": {
+        "id": "gt0009",
+        "priority": 7,
+        "when": [
+          "$gt0013|Systolic Blood Pressure ≤100 mm Hg|==null",
+          "$gt0012|Respiration Rate ≥ 22 /min |==null",
+          "$gt0011|Altered Mentation|==null"
+        ],
+        "then": [
+          "$gt0013|Systolic Blood Pressure ≤100 mm Hg|=0|local::at0012|Absent|",
+          "$gt0012|Respiration Rate ≥ 22 /min |=0|local::at0010|Absent|",
+          "$gt0011|Altered Mentation|=0|local::at0008|Absent|"
+        ]
+      },
+      "gt0010": {
+        "id": "gt0010",
+        "priority": 6,
+        "when": [
+          "$gt0003|Altered Mentation|==1|local::at0009|Present|"
+        ],
+        "then": [
+          "$gt0011|Altered Mentation|=1|local::at0009|Present|"
+        ]
+      },
+      "gt0014": {
+        "id": "gt0014",
+        "priority": 5,
+        "when": [
+          "$gt0004|Respiration Rate ≥ 22 /min |==1|local::at0011|Present|"
+        ],
+        "then": [
+          "$gt0012|Respiration Rate ≥ 22 /min |=1|local::at0011|Present|"
+        ]
+      },
+      "gt0015": {
+        "id": "gt0015",
+        "priority": 4,
+        "when": [
+          "$gt0005|Systolic Blood Pressure ≤100 mm Hg|==1|local::at0013|Present|"
+        ],
+        "then": [
+          "$gt0013|Systolic Blood Pressure ≤100 mm Hg|=1|local::at0013|Present|"
+        ]
+      },
+      "gt0016": {
+        "id": "gt0016",
+        "priority": 3,
+        "then": [
+          "$gt0008|Total Score|.magnitude=($gt0011.value+$gt0012.value)+$gt0013.value"
+        ]
+      },
+      "gt0019": {
+        "id": "gt0019",
+        "priority": 2,
+        "when": [
+          "$gt0008|Total Score|.magnitude<2"
+        ],
+        "then": [
+          "$gt0018|Risk assessment|=0|local::at0004|Not high risk.|"
+        ]
+      },
+      "gt0020": {
+        "id": "gt0020",
+        "priority": 1,
+        "when": [
+          "$gt0008|Total Score|.magnitude>=2"
+        ],
+        "then": [
+          "$gt0018|Risk assessment|=1|local::at0005|High risk.|"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "sv": {
+        "id": "sv",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "qSOFA",
+            "description": "qSOFA är en akronym för quick Sepsis Related Organ Failure Assessment. Poängsystemet används för att bland icke intensivvårdade patienter med förmodad infektionssjukdom identifiera de med hög risk för negativt utfall, mätt i mortalitet och IVA-vård ≥3 dagar. qSOFA utgörs av tre komponenter; förändrad medvetandegrad (GCS<15), förhöjd andningsfrekvens (≥22/min) och systoliskt blodtryck≤100 mmHg. Varje enskild faktor bidrar med en poäng. "
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "Förändrad medvetandegrad",
+            "description": "*(en) *"
+          },
+          "gt0004": {
+            "id": "gt0004",
+            "text": "Andningsfrekvens ≥ 22 /min ",
+            "description": "*(en) *"
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Systoliskt blodtryck ≤100 mm Hg",
+            "description": "*(en) *"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Total poäng",
+            "description": "*(en) *"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Ange förvalda värden"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Sätt förändrad medvetandegrad till föreligger"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Förändrad medvetandegrad",
+            "description": "*(en) *"
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "Andningsfrekvens ≥ 22 /min ",
+            "description": "*(en) *"
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "Systoliskt blodtryck ≤100 mm Hg",
+            "description": "*(en) *"
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "Sätt andningsfrekvens ≥22 /min  till föreligger"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "Sätt systoliskt blodtryck ≤100 mmHg till föreligger"
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "Räkna ut totalpoäng"
+          },
+          "gt0018": {
+            "id": "gt0018",
+            "text": "Risknivå",
+            "description": "*(en) *"
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "text": "Sätt risknivå till inte hög risk"
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "Sätt risknivå till hög risk"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      },
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "quick Sepsis Related Organ Failure Assessment",
+            "description": "qSOFA is an acronym for quick Sepsis Related Organ Failure Assessment. It is used to identify patients with suspected infection who have a greater risk of poor outcome outside of the intensive care unit. qSOFA consists of three criteria: altered mental state (GCS<15), fast respiratory rate (≥22 breaths per min), and low blood pressure (SBP≤100 mmHg). Each criteria is worth one point."
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "Altered Mentation",
+            "description": "*"
+          },
+          "gt0004": {
+            "id": "gt0004",
+            "text": "Respiration Rate ≥ 22 /min ",
+            "description": "*"
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Systolic Blood Pressure ≤100 mm Hg",
+            "description": "*"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Total Score",
+            "description": "*"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Set default"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Set altered mentation to present"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Altered Mentation",
+            "description": "*"
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "Respiration Rate ≥ 22 /min ",
+            "description": "*"
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "Systolic Blood Pressure ≤100 mm Hg",
+            "description": "*"
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "Set respiratory rate ≥22 /min  to present"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "Set systolic blood pressure ≤100 mm Hg to present"
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "Calculate total score"
+          },
+          "gt0018": {
+            "id": "gt0018",
+            "text": "Risk assessment",
+            "description": "*"
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "text": "Set risk level to low risk"
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "Set risk level to high risk"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/qSOFA.v1.test.yml
+++ b/gdl2/qSOFA.v1.test.yml
@@ -1,0 +1,62 @@
+guidelines:
+  1: qSOFA.v1
+test_cases:
+- id: Low risk
+  input:
+    1:
+      gt0003|Altered Mentation: 0|local::at0008|Absent|
+      'gt0004|Respiration Rate ≥ 22 /min ': 0|local::at0010|Absent|
+      gt0005|Systolic Blood Pressure ≤100 mm Hg: 0|local::at0012|Absent|
+      gt0021|Event time: 2019-05-24T15:30Z
+  expected_output:
+    1:
+      'gt0012|Respiration Rate ≥ 22 /min ': 0|local::at0010|Absent|
+      gt0011|Altered Mentation: 0|local::at0008|Absent|
+      gt0013|Systolic Blood Pressure ≤100 mm Hg: 0|local::at0012|Absent|
+      gt0008|Total Score: 0
+      gt0018|Risk assessment: 0|local::at0004|Not high risk.|
+- id: altered mentation
+  input:
+    1:
+      gt0003|Altered Mentation: 1|local::at0009|Present|
+      'gt0004|Respiration Rate ≥ 22 /min ': 0|local::at0010|Absent|
+      gt0005|Systolic Blood Pressure ≤100 mm Hg: 0|local::at0012|Absent|
+      gt0021|Event time: 2019-05-24T15:30Z
+  expected_output:
+    1:
+      'gt0012|Respiration Rate ≥ 22 /min ': 0|local::at0010|Absent|
+      gt0011|Altered Mentation: 1|local::at0009|Present|
+      gt0013|Systolic Blood Pressure ≤100 mm Hg: 0|local::at0012|Absent|
+      gt0008|Total Score: 1
+      gt0018|Risk assessment: 0|local::at0004|Not high risk.|
+- id: high RR
+  input:
+    1:
+      gt0003|Altered Mentation: 1|local::at0009|Present|
+      'gt0004|Respiration Rate ≥ 22 /min ': 1|local::at0011|Present|
+      gt0005|Systolic Blood Pressure ≤100 mm Hg: 0|local::at0012|Absent|
+      gt0021|Event time: 2019-05-24T15:30Z
+  expected_output:
+    1:
+      'gt0012|Respiration Rate ≥ 22 /min ': 1|local::at0011|Present|
+      gt0011|Altered Mentation: 1|local::at0009|Present|
+      gt0013|Systolic Blood Pressure ≤100 mm Hg: 0|local::at0012|Absent|
+      gt0008|Total Score: 2
+      gt0018|Risk assessment: 1|local::at0005|High risk.|
+
+
+- id: All
+  input:
+    1:
+      gt0003|Altered Mentation: 1|local::at0009|Present|
+      'gt0004|Respiration Rate ≥ 22 /min ': 1|local::at0011|Present|
+      gt0005|Systolic Blood Pressure ≤100 mm Hg: 1|local::at0013|Present|
+      gt0021|Event time: 2019-05-24T15:30Z
+  expected_output:
+    1:
+      'gt0012|Respiration Rate ≥ 22 /min ': 1|local::at0011|Present|
+      gt0011|Altered Mentation: 1|local::at0009|Present|
+      gt0013|Systolic Blood Pressure ≤100 mm Hg: 1|local::at0013|Present|
+      gt0008|Total Score: 3
+      gt0018|Risk assessment: 1|local::at0005|High risk.|
+


### PR DESCRIPTION
SOFA and qSOFA migrated. Larger changes in SOFA guideline:
(1) Event time
(2) Output  -> input
(3) .magnitude changed to constant comparison is GCS rules
(4) bilirubin thresholds slightly changed, that no value remains outside of any intervalls, i.e. bilirubin=12 was outside, while 11.9 was in one interval and 12.1 was in another.
(5) Creatinine thresholds are not changed. But the current thresholds has the same problem (see last test example). The reason I didn't touch them is because refs contain slightly different thresholds which are inside the guideline's current implementation, and I didn't want to make the verdict on my own.