### PR TITLE
TASH migrated

### DIFF
--- a/gdl2/TASH.v1.gdl2.json
+++ b/gdl2/TASH.v1.gdl2.json
@@ -1,0 +1,1235 @@
+{
+  "id": "TASH.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2016-01-10",
+      "name": "Syeeda S Farruque",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "other_contributors": [
+      "Dennis Forslund",
+      "Jimmy Axelsson"
+    ],
+    "lifecycle_state": "Author draft",
+    "details": {
+      "sv": {
+        "id": "sv",
+        "purpose": "Trauma Associated Severe Hemorrhage (TASH) används som stöd för hantering av svår blödning och för bedömning av behov av massiv transfusion hos traumapatienter.",
+        "keywords": [
+          "TASH",
+          "transfusion",
+          "trauma associated severe hemorrhage",
+          "trauma"
+        ],
+        "use": "TASH baseras på sju viktade parametrar:\r\n\r\nSystoliskt blodtryck\r\nHb-värde\r\nFAST (positiv)\r\nSvår fraktur och/eller bäckeninstabilitet\r\nHjärtfrekvens\r\nBase excess\r\nKön\r\n\r\nMaximal poäng uppgår till 28p och ju högre poäng, desto högre sannolikhet för behov av massiv transfusion. En poäng om ≥16p indikerar >50% risk för behov av massiv transfusion.",
+        "misuse": "Endast avsedd för bedömning av behov av massiv transfusion i enlighet med lokala protokoll.",
+        "copyright": "© Cambio Healthcare Systems"
+      },
+      "en": {
+        "id": "en",
+        "purpose": "Trauma Associated Severe Hemorrhage (TASH) score is made up with weight variables and is used in the management of severe haemorrhage and to predict the risk of needing to provide a massive transfusion for a trauma patient",
+        "keywords": [
+          "TASH",
+          "Massive transfusion"
+        ],
+        "use": "Seven independent variables were identified and used to build the TASH with scores related to various discretized values per variable which can be seen in (1)\n\r\nSBP\r - Sys Blood Pressure\nHb \r- Haemoglobin\nIntra-abdominal fluid\r\nComplex long bone and/or pelvic fractures\r\nHR\r - Heart Rate\nBE - Base excess\r\nGender \r\n\r\nThe TASH score ranges from 0 to 28. Increasing TASH-score points are associated with increasing probability of MT.\r\n\r\nA TASH score ≥ 16 points (i.e.) means a probability of MT >50%.",
+        "misuse": "TASH Score does not indicate if trauma patients should receive blood, only if they should receive blood through a massive transfusion protocol.",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Ref. 1: Yücel N, Lefering R, Maegele M, Vorweg M, Tjardes T, Ruchholtz S, Neugebauer EA, Wappler F, Bouillon B, Rixen D; Polytrauma Study Group of the German Trauma Society. Trauma Associated Severe Hemorrhage (TASH)-Score: probability of mass transfusion as surrogate for life threatening hemorrhage after multiple trauma. J Trauma. 2006 Jun;60(6):1228-36; discussion 1236-7. PubMed PMID: 16766965.\r\n\r\nRef. 2: Maegele M, Lefering R, Wafaisade A, Theodorou P, Wutzler S, Fischer P, Bouillon B, Paffrath T; Trauma Registry of Deutsche Gesellschaft für Unfallchirurgie (TR-DGU). Revalidation and update of the TASH-Score: a scoring system to predict the probability for massive transfusion as a surrogate for life-threatening haemorrhage after severe injury. Vox Sang. 2011 Feb;100(2):231-8. doi: 10.1111/j.1423-0410.2010.01387.x. Epub 2010 Aug 24. PubMed PMID: 20735809."
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0047": {
+        "id": "gt0047",
+        "model_id": "openEHR-EHR-OBSERVATION.tash.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.tash.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0048": {
+            "id": "gt0048",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0009]"
+          },
+          "gt0049": {
+            "id": "gt0049",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0010]"
+          },
+          "gt0092": {
+            "id": "gt0092",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0050": {
+        "id": "gt0050",
+        "model_id": "openEHR-EHR-OBSERVATION.tash.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.tash.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0051": {
+            "id": "gt0051",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0004]"
+          },
+          "gt0052": {
+            "id": "gt0052",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0005]"
+          },
+          "gt0053": {
+            "id": "gt0053",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0006]"
+          },
+          "gt0054": {
+            "id": "gt0054",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0007]"
+          },
+          "gt0055": {
+            "id": "gt0055",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0008]"
+          },
+          "gt0056": {
+            "id": "gt0056",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0009]"
+          },
+          "gt0057": {
+            "id": "gt0057",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0010]"
+          },
+          "gt0058": {
+            "id": "gt0058",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0036]"
+          }
+        }
+      },
+      "gt0059": {
+        "id": "gt0059",
+        "model_id": "openEHR-EHR-OBSERVATION.basic_demographic.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.basic_demographic.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0060": {
+            "id": "gt0060",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0004]"
+          },
+          "gt0093": {
+            "id": "gt0093",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0061": {
+        "id": "gt0061",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-full_blood_count.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-full_blood_count.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0062": {
+            "id": "gt0062",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.4]"
+          },
+          "gt0094": {
+            "id": "gt0094",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0063": {
+        "id": "gt0063",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-blood_gases.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-blood_gases.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0064": {
+            "id": "gt0064",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.9]"
+          },
+          "gt0095": {
+            "id": "gt0095",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0065": {
+        "id": "gt0065",
+        "model_id": "openEHR-EHR-OBSERVATION.blood_pressure.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.blood_pressure.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0066": {
+            "id": "gt0066",
+            "path": "/data[at0001]/events[at0006]/data[at0003]/items[at0004]"
+          },
+          "gt0096": {
+            "id": "gt0096",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0067": {
+        "id": "gt0067",
+        "model_id": "openEHR-EHR-OBSERVATION.pulse.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.pulse.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0068": {
+            "id": "gt0068",
+            "path": "/data[at0002]/events[at0003]/data[at0001]/items[at0004]"
+          },
+          "gt0097": {
+            "id": "gt0097",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      }
+    },
+    "rules": {
+      "gt0069": {
+        "id": "gt0069",
+        "priority": 23,
+        "when": [
+          "$gt0051|Gender score|==null",
+          "$gt0052|Haemoglobin score|==null",
+          "$gt0053|Base Excess score|==null",
+          "$gt0054|Sys BP score|==null",
+          "$gt0055|Heart Rate score|==null",
+          "$gt0056|Positive FAST for intra-abdo fluid|==null",
+          "$gt0057|Fracture of trunk/leg|==null"
+        ],
+        "then": [
+          "$gt0051|Gender score|=0|local::at0012|Female|",
+          "$gt0052|Haemoglobin score|=0|local::at0014|>= 12|",
+          "$gt0053|Base Excess score|=0|local::at0021|>= -2|",
+          "$gt0054|Sys BP score|=0|local::at0025|>= 120|",
+          "$gt0055|Heart Rate score|=0|local::at0028|<= 120|",
+          "$gt0056|Positive FAST for intra-abdo fluid|=0|local::at0030|No|",
+          "$gt0057|Fracture of trunk/leg|=0|local::at0032|No|"
+        ]
+      },
+      "gt0070": {
+        "id": "gt0070",
+        "priority": 22,
+        "when": [
+          "$gt0060|Gender|==local::at0006|Female|",
+          "$gt0060|Gender|!=null"
+        ],
+        "then": [
+          "$gt0051|Gender score|=0|local::at0012|Female|"
+        ]
+      },
+      "gt0071": {
+        "id": "gt0071",
+        "priority": 21,
+        "when": [
+          "$gt0060|Gender|==local::at0005|Male|",
+          "$gt0060|Gender|!=null"
+        ],
+        "then": [
+          "$gt0051|Gender score|=1|local::at0013|Male|"
+        ]
+      },
+      "gt0072": {
+        "id": "gt0072",
+        "priority": 20,
+        "when": [
+          "$gt0062|Haemoglobin|.magnitude>=12",
+          "$gt0062|Haemoglobin|.unit=='gm/dl'",
+          "$gt0062|Haemoglobin|!=null"
+        ],
+        "then": [
+          "$gt0052|Haemoglobin score|=0|local::at0014|>= 12|"
+        ]
+      },
+      "gt0073": {
+        "id": "gt0073",
+        "priority": 19,
+        "when": [
+          "$gt0062|Haemoglobin|.magnitude>=11",
+          "$gt0062|Haemoglobin|.magnitude<12",
+          "$gt0062|Haemoglobin|.unit=='gm/dl'",
+          "$gt0062|Haemoglobin|!=null"
+        ],
+        "then": [
+          "$gt0052|Haemoglobin score|=2|local::at0015|<12|"
+        ]
+      },
+      "gt0074": {
+        "id": "gt0074",
+        "priority": 18,
+        "when": [
+          "$gt0062|Haemoglobin|.magnitude>=10",
+          "$gt0062|Haemoglobin|.magnitude<11",
+          "$gt0062|Haemoglobin|.unit=='gm/dl'",
+          "$gt0062|Haemoglobin|!=null"
+        ],
+        "then": [
+          "$gt0052|Haemoglobin score|=3|local::at0016|<11|"
+        ]
+      },
+      "gt0075": {
+        "id": "gt0075",
+        "priority": 17,
+        "when": [
+          "$gt0062|Haemoglobin|.magnitude>=9",
+          "$gt0062|Haemoglobin|.magnitude<10",
+          "$gt0062|Haemoglobin|.unit=='gm/dl'",
+          "$gt0062|Haemoglobin|!=null"
+        ],
+        "then": [
+          "$gt0052|Haemoglobin score|=4|local::at0017|<10|"
+        ]
+      },
+      "gt0076": {
+        "id": "gt0076",
+        "priority": 16,
+        "when": [
+          "$gt0062|Haemoglobin|.magnitude<9",
+          "$gt0062|Haemoglobin|.magnitude>=7",
+          "$gt0062|Haemoglobin|.unit=='gm/dl'",
+          "$gt0062|Haemoglobin|!=null"
+        ],
+        "then": [
+          "$gt0052|Haemoglobin score|=6|local::at0018|<9|"
+        ]
+      },
+      "gt0077": {
+        "id": "gt0077",
+        "priority": 15,
+        "when": [
+          "$gt0062|Haemoglobin|.magnitude<7",
+          "$gt0062|Haemoglobin|.unit=='gm/dl'",
+          "$gt0062|Haemoglobin|!=null"
+        ],
+        "then": [
+          "$gt0052|Haemoglobin score|=8|local::at0019|<7|"
+        ]
+      },
+      "gt0082": {
+        "id": "gt0082",
+        "priority": 14,
+        "when": [
+          "$gt0066|Systolic|.magnitude>=120",
+          "$gt0066|Systolic|.unit=='mm[Hg]'",
+          "$gt0066|Systolic|!=null"
+        ],
+        "then": [
+          "$gt0054|Sys BP score|=0|local::at0025|>= 120|"
+        ]
+      },
+      "gt0083": {
+        "id": "gt0083",
+        "priority": 13,
+        "when": [
+          "$gt0066|Systolic|.magnitude>=100",
+          "$gt0066|Systolic|.magnitude<120",
+          "$gt0066|Systolic|.unit=='mm[Hg]'",
+          "$gt0066|Systolic|!=null"
+        ],
+        "then": [
+          "$gt0054|Sys BP score|=1|local::at0026|<120|"
+        ]
+      },
+      "gt0084": {
+        "id": "gt0084",
+        "priority": 12,
+        "when": [
+          "$gt0066|Systolic|.magnitude<100",
+          "$gt0066|Systolic|.unit=='mm[Hg]'",
+          "$gt0066|Systolic|!=null"
+        ],
+        "then": [
+          "$gt0054|Sys BP score|=4|local::at0027|<100|"
+        ]
+      },
+      "gt0085": {
+        "id": "gt0085",
+        "priority": 11,
+        "when": [
+          "$gt0068|Heart Rate|.magnitude<=120",
+          "$gt0068|Heart Rate|.unit=='/min'",
+          "$gt0068|Heart Rate|!=null"
+        ],
+        "then": [
+          "$gt0055|Heart Rate score|=0|local::at0028|<= 120|"
+        ]
+      },
+      "gt0086": {
+        "id": "gt0086",
+        "priority": 10,
+        "when": [
+          "$gt0068|Heart Rate|.magnitude>120",
+          "$gt0068|Heart Rate|.unit=='/min'",
+          "$gt0068|Heart Rate|!=null"
+        ],
+        "then": [
+          "$gt0055|Heart Rate score|=2|local::at0029|>120|"
+        ]
+      },
+      "gt0087": {
+        "id": "gt0087",
+        "priority": 9,
+        "when": [
+          "$gt0048|Positive FAST for intra-abdo fluid|!=null"
+        ],
+        "then": [
+          "$gt0056|Positive FAST for intra-abdo fluid|=$gt0048|Positive FAST for intra-abdo fluid|"
+        ]
+      },
+      "gt0088": {
+        "id": "gt0088",
+        "priority": 8,
+        "when": [
+          "$gt0049|Fracture of trunk/leg|!=null"
+        ],
+        "then": [
+          "$gt0057|Fracture of trunk/leg|=$gt0049|Fracture of trunk/leg|"
+        ]
+      },
+      "gt0091": {
+        "id": "gt0091",
+        "priority": 7,
+        "when": [
+          "$gt0064|Base excess|!=null"
+        ],
+        "then": [
+          "$gt0058|Total score|.magnitude=0-$gt0064.magnitude"
+        ]
+      },
+      "gt0078": {
+        "id": "gt0078",
+        "priority": 6,
+        "when": [
+          "$gt0064|Base excess|.unit=='mmol/l'",
+          "$gt0064|Base excess|!=null",
+          "$gt0058|Total score|.magnitude<=2"
+        ],
+        "then": [
+          "$gt0053|Base Excess score|=0|local::at0021|>= -2|"
+        ]
+      },
+      "gt0079": {
+        "id": "gt0079",
+        "priority": 5,
+        "when": [
+          "$gt0064|Base excess|.unit=='mmol/l'",
+          "$gt0064|Base excess|!=null",
+          "$gt0058|Total score|.magnitude>2",
+          "$gt0058|Total score|.magnitude<=6"
+        ],
+        "then": [
+          "$gt0053|Base Excess score|=1|local::at0022|<-2|"
+        ]
+      },
+      "gt0080": {
+        "id": "gt0080",
+        "priority": 4,
+        "when": [
+          "$gt0064|Base excess|.unit=='mmol/l'",
+          "$gt0064|Base excess|!=null",
+          "$gt0058|Total score|.magnitude>6",
+          "$gt0058|Total score|.magnitude<=10"
+        ],
+        "then": [
+          "$gt0053|Base Excess score|=3|local::at0023|<-6|"
+        ]
+      },
+      "gt0081": {
+        "id": "gt0081",
+        "priority": 3,
+        "when": [
+          "$gt0064|Base excess|.unit=='mmol/l'",
+          "$gt0064|Base excess|!=null",
+          "$gt0058|Total score|.magnitude>10"
+        ],
+        "then": [
+          "$gt0053|Base Excess score|=4|local::at0024|<-10|"
+        ]
+      },
+      "gt0098": {
+        "id": "gt0098",
+        "priority": 1,
+        "then": [
+          "$gt0058|Total score|.magnitude=((((($gt0051.value+$gt0052.value)+$gt0053.value)+$gt0054.value)+$gt0055.value)+$gt0056.value)+$gt0057.value"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "sv": {
+        "id": "sv",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "TASH",
+            "description": "Trauma Associated Severe Hemorrhage (TASH) används som stöd för hantering av svår blödning och för bedömning av behov av massiv transfusion hos traumapatienter. Maximal poäng uppgår till 28p och ju högre poäng, desto högre sannolikhet för behov av massiv transfusion. En poäng om ≥16p indikerar >50% risk för behov av massiv transfusion."
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "Kön",
+            "description": "*(en) *"
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Hemoglobin",
+            "description": "*(en) The mass concentration of haemoglobin"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Base excess",
+            "description": "*(en) The relative excess of alkaline."
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Systoliskt blodtryck",
+            "description": "*(en) Peak systemic arterial blood pressure  - measured in systolic or contraction phase of the heart cycle."
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Hjärtfrekvens",
+            "description": "*(en) The rate, measured in beats per minute."
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "Positiv FAST",
+            "description": "*(en) FAST (Focused assessment with sonography for trauma) - ultrasound to detect free fluid in the abdomen"
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "Fraktur",
+            "description": "*(en) Fracture of the trunk/legs"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": ""
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "text": "Kön poäng",
+            "description": "*(en) Male or Female"
+          },
+          "gt0018": {
+            "id": "gt0018",
+            "text": "Hb poäng",
+            "description": "*(en) Haemoglobin score"
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "text": "BE poäng",
+            "description": "*(en) Base Excess"
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "Sys blodtryck poäng",
+            "description": "*(en) Systolic Blood Pressure"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "text": "Hjärtfrekvens poäng",
+            "description": "*(en) *"
+          },
+          "gt0022": {
+            "id": "gt0022",
+            "text": "Positiv FAST",
+            "description": "*(en) FAST (Focused assessment with sonography for trauma) - ultrasound to detect free fluid in the abdomen"
+          },
+          "gt0023": {
+            "id": "gt0023",
+            "text": "Fraktur",
+            "description": "*(en) Fracture of the trunk/legs"
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "text": "Total poäng",
+            "description": "*(en) Sum of individual scores"
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "text": "Standard"
+          },
+          "gt0026": {
+            "id": "gt0026",
+            "text": "CDS kön - man"
+          },
+          "gt0027": {
+            "id": "gt0027",
+            "text": "CDS kön - kvinna"
+          },
+          "gt0028": {
+            "id": "gt0028",
+            "text": "Hb: <7"
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "text": "Hb: <9"
+          },
+          "gt0030": {
+            "id": "gt0030",
+            "text": "Hb: <10"
+          },
+          "gt0031": {
+            "id": "gt0031",
+            "text": "Hb: <11"
+          },
+          "gt0032": {
+            "id": "gt0032",
+            "text": "Hb: <12"
+          },
+          "gt0033": {
+            "id": "gt0033",
+            "text": "Hb: >= 12"
+          },
+          "gt0034": {
+            "id": "gt0034",
+            "text": "BE < -10"
+          },
+          "gt0035": {
+            "id": "gt0035",
+            "text": "BE < -6"
+          },
+          "gt0036": {
+            "id": "gt0036",
+            "text": "BE: <-2"
+          },
+          "gt0037": {
+            "id": "gt0037",
+            "text": "BE: >= -2"
+          },
+          "gt0038": {
+            "id": "gt0038",
+            "text": "Systoliskt blodtryck <100"
+          },
+          "gt0039": {
+            "id": "gt0039",
+            "text": "Systoliskt blodtryck <120"
+          },
+          "gt0040": {
+            "id": "gt0040",
+            "text": "Systoliskt blodtryck >= 120"
+          },
+          "gt0041": {
+            "id": "gt0041",
+            "text": "Hjärtfrekvens >120"
+          },
+          "gt0042": {
+            "id": "gt0042",
+            "text": "Hjärtfrekvens <= 120"
+          },
+          "gt0043": {
+            "id": "gt0043",
+            "text": "Positiv FAST"
+          },
+          "gt0044": {
+            "id": "gt0044",
+            "text": "Fraktur"
+          },
+          "gt0045": {
+            "id": "gt0045",
+            "text": "Öppen eller dislocerad femurfraktur"
+          },
+          "gt0046": {
+            "id": "gt0046",
+            "text": "Total poäng"
+          },
+          "gt0048": {
+            "id": "gt0048",
+            "text": "Positiv FAST",
+            "description": "*(en) FAST (Focused assessment with sonography for trauma) - ultrasound to detect free fluid in the abdomen"
+          },
+          "gt0049": {
+            "id": "gt0049",
+            "text": "Fraktur",
+            "description": "*(en) Fracture of the trunk/legs"
+          },
+          "gt0051": {
+            "id": "gt0051",
+            "text": "Kön poäng",
+            "description": "*(en) Male or Female"
+          },
+          "gt0052": {
+            "id": "gt0052",
+            "text": "Hb poäng",
+            "description": "*(en) Haemoglobin score"
+          },
+          "gt0053": {
+            "id": "gt0053",
+            "text": "BE poäng",
+            "description": "*(en) Base Excess"
+          },
+          "gt0054": {
+            "id": "gt0054",
+            "text": "Systoliskt blodtryck poäng",
+            "description": "*(en) Systolic Blood Pressure"
+          },
+          "gt0055": {
+            "id": "gt0055",
+            "text": "Hjärtfrekvens poäng",
+            "description": "*(en) *"
+          },
+          "gt0056": {
+            "id": "gt0056",
+            "text": "Positiv FAST",
+            "description": "*(en) FAST (Focused assessment with sonography for trauma) - ultrasound to detect free fluid in the abdomen"
+          },
+          "gt0057": {
+            "id": "gt0057",
+            "text": "Fraktur",
+            "description": "*(en) Fracture of the trunk/legs"
+          },
+          "gt0058": {
+            "id": "gt0058",
+            "text": "Total poäng",
+            "description": "*(en) Sum of individual scores"
+          },
+          "gt0060": {
+            "id": "gt0060",
+            "text": "Kön",
+            "description": "*(en) *"
+          },
+          "gt0062": {
+            "id": "gt0062",
+            "text": "Hemoglobin",
+            "description": "*(en) The mass concentration of haemoglobin"
+          },
+          "gt0064": {
+            "id": "gt0064",
+            "text": "Base excess",
+            "description": "*(en) The relative excess of alkaline."
+          },
+          "gt0066": {
+            "id": "gt0066",
+            "text": "Systoliskt blodtryck",
+            "description": "*(en) Peak systemic arterial blood pressure  - measured in systolic or contraction phase of the heart cycle."
+          },
+          "gt0068": {
+            "id": "gt0068",
+            "text": "Hjärtfrekvens",
+            "description": "*(en) The rate, measured in beats per minute."
+          },
+          "gt0069": {
+            "id": "gt0069",
+            "text": "Standard"
+          },
+          "gt0070": {
+            "id": "gt0070",
+            "text": "CDS kön - kvinna"
+          },
+          "gt0071": {
+            "id": "gt0071",
+            "text": "CDS kön - man"
+          },
+          "gt0072": {
+            "id": "gt0072",
+            "text": "CDS Hb: >=12"
+          },
+          "gt0073": {
+            "id": "gt0073",
+            "text": "CDS Hb: <12"
+          },
+          "gt0074": {
+            "id": "gt0074",
+            "text": "CDS Hb: <11"
+          },
+          "gt0075": {
+            "id": "gt0075",
+            "text": "CDS Hb: <10"
+          },
+          "gt0076": {
+            "id": "gt0076",
+            "text": "CDS Hb: <9"
+          },
+          "gt0077": {
+            "id": "gt0077",
+            "text": "CDS Hb: <7"
+          },
+          "gt0078": {
+            "id": "gt0078",
+            "text": "CDS BE: >= -2"
+          },
+          "gt0079": {
+            "id": "gt0079",
+            "text": "CDS BE: < -2"
+          },
+          "gt0080": {
+            "id": "gt0080",
+            "text": "CDS BE: < -6"
+          },
+          "gt0081": {
+            "id": "gt0081",
+            "text": "CDS BE:<-10"
+          },
+          "gt0082": {
+            "id": "gt0082",
+            "text": "CDS systoliskt blodtryck: >=120"
+          },
+          "gt0083": {
+            "id": "gt0083",
+            "text": "CDS systoliskt blodtryck: <120"
+          },
+          "gt0084": {
+            "id": "gt0084",
+            "text": "CDS systoliskt blodtryck: <100"
+          },
+          "gt0085": {
+            "id": "gt0085",
+            "text": "CDS hjärtfrekvens: <= 120"
+          },
+          "gt0086": {
+            "id": "gt0086",
+            "text": "CDS hjärtfrekvens: >120"
+          },
+          "gt0087": {
+            "id": "gt0087",
+            "text": "CDS FAST"
+          },
+          "gt0088": {
+            "id": "gt0088",
+            "text": "CDS fraktur"
+          },
+          "gt0089": {
+            "id": "gt0089",
+            "text": "Total poäng"
+          },
+          "gt0091": {
+            "id": "gt0091",
+            "text": "*(en) Set nBE",
+            "description": ""
+          },
+          "gt0092": {
+            "id": "gt0092",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0093": {
+            "id": "gt0093",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0094": {
+            "id": "gt0094",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0095": {
+            "id": "gt0095",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0096": {
+            "id": "gt0096",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0097": {
+            "id": "gt0097",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0098": {
+            "id": "gt0098",
+            "text": "*(en) Total score",
+            "description": ""
+          }
+        }
+      },
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Trauma Associated Severe Hemorrhage",
+            "description": "Trauma Associated Severe Hemorrhage (TASH) score is used in the management of severe haemorrhage and to predict the risk of needing to provide a massive transfusion for a trauma patient"
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "Gender",
+            "description": "*"
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Haemoglobin",
+            "description": "The mass concentration of haemoglobin"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Base excess",
+            "description": "The relative excess of alkaline."
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Systolic",
+            "description": "Peak systemic arterial blood pressure  - measured in systolic or contraction phase of the heart cycle."
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Heart Rate",
+            "description": "The rate, measured in beats per minute."
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "Positive FAST for intra-abdo fluid",
+            "description": "FAST (Focused assessment with sonography for trauma) - ultrasound to detect free fluid in the abdomen"
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "Fracture of trunk/leg",
+            "description": "Fracture of the trunk/legs"
+          },
+          "gt0015": {
+            "id": "gt0015"
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "text": "Gender score",
+            "description": "Male or Female"
+          },
+          "gt0018": {
+            "id": "gt0018",
+            "text": "Hb score",
+            "description": "Haemoglobin score"
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "text": "BE score",
+            "description": "Base Excess"
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "Sys BP score",
+            "description": "Systolic Blood Pressure"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "text": "HR score",
+            "description": "*"
+          },
+          "gt0022": {
+            "id": "gt0022",
+            "text": "Positive FAST for intra-abdo fluid",
+            "description": "FAST (Focused assessment with sonography for trauma) - ultrasound to detect free fluid in the abdomen"
+          },
+          "gt0023": {
+            "id": "gt0023",
+            "text": "Fracture of trunk/leg",
+            "description": "Fracture of the trunk/legs"
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "text": "Total score",
+            "description": "Sum of individual scores"
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "text": "Default"
+          },
+          "gt0026": {
+            "id": "gt0026",
+            "text": "Set gender: male"
+          },
+          "gt0027": {
+            "id": "gt0027",
+            "text": "Set gender: female"
+          },
+          "gt0028": {
+            "id": "gt0028",
+            "text": "Hb: <7"
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "text": "Hb: <9"
+          },
+          "gt0030": {
+            "id": "gt0030",
+            "text": "Hb: <10"
+          },
+          "gt0031": {
+            "id": "gt0031",
+            "text": "Hb: <11"
+          },
+          "gt0032": {
+            "id": "gt0032",
+            "text": "Hb: <12"
+          },
+          "gt0033": {
+            "id": "gt0033",
+            "text": "Hb: >= 12"
+          },
+          "gt0034": {
+            "id": "gt0034",
+            "text": "BE < -10"
+          },
+          "gt0035": {
+            "id": "gt0035",
+            "text": "BE < -6"
+          },
+          "gt0036": {
+            "id": "gt0036",
+            "text": "BE: <-2"
+          },
+          "gt0037": {
+            "id": "gt0037",
+            "text": "BE: >= -2"
+          },
+          "gt0038": {
+            "id": "gt0038",
+            "text": "SBP: <100"
+          },
+          "gt0039": {
+            "id": "gt0039",
+            "text": "SBP: <120"
+          },
+          "gt0040": {
+            "id": "gt0040",
+            "text": "SBP: >= 120"
+          },
+          "gt0041": {
+            "id": "gt0041",
+            "text": "HR: >120"
+          },
+          "gt0042": {
+            "id": "gt0042",
+            "text": "HR: <= 120"
+          },
+          "gt0043": {
+            "id": "gt0043",
+            "text": "Positive FAST"
+          },
+          "gt0044": {
+            "id": "gt0044",
+            "text": "Trunk/leg fracture"
+          },
+          "gt0045": {
+            "id": "gt0045",
+            "text": "Open/dislocated Femur Fracture"
+          },
+          "gt0046": {
+            "id": "gt0046",
+            "text": "Total score"
+          },
+          "gt0048": {
+            "id": "gt0048",
+            "text": "Positive FAST for intra-abdo fluid",
+            "description": "FAST (Focused assessment with sonography for trauma) - ultrasound to detect free fluid in the abdomen"
+          },
+          "gt0049": {
+            "id": "gt0049",
+            "text": "Fracture of trunk/leg",
+            "description": "Fracture of the trunk/legs"
+          },
+          "gt0051": {
+            "id": "gt0051",
+            "text": "Gender score",
+            "description": "Male or Female"
+          },
+          "gt0052": {
+            "id": "gt0052",
+            "text": "Haemoglobin score",
+            "description": "Haemoglobin score"
+          },
+          "gt0053": {
+            "id": "gt0053",
+            "text": "Base Excess score",
+            "description": "Base Excess"
+          },
+          "gt0054": {
+            "id": "gt0054",
+            "text": "Sys BP score",
+            "description": "Systolic Blood Pressure"
+          },
+          "gt0055": {
+            "id": "gt0055",
+            "text": "Heart Rate score",
+            "description": "*"
+          },
+          "gt0056": {
+            "id": "gt0056",
+            "text": "Positive FAST for intra-abdo fluid",
+            "description": "FAST (Focused assessment with sonography for trauma) - ultrasound to detect free fluid in the abdomen"
+          },
+          "gt0057": {
+            "id": "gt0057",
+            "text": "Fracture of trunk/leg",
+            "description": "Fracture of the trunk/legs"
+          },
+          "gt0058": {
+            "id": "gt0058",
+            "text": "Total score",
+            "description": "Sum of individual scores"
+          },
+          "gt0060": {
+            "id": "gt0060",
+            "text": "Gender",
+            "description": "*"
+          },
+          "gt0062": {
+            "id": "gt0062",
+            "text": "Haemoglobin",
+            "description": "The mass concentration of haemoglobin"
+          },
+          "gt0064": {
+            "id": "gt0064",
+            "text": "Base excess",
+            "description": "The relative excess of alkaline."
+          },
+          "gt0066": {
+            "id": "gt0066",
+            "text": "Systolic",
+            "description": "Peak systemic arterial blood pressure  - measured in systolic or contraction phase of the heart cycle."
+          },
+          "gt0068": {
+            "id": "gt0068",
+            "text": "Heart Rate",
+            "description": "The rate, measured in beats per minute."
+          },
+          "gt0069": {
+            "id": "gt0069",
+            "text": "Default"
+          },
+          "gt0070": {
+            "id": "gt0070",
+            "text": "Set Gender score: F"
+          },
+          "gt0071": {
+            "id": "gt0071",
+            "text": "Set gender score: M"
+          },
+          "gt0072": {
+            "id": "gt0072",
+            "text": "Set Hb: >=12"
+          },
+          "gt0073": {
+            "id": "gt0073",
+            "text": "Set Hb: <12"
+          },
+          "gt0074": {
+            "id": "gt0074",
+            "text": "Set Hb: <11"
+          },
+          "gt0075": {
+            "id": "gt0075",
+            "text": "Set Hb: <10"
+          },
+          "gt0076": {
+            "id": "gt0076",
+            "text": "Set Hb: <9"
+          },
+          "gt0077": {
+            "id": "gt0077",
+            "text": "Set Hb: <7"
+          },
+          "gt0078": {
+            "id": "gt0078",
+            "text": "Set BE: >= -2"
+          },
+          "gt0079": {
+            "id": "gt0079",
+            "text": "Set BE: < -2"
+          },
+          "gt0080": {
+            "id": "gt0080",
+            "text": "Set BE: < -6"
+          },
+          "gt0081": {
+            "id": "gt0081",
+            "text": "Set BE:<-10"
+          },
+          "gt0082": {
+            "id": "gt0082",
+            "text": "Set SBP: >=120"
+          },
+          "gt0083": {
+            "id": "gt0083",
+            "text": "Set SBP: <120"
+          },
+          "gt0084": {
+            "id": "gt0084",
+            "text": "Set SBP: <100"
+          },
+          "gt0085": {
+            "id": "gt0085",
+            "text": "Set HR: <= 120"
+          },
+          "gt0086": {
+            "id": "gt0086",
+            "text": "Set HR: >120"
+          },
+          "gt0087": {
+            "id": "gt0087",
+            "text": "Set FAST"
+          },
+          "gt0088": {
+            "id": "gt0088",
+            "text": "Set Fracture"
+          },
+          "gt0089": {
+            "id": "gt0089",
+            "text": "Total score"
+          },
+          "gt0091": {
+            "id": "gt0091",
+            "text": "Set nBE"
+          },
+          "gt0092": {
+            "id": "gt0092",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0093": {
+            "id": "gt0093",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0094": {
+            "id": "gt0094",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0095": {
+            "id": "gt0095",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0096": {
+            "id": "gt0096",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0097": {
+            "id": "gt0097",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0098": {
+            "id": "gt0098",
+            "text": "Total score"
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/TASH.v1.test.yml
+++ b/gdl2/TASH.v1.test.yml
@@ -1,0 +1,251 @@
+guidelines:
+  1: TASH.v1
+test_cases:
+- id: Score 0
+  input:
+    1:
+      gt0048|Positive FAST for intra-abdo fluid: 0|local::at0030|No|
+      gt0049|Fracture of trunk/leg: 0|local::at0032|No|
+      gt0092|Event time: 2019-06-26T18:20Z
+      gt0060|Gender: local::at0006|Female|
+      gt0093|Event time: 2019-06-26T18:20Z
+      gt0062|Haemoglobin: 13,gm/dl
+      gt0094|Event time: 2019-06-24T18:20Z
+      gt0064|Base excess: 1,mmol/l
+      gt0095|Event time: 2019-06-25T18:20Z
+      gt0066|Systolic: 122,mm[Hg]
+      gt0096|Event time: 2019-06-26T18:20Z
+      gt0068|Heart Rate: 78,/min
+      gt0097|Event time: 2019-06-26T18:20Z
+  expected_output:
+    1:
+      gt0051|Gender score: 0|local::at0012|Female|
+      gt0053|Base Excess score: 0|local::at0021|>= -2|
+      gt0054|Sys BP score: 0|local::at0025|>= 120|
+      gt0058|Total score: 0
+      gt0052|Haemoglobin score: 0|local::at0014|>= 12|
+      gt0056|Positive FAST for intra-abdo fluid: 0|local::at0030|No|
+      gt0057|Fracture of trunk/leg: 0|local::at0032|No|
+      gt0055|Heart Rate score: 0|local::at0028|<= 120|
+
+
+- id: All worse, HB 11, 100<BP<120
+  input:
+    1:
+      gt0048|Positive FAST for intra-abdo fluid: 3|local::at0031|Yes|
+      gt0049|Fracture of trunk/leg: 3|local::at0038|Open or Dislocated Femur fracture|
+      gt0092|Event time: 2019-06-26T18:20Z
+      gt0060|Gender: local::at0005|Male|
+      gt0093|Event time: 2019-06-26T18:20Z
+      gt0062|Haemoglobin: 11,gm/dl
+      gt0094|Event time: 2019-06-24T18:20Z
+      gt0064|Base excess: 1,mmol/l
+      gt0095|Event time: 2019-06-25T18:20Z
+      gt0066|Systolic: 112,mm[Hg]
+      gt0096|Event time: 2019-06-26T18:20Z
+      gt0068|Heart Rate: 121,/min
+      gt0097|Event time: 2019-06-26T18:20Z
+  expected_output:
+    1:
+      gt0051|Gender score: 1|local::at0013|Male|
+      gt0053|Base Excess score: 0|local::at0021|>= -2|
+      gt0054|Sys BP score: 1|local::at0026|<120|
+      gt0058|Total score: 12
+      gt0052|Haemoglobin score: 2|local::at0015|<12|
+      gt0056|Positive FAST for intra-abdo fluid: 3|local::at0031|Yes|
+      gt0057|Fracture of trunk/leg: 3|local::at0038|Open or Dislocated Femur fracture|
+      gt0055|Heart Rate score: 2|local::at0029|>120|
+
+
+- id: HB 10, BP<100
+  input:
+    1:
+      gt0048|Positive FAST for intra-abdo fluid: 3|local::at0031|Yes|
+      gt0049|Fracture of trunk/leg: 3|local::at0038|Open or Dislocated Femur fracture|
+      gt0092|Event time: 2019-06-26T18:20Z
+      gt0060|Gender: local::at0005|Male|
+      gt0093|Event time: 2019-06-26T18:20Z
+      gt0062|Haemoglobin: 10,gm/dl
+      gt0094|Event time: 2019-06-24T18:20Z
+      gt0064|Base excess: 1,mmol/l
+      gt0095|Event time: 2019-06-25T18:20Z
+      gt0066|Systolic: 92,mm[Hg]
+      gt0096|Event time: 2019-06-26T18:20Z
+      gt0068|Heart Rate: 121,/min
+      gt0097|Event time: 2019-06-26T18:20Z
+  expected_output:
+    1:
+      gt0051|Gender score: 1|local::at0013|Male|
+      gt0053|Base Excess score: 0|local::at0021|>= -2|
+      gt0054|Sys BP score: 4|local::at0027|<100|
+      gt0058|Total score: 16
+      gt0052|Haemoglobin score: 3|local::at0016|<11|
+      gt0056|Positive FAST for intra-abdo fluid: 3|local::at0031|Yes|
+      gt0057|Fracture of trunk/leg: 3|local::at0038|Open or Dislocated Femur fracture|
+      gt0055|Heart Rate score: 2|local::at0029|>120|
+
+- id: HB 9
+  input:
+    1:
+      gt0048|Positive FAST for intra-abdo fluid: 3|local::at0031|Yes|
+      gt0049|Fracture of trunk/leg: 3|local::at0038|Open or Dislocated Femur fracture|
+      gt0092|Event time: 2019-06-26T18:20Z
+      gt0060|Gender: local::at0005|Male|
+      gt0093|Event time: 2019-06-26T18:20Z
+      gt0062|Haemoglobin: 9,gm/dl
+      gt0094|Event time: 2019-06-24T18:20Z
+      gt0064|Base excess: 1,mmol/l
+      gt0095|Event time: 2019-06-25T18:20Z
+      gt0066|Systolic: 92,mm[Hg]
+      gt0096|Event time: 2019-06-26T18:20Z
+      gt0068|Heart Rate: 121,/min
+      gt0097|Event time: 2019-06-26T18:20Z
+  expected_output:
+    1:
+      gt0051|Gender score: 1|local::at0013|Male|
+      gt0053|Base Excess score: 0|local::at0021|>= -2|
+      gt0054|Sys BP score: 4|local::at0027|<100|
+      gt0058|Total score: 17
+      gt0052|Haemoglobin score: 4|local::at0017|<10|
+      gt0056|Positive FAST for intra-abdo fluid: 3|local::at0031|Yes|
+      gt0057|Fracture of trunk/leg: 3|local::at0038|Open or Dislocated Femur fracture|
+      gt0055|Heart Rate score: 2|local::at0029|>120|
+
+- id: HB 8
+  input:
+    1:
+      gt0048|Positive FAST for intra-abdo fluid: 3|local::at0031|Yes|
+      gt0049|Fracture of trunk/leg: 3|local::at0038|Open or Dislocated Femur fracture|
+      gt0092|Event time: 2019-06-26T18:20Z
+      gt0060|Gender: local::at0005|Male|
+      gt0093|Event time: 2019-06-26T18:20Z
+      gt0062|Haemoglobin: 8,gm/dl
+      gt0094|Event time: 2019-06-24T18:20Z
+      gt0064|Base excess: 1,mmol/l
+      gt0095|Event time: 2019-06-25T18:20Z
+      gt0066|Systolic: 92,mm[Hg]
+      gt0096|Event time: 2019-06-26T18:20Z
+      gt0068|Heart Rate: 121,/min
+      gt0097|Event time: 2019-06-26T18:20Z
+  expected_output:
+    1:
+      gt0051|Gender score: 1|local::at0013|Male|
+      gt0053|Base Excess score: 0|local::at0021|>= -2|
+      gt0054|Sys BP score: 4|local::at0027|<100|
+      gt0058|Total score: 19
+      gt0052|Haemoglobin score: 6|local::at0018|<9|
+      gt0056|Positive FAST for intra-abdo fluid: 3|local::at0031|Yes|
+      gt0057|Fracture of trunk/leg: 3|local::at0038|Open or Dislocated Femur fracture|
+      gt0055|Heart Rate score: 2|local::at0029|>120|
+
+
+- id: HB 6
+  input:
+    1:
+      gt0048|Positive FAST for intra-abdo fluid: 3|local::at0031|Yes|
+      gt0049|Fracture of trunk/leg: 3|local::at0038|Open or Dislocated Femur fracture|
+      gt0092|Event time: 2019-06-26T18:20Z
+      gt0060|Gender: local::at0005|Male|
+      gt0093|Event time: 2019-06-26T18:20Z
+      gt0062|Haemoglobin: 6,gm/dl
+      gt0094|Event time: 2019-06-24T18:20Z
+      gt0064|Base excess: 1,mmol/l
+      gt0095|Event time: 2019-06-25T18:20Z
+      gt0066|Systolic: 92,mm[Hg]
+      gt0096|Event time: 2019-06-26T18:20Z
+      gt0068|Heart Rate: 121,/min
+      gt0097|Event time: 2019-06-26T18:20Z
+  expected_output:
+    1:
+      gt0051|Gender score: 1|local::at0013|Male|
+      gt0053|Base Excess score: 0|local::at0021|>= -2|
+      gt0054|Sys BP score: 4|local::at0027|<100|
+      gt0058|Total score: 21
+      gt0052|Haemoglobin score: 8|local::at0019|<7|
+      gt0056|Positive FAST for intra-abdo fluid: 3|local::at0031|Yes|
+      gt0057|Fracture of trunk/leg: 3|local::at0038|Open or Dislocated Femur fracture|
+      gt0055|Heart Rate score: 2|local::at0029|>120|
+
+- id: Base excess -4 (works in execution tab, not here)
+  input:
+    1:
+      gt0048|Positive FAST for intra-abdo fluid: 3|local::at0031|Yes|
+      gt0049|Fracture of trunk/leg: 3|local::at0038|Open or Dislocated Femur fracture|
+      gt0092|Event time: 2019-06-26T18:20Z
+      gt0060|Gender: local::at0005|Male|
+      gt0093|Event time: 2019-06-26T18:20Z
+      gt0062|Haemoglobin: 6,gm/dl
+      gt0094|Event time: 2019-06-24T18:20Z
+      gt0064|Base excess: -4,mmol/l
+      gt0095|Event time: 2019-06-25T18:20Z
+      gt0066|Systolic: 92,mm[Hg]
+      gt0096|Event time: 2019-06-26T18:20Z
+      gt0068|Heart Rate: 121,/min
+      gt0097|Event time: 2019-06-26T18:20Z
+  expected_output:
+    1:
+      gt0051|Gender score: 1|local::at0013|Male|
+      gt0053|Base Excess score: 1|local::at0022|<-2|
+      gt0054|Sys BP score: 4|local::at0027|<100|
+      gt0058|Total score: 22
+      gt0052|Haemoglobin score: 8|local::at0019|<7|
+      gt0056|Positive FAST for intra-abdo fluid: 3|local::at0031|Yes|
+      gt0057|Fracture of trunk/leg: 3|local::at0038|Open or Dislocated Femur fracture|
+      gt0055|Heart Rate score: 2|local::at0029|>120|
+
+- id: Base excess -9 (works in execution tab, not here)
+  input:
+    1:
+      gt0048|Positive FAST for intra-abdo fluid: 3|local::at0031|Yes|
+      gt0049|Fracture of trunk/leg: 3|local::at0038|Open or Dislocated Femur fracture|
+      gt0092|Event time: 2019-06-26T18:20Z
+      gt0060|Gender: local::at0005|Male|
+      gt0093|Event time: 2019-06-26T18:20Z
+      gt0062|Haemoglobin: 6,gm/dl
+      gt0094|Event time: 2019-06-24T18:20Z
+      gt0064|Base excess: -9,mmol/l
+      gt0095|Event time: 2019-06-25T18:20Z
+      gt0066|Systolic: 92,mm[Hg]
+      gt0096|Event time: 2019-06-26T18:20Z
+      gt0068|Heart Rate: 121,/min
+      gt0097|Event time: 2019-06-26T18:20Z
+  expected_output:
+    1:
+      gt0051|Gender score: 1|local::at0013|Male|
+      gt0053|Base Excess score: 3|local::at0023|<-6|
+      gt0054|Sys BP score: 4|local::at0027|<100|
+      gt0058|Total score: 24
+      gt0052|Haemoglobin score: 8|local::at0019|<7|
+      gt0056|Positive FAST for intra-abdo fluid: 3|local::at0031|Yes|
+      gt0057|Fracture of trunk/leg: 3|local::at0038|Open or Dislocated Femur fracture|
+      gt0055|Heart Rate score: 2|local::at0029|>120|
+
+
+- id: Base excess -11 (works in execution tab, not here)
+  input:
+    1:
+      gt0048|Positive FAST for intra-abdo fluid: 3|local::at0031|Yes|
+      gt0049|Fracture of trunk/leg: 3|local::at0038|Open or Dislocated Femur fracture|
+      gt0092|Event time: 2019-06-26T18:20Z
+      gt0060|Gender: local::at0005|Male|
+      gt0093|Event time: 2019-06-26T18:20Z
+      gt0062|Haemoglobin: 6,gm/dl
+      gt0094|Event time: 2019-06-24T18:20Z
+      gt0064|Base excess: -11,mmol/l
+      gt0095|Event time: 2019-06-25T18:20Z
+      gt0066|Systolic: 92,mm[Hg]
+      gt0096|Event time: 2019-06-26T18:20Z
+      gt0068|Heart Rate: 121,/min
+      gt0097|Event time: 2019-06-26T18:20Z
+  expected_output:
+    1:
+      gt0051|Gender score: 1|local::at0013|Male|
+      gt0053|Base Excess score: 4|local::at0024|<-10|
+      gt0054|Sys BP score: 4|local::at0027|<100|
+      gt0058|Total score: 25
+      gt0052|Haemoglobin score: 8|local::at0019|<7|
+      gt0056|Positive FAST for intra-abdo fluid: 3|local::at0031|Yes|
+      gt0057|Fracture of trunk/leg: 3|local::at0038|Open or Dislocated Femur fracture|
+      gt0055|Heart Rate score: 2|local::at0029|>120|
+
+

--- a/gdl2/TASH_Assessment.v1.gdl2.json
+++ b/gdl2/TASH_Assessment.v1.gdl2.json
@@ -1,0 +1,197 @@
+{
+  "id": "TASH_Assessment.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2017-03-02",
+      "name": "Syeeda S Farruque",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "other_contributors": [
+      "Dennis Forslund",
+      "Jimmy Axelsson"
+    ],
+    "lifecycle_state": "Author draft",
+    "details": {
+      "sv": {
+        "id": "sv",
+        "purpose": "Att utvärdera poäng genererad i enlighet med Trauma Associated Severe Hemorrhage (TASH), som används som stöd för hantering av svår blödning och för bedömning av behov av massiv transfusion hos traumapatienter.",
+        "keywords": [
+          "massiv transfusion",
+          "TASH",
+          "Trauma Associated Severe Hemorrhage"
+        ],
+        "use": "Använd för att utvärdera poäng genererad i enlighet med Trauma Associated Severe Hemorrhage (TASH), som används som stöd för hantering av svår blödning och för bedömning av behov av massiv transfusion hos traumapatienter.\r\n\r\nTASH baseras på sju viktade parametrar:\r\n\r\nSystoliskt blodtryck\r\nHb-värde\r\nFAST (positiv)\r\nSvår fraktur och/eller bäckeninstabilitet\r\nHjärtfrekvens\r\nBase excess\r\nKön\r\n\r\nMaximal poäng uppgår till 28p och ju högre poäng, desto högre sannolikhet för behov av massiv transfusion. En poäng om ≥16p indikerar >50% risk, medan ≥ 27p indikerar 100% risk för behov av massiv transfusion.",
+        "misuse": "Endast avsedd för bedömning av behov av massiv transfusion i enlighet med lokala protokoll.",
+        "copyright": "© Cambio Healthcare Systems"
+      },
+      "en": {
+        "id": "en",
+        "purpose": "Trauma Associated Severe Hemorrhage (TASH) score is made up with weighted variables and is used in the management of severe haemorrhage and to predict the risk of needing to provide a massive transfusion for a trauma patient",
+        "keywords": [
+          "massive transfusion",
+          "TASH",
+          "Trauma Associated Severe Hemorrhage"
+        ],
+        "use": "Increasing TASH-score points are associated with increasing probability of MT.\r\n\r\nA TASH score ≥ 16 points (i.e.) means a probability of MT >50% and a score ≥ 27 is equivalent to 100% probability of MT",
+        "misuse": "TASH Score does not indicate if trauma patients should receive blood, only if they should receive blood through a massive transfusion protocol.",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Ref. 1: Yücel N, Lefering R, Maegele M, Vorweg M, Tjardes T, Ruchholtz S, Neugebauer EA, Wappler F, Bouillon B, Rixen D; Polytrauma Study Group of the German Trauma Society. Trauma Associated Severe Hemorrhage (TASH)-Score: probability of mass transfusion as surrogate for life threatening hemorrhage after multiple trauma. J Trauma. 2006 Jun;60(6):1228-36; discussion 1236-7. PubMed PMID: 16766965.\r\n\r\nRef. 2: Maegele M, Lefering R, Wafaisade A, Theodorou P, Wutzler S, Fischer P, Bouillon B, Paffrath T; Trauma Registry of Deutsche Gesellschaft für Unfallchirurgie (TR-DGU). Revalidation and update of the TASH-Score: a scoring system to predict the probability for massive transfusion as a surrogate for life-threatening haemorrhage after severe injury. Vox Sang. 2011 Feb;100(2):231-8. doi: 10.1111/j.1423-0410.2010.01387.x. Epub 2010 Aug 24. PubMed PMID: 20735809.\r\n"
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0002": {
+        "id": "gt0002",
+        "model_id": "openEHR-EHR-EVALUATION.trauma_associated_severe_hemorrhage_assessment.v1",
+        "template_id": "openEHR-EHR-EVALUATION.trauma_associated_severe_hemorrhage_assessment.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0007": {
+            "id": "gt0007",
+            "path": "/data[at0001]/items[at0002]"
+          }
+        }
+      },
+      "gt0003": {
+        "id": "gt0003",
+        "model_id": "openEHR-EHR-OBSERVATION.tash.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.tash.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0006": {
+            "id": "gt0006",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0036]"
+          }
+        }
+      }
+    },
+    "rules": {
+      "gt0009": {
+        "id": "gt0009",
+        "priority": 3,
+        "when": [
+          "$gt0006|Total score|<16"
+        ],
+        "then": [
+          "$gt0007|Probability of Massive Transfusion|=0|local::at0003|< 50% |"
+        ]
+      },
+      "gt0010": {
+        "id": "gt0010",
+        "priority": 2,
+        "when": [
+          "$gt0006|Total score|<=26",
+          "$gt0006|Total score|>=16"
+        ],
+        "then": [
+          "$gt0007|Probability of Massive Transfusion|=1|local::at0004|50-99%|"
+        ]
+      },
+      "gt0011": {
+        "id": "gt0011",
+        "priority": 1,
+        "when": [
+          "$gt0006|Total score|>=27"
+        ],
+        "then": [
+          "$gt0007|Probability of Massive Transfusion|=2|local::at0005|100%|"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "sv": {
+        "id": "sv",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Trauma associated severe hemorrhage utvärdering",
+            "description": "Utvärdering av poäng genererad i enlighet med Trauma Associated Severe Hemorrhage (TASH), som används som stöd för hantering av svår blödning och för bedömning av behov av massiv transfusion hos traumapatienter."
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Total poäng",
+            "description": "*(en) Sum of individual scores"
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Total poäng",
+            "description": "*(en) Sum of individual scores"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Risk för massiv transfusion",
+            "description": "*(en) Increasing TASH-score points are associated with increasing probability of MT."
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "CDS poäng"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "CDS risk för massiv transfusion: < 50%"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "CDS risk för massiv transfusion: 50-99%"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "CDS risk för massiv transfusion: 100%"
+          }
+        }
+      },
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "TASH Assessment",
+            "description": "Trauma Associated Severe Hemorrhage (TASH) score is used in the management of severe haemorrhage and to predict the risk of needing to provide a massive transfusion for a trauma patient"
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Total score",
+            "description": "Sum of individual scores"
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Total score",
+            "description": "Sum of individual scores"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Probability of Massive Transfusion",
+            "description": "Increasing TASH-score points are associated with increasing probability of MT."
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Set score"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Set Probability of MT: < 50%"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Set Probability of MT: 50-99%"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Set Probability of MT: 100%"
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/TASH_Assessment.v1.test.yml
+++ b/gdl2/TASH_Assessment.v1.test.yml
@@ -1,0 +1,24 @@
+guidelines:
+  1: TASH_Assessment.v1
+test_cases:
+- id: 14
+  input:
+    1:
+      gt0006|Total score: 14
+  expected_output:
+    1:
+      gt0007|Probability of Massive Transfusion: 0|local::at0003|< 50% |
+- id: 22
+  input:
+    1:
+      gt0006|Total score: 22
+  expected_output:
+    1:
+      gt0007|Probability of Massive Transfusion: 1|local::at0004|50-99%|
+- id: 30
+  input:
+    1:
+      gt0006|Total score: 30
+  expected_output:
+    1:
+      gt0007|Probability of Massive Transfusion: 2|local::at0005|100%|


### PR DESCRIPTION
A very difficult work because the editor cannot really handle negative values. Encountered this problem several times in this guideline: comparison, expressions, etc. Moreover, creating a local variable does not work either. Finally, I was able to create a workaround, a not too elegant one. After calculating all sub-scores, the base excess score is calculated by temporary storing the opposite of base excess in the total score (since it is not possible to store the value in a local variable). Then total score is calculated.
Other changes: event time, output -> input.

In the execution tab all test cases work correctly. In the test tab negative values can't be tested. All other features are tested in the attached test file, the last three cases are meant to test the base excess rules, these cases don't run. After fixing the bug, these should work in the test tab as well.