### PR TITLE
sPESI addessment migrated

### DIFF
--- a/gdl2/sPESI_Assessment.v1.gdl2.json
+++ b/gdl2/sPESI_Assessment.v1.gdl2.json
@@ -1,0 +1,234 @@
+{
+  "id": "sPESI_Assessment.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2017-09-04",
+      "name": "Syeeda S Farruque",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "other_contributors": [
+      "Dennis Forslund, Cambio Healthcare Systems"
+    ],
+    "lifecycle_state": "Author draft",
+    "details": {
+      "sv": {
+        "id": "sv",
+        "purpose": "Att vid fastställd diagnos riskstratifiera patienter med lungemboli i syfte att bedöma vilka patienter som kräver inläggning respektive kan skrivas ut för hembehandling.",
+        "keywords": [
+          "lungemboli",
+          "Simplified PESI",
+          "PESI"
+        ],
+        "use": "Instrumentet baseras på sex kriterier:\r\n\r\n- Historik av cancer\r\n- Historik av kardiopulmonell sjukdom\r\n- Ålder\r\n- Hjärtfrekvens\r\n- Systoliskt blodtryck\r\n- Syresaturation\r\n\r\nÄr minst ett av kriterierna uppfyllt hör patienten till högriskgruppen:\r\n0p - låg risk, 30-dagarsmortalitet 1,1% och svår morbiditet 1,5%. För dessa patienter kan hembehandling övervägas, om kliniskt lämpligt och sociala faktorer gör det möjligt.\r\n\r\nMinst 1p - hög risk, 30-dagarsmortalitet 8,9% och svår morbiditet 2,7%. Överväg inläggning.",
+        "misuse": "Endast tillämplig vid fastställd diagnos. Endast avsedd att utgöra stöd till klinisk bedömning.",
+        "copyright": "© Cambio Healthcare Systems"
+      },
+      "en": {
+        "id": "en",
+        "purpose": "Once a diagnosis of Pulmonary Embolism has been made, the Simplified PESI score can risk stratify patients between those at high risk and requiring inpatient admission and those with low risk who may be managed as an outpatient",
+        "keywords": [
+          "pulmonary embolism",
+          "Simplified PESI"
+        ],
+        "use": "Management\r\n\r\nLow risk of mortality (1.1%) or severe morbidity (1.5%) for a score of 0\r\n\r\nConsider outpatient management of PE if clinically appropriate and social factors allow for it.\r\n   \r\nHigh risk of mortality (8.9%) or severe morbidity (2.7%) for a score of ≥ 1\r\n\r\nConsider inpatient management and higher levels of care if clinically appropriate.",
+        "misuse": "Do not use alone without sound clinical judgement and only for risk stratification once a diagnosis has been made.",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Ref. 1: Jiménez D, Aujesky D, Moores L, Gómez V, Lobo JL, Uresandi F, Otero R, Monreal M, Muriel A, Yusen RD; RIETE Investigators. Simplification of the pulmonary embolism severity index for prognostication in patients with acute symptomatic pulmonary embolism. Arch Intern Med. 2010 Aug 9;170(15):1383-9. PubMed PMID:20696966."
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0002": {
+        "id": "gt0002",
+        "model_id": "openEHR-EHR-EVALUATION.simplified_pesi_assessment.v1",
+        "template_id": "openEHR-EHR-EVALUATION.simplified_pesi_assessment.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0007": {
+            "id": "gt0007",
+            "path": "/data[at0001]/items[at0002]"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "path": "/data[at0001]/items[at0006]"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "path": "/data[at0001]/items[at0003]"
+          }
+        }
+      },
+      "gt0012": {
+        "id": "gt0012",
+        "model_id": "openEHR-EHR-OBSERVATION.simplified_pesi.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.simplified_pesi.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0014": {
+            "id": "gt0014",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0023]"
+          }
+        }
+      }
+    },
+    "rules": {
+      "gt0016": {
+        "id": "gt0016",
+        "priority": 2,
+        "when": [
+          "$gt0014|Total score|==0"
+        ],
+        "then": [
+          "$gt0007|Percentage Mortality Risk|=0|local::at0004|Low risk of mortality (1.1%)|",
+          "$gt0008|Percentage Severe Morbidity|=0|local::at0007|Severe morbidity (1.5%)|",
+          "$gt0009|Management|=0|local::at0009|Consider outpatient management of PE|"
+        ]
+      },
+      "gt0017": {
+        "id": "gt0017",
+        "priority": 1,
+        "when": [
+          "$gt0014|Total score|>=1"
+        ],
+        "then": [
+          "$gt0007|Percentage Mortality Risk|=1|local::at0005|High risk of mortality (8.9%)|",
+          "$gt0008|Percentage Severe Morbidity|=1|local::at0008|Severe morbidity (2.7%)|",
+          "$gt0009|Management|=1|local::at0010|Consider inpatient management of PE|"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "sv": {
+        "id": "sv",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Simplified PESI utvärdering",
+            "description": "Simplified Pulmonary Embolism Severity Index (PESI) kan användas för att uppskatta 30-dagarsmortalitet för patienter med lungemboli."
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Poäng",
+            "description": "Summan av samtliga faktorer."
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Poäng",
+            "description": "Summan av samtliga faktorer."
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "30-dagarsmortalitet",
+            "description": ""
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Svår morbiditet",
+            "description": ""
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Rekommendation",
+            "description": "Rekommenderad åtgärd baserat på resultat."
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Poäng",
+            "description": "Summan av samtliga faktorer."
+          },
+          "gt0013": {
+            "id": "gt0013"
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "Poäng",
+            "description": "Summan av samtliga faktorer."
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "*(en) score"
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "CDS Låg risk"
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "text": "CDS Hög risk"
+          }
+        }
+      },
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Simplified PESI Assessment",
+            "description": "Simplified PESI (Pulmonary Embolism Severity Index) or sPESI predicts 30-day outcome of patients with PE (Pulmonary Embolism)"
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Total score",
+            "description": "Total sum of the individual scores"
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Total score",
+            "description": "Total sum of the individual scores"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Percentage Mortality Risk",
+            "description": "Percentage Mortality Risk"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Percentage Severe Morbidity",
+            "description": "Percentage Severe Morbidity"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Management",
+            "description": "Management"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Total score",
+            "description": "Total sum of the individual scores"
+          },
+          "gt0013": {
+            "id": "gt0013"
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "Total score",
+            "description": "Total sum of the individual scores"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "score"
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "Low risk mortality, morbidity and management"
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "text": "High risk mortality, morbidity and management"
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/sPESI_Assessment.v1.test.yml
+++ b/gdl2/sPESI_Assessment.v1.test.yml
@@ -1,0 +1,21 @@
+guidelines:
+  1: sPESI_Assessment.v1
+test_cases:
+- id: 1
+  input:
+    1:
+      gt0014|Total score: 1
+  expected_output:
+    1:
+      gt0009|Management: 1|local::at0010|Consider inpatient management of PE|
+      gt0008|Percentage Severe Morbidity: 1|local::at0008|Severe morbidity (2.7%)|
+      gt0007|Percentage Mortality Risk: 1|local::at0005|High risk of mortality (8.9%)|
+- id: 0
+  input:
+    1:
+      gt0014|Total score: 0
+  expected_output:
+    1:
+      gt0009|Management: 0|local::at0009|Consider outpatient management of PE|
+      gt0008|Percentage Severe Morbidity: 0|local::at0007|Severe morbidity (1.5%)|
+      gt0007|Percentage Mortality Risk: 0|local::at0004|Low risk of mortality (1.1%)|


### PR DESCRIPTION
sPESI assessment migrated before I noticed that the base guideline was being migrated by Aulia.
This works fine and was very easy, only output->input change was necessary.