### PR TITLE
THRIVE migrated

### DIFF
--- a/gdl2/THRIVE Score Assessment.v1.gdl2.json
+++ b/gdl2/THRIVE Score Assessment.v1.gdl2.json
@@ -1,0 +1,137 @@
+{
+  "id": "THRIVE Score Assessment.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2017-09-03",
+      "name": "Syeeda S Farruque",
+      "organisation": "© Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "lifecycle_state": "Author draft",
+    "details": {
+      "en": {
+        "id": "en",
+        "purpose": "The THRIVE score helps to predict functional outcome, death after stroke, and the risk of brain hemorrhage after IV tPA administration in patients who suffer an ischemic stroke.",
+        "keywords": [
+          "THRIVE Score for Stroke Outcome",
+          "NIHSS",
+          "ischemic stroke",
+          "IV tPA"
+        ],
+        "use": "The Total Health Risk In Vascular Events (THRIVE) score utilises variables such as the NIHSS score, age, and chronic disease such as hypertension, diabetes mellitus and atrial fibrillation to predict long-term neurologic outcomes in stroke patients. \n\nScore of 0 :\n\n79-88% chance of a good neurological outcome\n0-2% predicted mortality at 90 days.\n\nScore of 9:\n\n7-16% chance of a good neurological outcome\n38-58% mortality at 90 days.",
+        "misuse": "Do not use for diagnostic purposes alone.",
+        "copyright": "Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Ref. 1: Flint AC, Cullen SP, Faigeles BS, Rao VA. Predicting long-term outcome after endovascular stroke treatment: the totaled health risks in vascular events score. AJNR Am J Neuroradiol. 2010 Aug;31(7):1192-6. doi: 10.3174/ajnr.A2050. Epub 2010 Mar 11. PubMed PMID: 20223889."
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0002": {
+        "id": "gt0002",
+        "model_id": "openEHR-EHR-EVALUATION.thrive_score_assessment.v1",
+        "template_id": "openEHR-EHR-EVALUATION.thrive_score_assessment.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0007": {
+            "id": "gt0007",
+            "path": "/data[at0001]/items[at0002]"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "path": "/data[at0001]/items[at0003]"
+          }
+        }
+      },
+      "gt0003": {
+        "id": "gt0003",
+        "model_id": "openEHR-EHR-OBSERVATION.thrive_score_for_stroke_outcome.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.thrive_score_for_stroke_outcome.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0006": {
+            "id": "gt0006",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0009]"
+          }
+        }
+      }
+    },
+    "rules": {
+      "gt0010": {
+        "id": "gt0010",
+        "priority": 2,
+        "when": [
+          "$gt0006|Total score|==0"
+        ],
+        "then": [
+          "$gt0008|Percentage predicted mortality at 90 days|=0|local::at0006|0-2%|",
+          "$gt0007|Chance of a good neurological outcome|=0|local::at0004|79-88%|"
+        ]
+      },
+      "gt0011": {
+        "id": "gt0011",
+        "priority": 1,
+        "when": [
+          "$gt0006|Total score|==9"
+        ],
+        "then": [
+          "$gt0007|Chance of a good neurological outcome|=1|local::at0005|7-16%|",
+          "$gt0008|Percentage predicted mortality at 90 days|=1|local::at0007|38-58%|"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Thrive score assessment",
+            "description": "THRIVE Score for Stroke Outcome provides an estimated prognosis after an acute ischemic stroke"
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Total score",
+            "description": "Total score"
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Total score",
+            "description": "Total score"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Chance of a good neurological outcome",
+            "description": "Chance of a good neurological outcome"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Percentage predicted mortality at 90 days",
+            "description": "Percentage predicted mortality at 90 days"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "score"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Set Chance of good outcome and predicted mortality for score 0"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Set Chance of good outcome and predicted mortality for score 9"
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/THRIVE Score Assessment.v1.test.yml
+++ b/gdl2/THRIVE Score Assessment.v1.test.yml
@@ -1,0 +1,19 @@
+guidelines:
+  1: THRIVE Score Assessment.v1
+test_cases:
+- id: score_9
+  input:
+    1:
+      gt0006|Total score: 9
+  expected_output:
+    1:
+      gt0007|Chance of a good neurological outcome: 1|local::at0005|7-16%|
+      gt0008|Percentage predicted mortality at 90 days: 1|local::at0007|38-58%|
+- id: score 0
+  input:
+    1:
+      gt0006|Total score: 0
+  expected_output:
+    1:
+      gt0007|Chance of a good neurological outcome: 0|local::at0004|79-88%|
+      gt0008|Percentage predicted mortality at 90 days:  0|local::at0006|0-2%|

--- a/gdl2/THRIVE_for_Stroke.v1.gdl2.json
+++ b/gdl2/THRIVE_for_Stroke.v1.gdl2.json
@@ -1,0 +1,398 @@
+{
+  "id": "THRIVE_for_Stroke.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2017-09-03",
+      "name": "Syeeda S Farruque",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "lifecycle_state": "Author draft",
+    "details": {
+      "en": {
+        "id": "en",
+        "purpose": "The THRIVE score helps to predict functional outcome, death after stroke, and the risk of brain hemorrhage after IV tPA administration in patients who suffer an ischemic stroke.",
+        "keywords": [
+          "Thrive score for stroke outcome",
+          "NIHSS",
+          "ischemic stroke",
+          "IV tPA"
+        ],
+        "use": "The Total Health Risk In Vascular Events (THRIVE) score utilises variables such as the NIHSS score, age, and chronic disease such as hypertension, diabetes mellitus and atrial fibrillation to predict long-term neurologic outcomes in stroke patients. \r\n\r\nThe score ranges from 0-9 increasing in severity. The following scoring criteria are used:\r\n\r\nCriteria \t                                      Value\r\n\r\nNIH Stroke Scale\r\n≤ 10 \t                                      0\r\n11-20 \t                                    +2\r\n≥ 21 \t                                    +4\r\nAge\r\n≤ 59 \t                                      0\r\n60-79 \t                                   +1\r\n≥ 80 \t                                   +2\r\nHistory\r\nHypertension \t                  +1\r\nDiabetes mellitus \t                  +1\r\nAtrial fibrillation \t                  +1\r\n\r\nScore of 0 :\r\n\r\n79-88% chance of a good neurological outcome\r\n0-2% predicted mortality at 90 days.\r\n\r\nScore of 9:\r\n\r\n7-16% chance of a good neurological outcome\r\n38-58% mortality at 90 days.\r\n",
+        "misuse": "Do not use for diagnostic purposes alone.",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Ref. 1: Flint AC, Cullen SP, Faigeles BS, Rao VA. Predicting long-term outcome after endovascular stroke treatment: the totaled health risks in vascular events score. AJNR Am J Neuroradiol. 2010 Aug;31(7):1192-6. doi: 10.3174/ajnr.A2050. Epub 2010 Mar 11. PubMed PMID: 20223889."
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0002": {
+        "id": "gt0002",
+        "model_id": "openEHR-EHR-OBSERVATION.nihss.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.nihss.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0003": {
+            "id": "gt0003",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0021]"
+          },
+          "gt0030": {
+            "id": "gt0030",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0004": {
+        "id": "gt0004",
+        "model_id": "openEHR-EHR-OBSERVATION.basic_demographic.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.basic_demographic.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0005": {
+            "id": "gt0005",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0008]"
+          },
+          "gt0031": {
+            "id": "gt0031",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0006": {
+        "id": "gt0006",
+        "model_id": "openEHR-EHR-OBSERVATION.basic_demographic.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.basic_demographic.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0007": {
+            "id": "gt0007",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0013]"
+          }
+        }
+      },
+      "gt0008": {
+        "id": "gt0008",
+        "model_id": "openEHR-EHR-OBSERVATION.thrive_score_for_stroke_outcome.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.thrive_score_for_stroke_outcome.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0009": {
+            "id": "gt0009",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0006]"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0007]"
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0008]"
+          },
+          "gt0032": {
+            "id": "gt0032",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0010": {
+        "id": "gt0010",
+        "model_id": "openEHR-EHR-OBSERVATION.thrive_score_for_stroke_outcome.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.thrive_score_for_stroke_outcome.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0013": {
+            "id": "gt0013",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0004]"
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0005]"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0006]"
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0007]"
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0008]"
+          },
+          "gt0018": {
+            "id": "gt0018",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0009]"
+          }
+        }
+      }
+    },
+    "default_actions": [
+      "$gt0015|History of hypertension|=0|local::at0017|No|",
+      "$gt0016|History of diabetes mellitus|=0|local::at0019|No|",
+      "$gt0017|History of atrial fibrillation|=0|local::at0021|No|"
+    ],
+    "rules": {
+      "gt0019": {
+        "id": "gt0019",
+        "priority": 11,
+        "when": [
+          "$gt0005|Birthdate|!=null"
+        ],
+        "then": [
+          "$gt0007|Age|.unit='a'",
+          "$gt0007|Age|.magnitude=$currentDateTime.year-$gt0005.year"
+        ]
+      },
+      "gt0020": {
+        "id": "gt0020",
+        "priority": 10,
+        "when": [
+          "$gt0007|Age|<=59,a"
+        ],
+        "then": [
+          "$gt0013|Age score|=0|local::at0011|Score for ≤ 59|"
+        ]
+      },
+      "gt0021": {
+        "id": "gt0021",
+        "priority": 9,
+        "when": [
+          "$gt0007|Age|<=79,a",
+          "$gt0007|Age|>=60,a"
+        ],
+        "then": [
+          "$gt0013|Age score|=1|local::at0012|Score for 60-79|"
+        ]
+      },
+      "gt0022": {
+        "id": "gt0022",
+        "priority": 8,
+        "when": [
+          "$gt0007|Age|>=80,a"
+        ],
+        "then": [
+          "$gt0013|Age score|=2|local::at0013|Score for ≥ 80|"
+        ]
+      },
+      "gt0023": {
+        "id": "gt0023",
+        "priority": 7,
+        "when": [
+          "$gt0009|History of hypertension|!=null"
+        ],
+        "then": [
+          "$gt0015|History of hypertension|=$gt0009|History of hypertension|"
+        ]
+      },
+      "gt0024": {
+        "id": "gt0024",
+        "priority": 6,
+        "when": [
+          "$gt0011|History of diabetes mellitus|!=null"
+        ],
+        "then": [
+          "$gt0016|History of diabetes mellitus|=$gt0011|History of diabetes mellitus|"
+        ]
+      },
+      "gt0025": {
+        "id": "gt0025",
+        "priority": 5,
+        "when": [
+          "$gt0012|History of atrial fibrillation|!=null"
+        ],
+        "then": [
+          "$gt0017|History of atrial fibrillation|=$gt0012|History of atrial fibrillation|"
+        ]
+      },
+      "gt0026": {
+        "id": "gt0026",
+        "priority": 4,
+        "when": [
+          "$gt0003|Total score|<=10"
+        ],
+        "then": [
+          "$gt0014|NIHSS score|=0|local::at0014|Score ≤ 10|"
+        ]
+      },
+      "gt0027": {
+        "id": "gt0027",
+        "priority": 3,
+        "when": [
+          "$gt0003|Total score|<=20",
+          "$gt0003|Total score|>=11"
+        ],
+        "then": [
+          "$gt0014|NIHSS score|=2|local::at0015|Score 11-20|"
+        ]
+      },
+      "gt0028": {
+        "id": "gt0028",
+        "priority": 2,
+        "when": [
+          "$gt0003|Total score|>=21"
+        ],
+        "then": [
+          "$gt0014|NIHSS score|=4|local::at0016|Score ≥ 21|"
+        ]
+      },
+      "gt0029": {
+        "id": "gt0029",
+        "priority": 1,
+        "then": [
+          "$gt0018|Total score|.magnitude=((($gt0013.value+$gt0014.value)+$gt0015.value)+$gt0016.value)+$gt0017.value"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Thrive for stroke",
+            "description": "THRIVE Score for Stroke Outcome provides an estimated prognosis after an acute ischemic stroke"
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "Total score",
+            "description": "Sum of all factors."
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Birthdate",
+            "description": "The patient's date of birth."
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Age",
+            "description": "Age in years, and for babies: months, weeks or days"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "History of hypertension",
+            "description": "History of hypertension"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "History of diabetes mellitus",
+            "description": "History of diabetes mellitus"
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "History of atrial fibrillation",
+            "description": "History of atrial fibrillation"
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "Age score",
+            "description": "Score according to age"
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "NIHSS score",
+            "description": "NIHSS (Stroke Scale)"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "History of hypertension",
+            "description": "History of hypertension"
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "History of diabetes mellitus",
+            "description": "History of diabetes mellitus"
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "text": "History of atrial fibrillation",
+            "description": "History of atrial fibrillation"
+          },
+          "gt0018": {
+            "id": "gt0018",
+            "text": "Total score",
+            "description": "Total score"
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "text": "Calculate age"
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "Set Age score for 0"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "text": "Set Age score for 1"
+          },
+          "gt0022": {
+            "id": "gt0022",
+            "text": "Set Age score for 2"
+          },
+          "gt0023": {
+            "id": "gt0023",
+            "text": "Set History of hypertension"
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "text": "Set History of diabetes mellitus"
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "text": "Set History of atrial fibrillation"
+          },
+          "gt0026": {
+            "id": "gt0026",
+            "text": "Set NIHSS score 0"
+          },
+          "gt0027": {
+            "id": "gt0027",
+            "text": "Set NIHSS score 2"
+          },
+          "gt0028": {
+            "id": "gt0028",
+            "text": "Set NIHSS score 4"
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "text": "Calculate total score"
+          },
+          "gt0030": {
+            "id": "gt0030",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0031": {
+            "id": "gt0031",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0032": {
+            "id": "gt0032",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/THRIVE_for_Stroke.v1.test.yml
+++ b/gdl2/THRIVE_for_Stroke.v1.test.yml
@@ -1,0 +1,109 @@
+guidelines:
+  1: THRIVE_for_Stroke.v1
+test_cases:
+- id: score 0
+  input:
+    1:
+      gt0003|Total score: 8
+      gt0030|Event time: 2019-05-27T16:09Z
+      gt0005|Birthdate: 1969-05-27T16:09Z
+      gt0031|Event time: 2019-05-27T16:09Z
+      gt0009|History of hypertension: 0|local::at0017|No|
+      gt0011|History of diabetes mellitus: 0|local::at0019|No|
+      gt0012|History of atrial fibrillation: 0|local::at0021|No|
+      gt0032|Event time: 2019-05-27T16:10Z
+  expected_output:
+    1:
+      gt0007|Age: 50,a
+      gt0016|History of diabetes mellitus: 0|local::at0019|No|
+      gt0017|History of atrial fibrillation: 0|local::at0021|No|
+      gt0015|History of hypertension: 0|local::at0017|No|
+      gt0013|Age score: 0|local::at0011|Score for ≤ 59|
+      gt0018|Total score: 0
+      gt0014|NIHSS score: 0|local::at0014|Score ≤ 10|
+- id: hypertension
+  input:
+    1:
+      gt0003|Total score: 8
+      gt0030|Event time: 2019-05-27T16:09Z
+      gt0005|Birthdate: 1969-05-27T16:09Z
+      gt0031|Event time: 2019-05-27T16:09Z
+      gt0009|History of hypertension: 1|local::at0018|Yes|
+      gt0011|History of diabetes mellitus: 0|local::at0019|No|
+      gt0012|History of atrial fibrillation: 0|local::at0021|No|
+      gt0032|Event time: 2019-05-27T16:10Z
+  expected_output:
+    1:
+      gt0007|Age: 50,a
+      gt0016|History of diabetes mellitus: 0|local::at0019|No|
+      gt0017|History of atrial fibrillation: 0|local::at0021|No|
+      gt0015|History of hypertension: 1|local::at0018|Yes|
+      gt0013|Age score: 0|local::at0011|Score for ≤ 59|
+      gt0018|Total score: 1
+      gt0014|NIHSS score: 0|local::at0014|Score ≤ 10|
+
+- id: AF, DM, Age 60
+  input:
+    1:
+      gt0003|Total score: 8
+      gt0030|Event time: 2019-05-27T16:09Z
+      gt0005|Birthdate: 1959-05-27T16:09Z
+      gt0031|Event time: 2019-05-27T16:09Z
+      gt0009|History of hypertension: 0|local::at0017|No|
+      gt0011|History of diabetes mellitus: 1|local::at0020|Yes|
+      gt0012|History of atrial fibrillation: 1|local::at0022|Yes|
+      gt0032|Event time: 2019-05-27T16:10Z
+  expected_output:
+    1:
+      gt0007|Age: 60,a
+      gt0016|History of diabetes mellitus: 1|local::at0020|Yes|
+      gt0017|History of atrial fibrillation: 1|local::at0022|Yes|
+      gt0015|History of hypertension: 0|local::at0017|No|
+      gt0013|Age score: 1|local::at0012|Score for 60-79|
+      gt0018|Total score: 3
+      gt0014|NIHSS score: 0|local::at0014|Score ≤ 10|
+
+- id: nihss 11-20, age 80
+  input:
+    1:
+      gt0003|Total score: 11
+      gt0030|Event time: 2019-05-27T16:09Z
+      gt0005|Birthdate: 1939-05-27T16:09Z
+      gt0031|Event time: 2019-05-27T16:09Z
+      gt0009|History of hypertension: 0|local::at0017|No|
+      gt0011|History of diabetes mellitus: 1|local::at0020|Yes|
+      gt0012|History of atrial fibrillation: 1|local::at0022|Yes|
+      gt0032|Event time: 2019-05-27T16:10Z
+  expected_output:
+    1:
+      gt0007|Age: 80,a
+      gt0016|History of diabetes mellitus: 1|local::at0020|Yes|
+      gt0017|History of atrial fibrillation: 1|local::at0022|Yes|
+      gt0015|History of hypertension: 0|local::at0017|No|
+      gt0013|Age score: 2|local::at0013|Score for ≥ 80|
+      gt0018|Total score: 6
+      gt0014|NIHSS score: 2|local::at0015|Score 11-20|
+
+
+- id: nihss above 20
+  input:
+    1:
+      gt0003|Total score: 21
+      gt0030|Event time: 2019-05-27T16:09Z
+      gt0005|Birthdate: 1939-05-27T16:09Z
+      gt0031|Event time: 2019-05-27T16:09Z
+      gt0009|History of hypertension: 0|local::at0017|No|
+      gt0011|History of diabetes mellitus: 1|local::at0020|Yes|
+      gt0012|History of atrial fibrillation: 1|local::at0022|Yes|
+      gt0032|Event time: 2019-05-27T16:10Z
+  expected_output:
+    1:
+      gt0007|Age: 80,a
+      gt0016|History of diabetes mellitus: 1|local::at0020|Yes|
+      gt0017|History of atrial fibrillation: 1|local::at0022|Yes|
+      gt0015|History of hypertension: 0|local::at0017|No|
+      gt0013|Age score: 2|local::at0013|Score for ≥ 80|
+      gt0018|Total score: 8
+      gt0014|NIHSS score: 4|local::at0016|Score ≥ 21|
+
+


### PR DESCRIPTION
THRIVE migrated. Although I think in the current form THRIVE score assessment makes no sense, as it fires only if the score is either 0 or 9.
In addition, it contradicts the literature, where it says: "The THRIVE score strongly predicts outcomes among patients undergoing endovascular stroke treatment (Fig 2). Patients with a low THRIVE score of 0–2 had good outcomes in 64.7% of cases, patients with a moderate THRIVE score of 3–5 had good outcomes in 43.5% of cases, and patients with a high THRIVE score of 6–9 had good outcomes in 10.6% of cases (Fig 2 A; P < .001, Mantel-Haenszel χ2 test). Patients with a low THRIVE score of 0–2 had a mortality rate of 5.9% by 90 days, patients with a moderate THRIVE score of 3–5 had a mortality rate of 30.1% by 90 days, and patients with a high THRIVE score of 6–9 had a mortality rate of 56.4% by 90 days". If you agree, I would implement rather this.
Current changes:
(1) Event time
(2)  output->input