### PR TITLE
Has bled

### DIFF
--- a/gdl2/HAS-BLED.v1.gdl2.json
+++ b/gdl2/HAS-BLED.v1.gdl2.json
@@ -1,0 +1,1078 @@
+{
+  "id": "HAS-BLED.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2016-01-06",
+      "name": "Syeeda S Farruque",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "other_contributors": [
+      "Dennis Forslund",
+      "Jimmy Axelsson"
+    ],
+    "lifecycle_state": "Author draft",
+    "details": {
+      "sv": {
+        "id": "sv",
+        "purpose": "Att registrera resultat i enlighet med HAS-BLED och därigenom få stöd i bedömning av blödningsrisk hos patienter med behandlat förmaksflimmer.",
+        "keywords": [
+          "HAS-BLED",
+          "stroke",
+          "förmaksflimmer",
+          "antikoagulantia",
+          "blödning"
+        ],
+        "use": "Använd för registrering av resultat i enlighet med HAS-BLED och därigenom få stöd i bedömning av blödningsrisk hos patienter med behandlat (antikoagulantia) förmaksflimmer.\r\n\r\nInstrumentet baseras på nio faktorer:\r\n- Hypertoni: definieras i detta fall som systoliskt blodtryck >160 mmHg.\r\n- Njurpåverka: förekomst av kronisk dialys, njurtransplantation eller ett kreatininvärde om >200 umol/L.\r\n- Leverpåverkan: kronisk leversjukdom, bilirubin >2x övre referensvärde, ASAT/ALAT >3x övre referensvärde\r\n- Tidigare genomgången stroke\r\n- Tidigare blödning, anemi eller blödningsrisk\r\n- Riskvärde PK(INR): instabilt/högt värde, inom teurapeutiskt intervall <60% av tiden\r\n- Patienten är 65 år gammal eller äldre\r\n- Koagulationshämmande läkemedel: trombocythämmande läkemedel, NSAID\r\n- Bruk av alkohol: ≥ 8 glas alkohol per vecka\r\n",
+        "misuse": "Ej avsedd för att användas isolerat och är ej att betrakta som diagnostisk.\r\n",
+        "copyright": "© Cambio Healthcare Systems"
+      },
+      "en": {
+        "id": "en",
+        "purpose": "To record HAS-BLED bleeding risk score",
+        "keywords": [
+          "HAS-BLED",
+          "stroke",
+          "atrial fibrillation",
+          "anticoagulants",
+          "haemorrhage",
+          "bleeding"
+        ],
+        "use": "Hypertension is defined as systolic blood pressure >160 mmHg. Abnormal kidney function is defined as the presence of chronic dialysis or renal transplantation or serum creatinine 200 umol/L. Abnormal liver function is defined as chronic hepatic disease (e.g. cirrhosis) or biochemical evidence of significant hepatic derangement (e.g. bilirubin > 2 x upper limit of normal, in association with aspartate aminotransferase/alanine aminotransferase/alkaline phosphatase >3 x upper limit normal, etc.). Bleeding refers to previous bleeding history and/or predisposition to bleeding, e.g. bleeding diathesis, anaemia, etc. Labile INRs refers to unstable/high INRs or poor time in therapeutic range (e.g. <60%). Drugs/alcohol use refers to concomitant use of drugs, such as antiplatelet agents, non-steroidal anti-inflammatory drugs, or alcohol abuse, etc.\r\nINR (international normalized ratio). Adapted from Pisters et al.60\r\n\r\nIndividual scores are 0 for No or 1 for Yes with a maximum total score ranging between 0 and 9",
+        "misuse": "Not to be used alone for absolute diagnostic purposes",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Ref. 1: Pisters R, Lane DA, Nieuwlaat R, et al. A Novel User-Friendly Score (Has-Bled) To Assess 1-Year Risk Of Major Bleeding In Patients With Atrial Fibrillation: The Euro Heart Survey. Chest. 2010;138(5):1093-1100. \r\n\r\nRef. 2: Lip GY, Frison L, Halperin JL, Lane DA. Comparative validation of a novel risk score for predicting bleeding risk in anticoagulated patients with atrial fibrillation: the HAS-BLED (Hypertension, Abnormal Renal/Liver Function, Stroke, Bleeding History or Predisposition, Labile INR, Elderly, Drugs/Alcohol Concomitantly) score. J Am Coll Cardiol. 2011 Jan 11;57(2):173-80. doi: 10.1016/j.jacc.2010.09.024. Epub 2010 Nov 24."
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0002": {
+        "id": "gt0002",
+        "model_id": "openEHR-EHR-OBSERVATION.blood_pressure.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.blood_pressure.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0003": {
+            "id": "gt0003",
+            "path": "/data[at0001]/events[at0006]/data[at0003]/items[at0004]"
+          },
+          "gt0064": {
+            "id": "gt0064",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0004": {
+        "id": "gt0004",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test_creatinine.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test_creatinine.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0005": {
+            "id": "gt0005",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0005]"
+          },
+          "gt0065": {
+            "id": "gt0065",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0006": {
+        "id": "gt0006",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-bilirubin.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-bilirubin.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0007": {
+            "id": "gt0007",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0091]"
+          },
+          "gt0066": {
+            "id": "gt0066",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0008": {
+        "id": "gt0008",
+        "model_id": "openEHR-EHR-OBSERVATION.basic_demographic.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.basic_demographic.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0060": {
+            "id": "gt0060",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0008]"
+          },
+          "gt0067": {
+            "id": "gt0067",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0010": {
+        "id": "gt0010",
+        "model_id": "openEHR-EHR-OBSERVATION.alcohol_use.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.alcohol_use.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0011": {
+            "id": "gt0011",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0005]/items[at0015]/items[at0014]"
+          },
+          "gt0068": {
+            "id": "gt0068",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0012": {
+        "id": "gt0012",
+        "model_id": "openEHR-EHR-OBSERVATION.has_bled.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.has_bled.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0013": {
+            "id": "gt0013",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0004]"
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0005]"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0006]"
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0007]"
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0008]"
+          },
+          "gt0018": {
+            "id": "gt0018",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0009]"
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0011]"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0012]"
+          },
+          "gt0069": {
+            "id": "gt0069",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0022": {
+        "id": "gt0022",
+        "model_id": "openEHR-EHR-OBSERVATION.has_bled.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.has_bled.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0023": {
+            "id": "gt0023",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0004]"
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0005]"
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0006]"
+          },
+          "gt0026": {
+            "id": "gt0026",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0007]"
+          },
+          "gt0027": {
+            "id": "gt0027",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0008]"
+          },
+          "gt0028": {
+            "id": "gt0028",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0009]"
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0010]"
+          },
+          "gt0030": {
+            "id": "gt0030",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0011]"
+          },
+          "gt0031": {
+            "id": "gt0031",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0012]"
+          },
+          "gt0032": {
+            "id": "gt0032",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0013]"
+          }
+        }
+      },
+      "gt0040": {
+        "id": "gt0040",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-alt.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-alt.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0043": {
+            "id": "gt0043",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078]"
+          },
+          "gt0070": {
+            "id": "gt0070",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0041": {
+        "id": "gt0041",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-alp.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-alp.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0042": {
+            "id": "gt0042",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078]"
+          },
+          "gt0072": {
+            "id": "gt0072",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0047": {
+        "id": "gt0047",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-ast.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-ast.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0048": {
+            "id": "gt0048",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078]"
+          },
+          "gt0071": {
+            "id": "gt0071",
+            "path": "/data/events/time"
+          }
+        },
+        "predicates": [
+          "max(/data/events/time)"
+        ]
+      },
+      "gt0061": {
+        "id": "gt0061",
+        "model_id": "openEHR-EHR-OBSERVATION.basic_demographic.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.basic_demographic.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0062": {
+            "id": "gt0062",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0013]"
+          }
+        }
+      }
+    },
+    "rules": {
+      "gt0033": {
+        "id": "gt0033",
+        "priority": 18,
+        "when": [
+          "$gt0026|Stroke History|==null",
+          "$gt0027|Prior Major Bleeding or Predisposition to Bleeding|==null",
+          "$gt0028|Labile INR|==null",
+          "$gt0029|Age > 65|==null",
+          "$gt0030|Medication Usage Predisposing to Bleeding|==null",
+          "$gt0031|Alcohol or Drug Usage History|==null",
+          "$gt0023|Hypertension History|==null",
+          "$gt0024|Renal Disease|==null",
+          "$gt0025|Liver Disease|==null"
+        ],
+        "then": [
+          "$gt0023|Hypertension History|=0|local::at0014|No|",
+          "$gt0024|Renal Disease|=0|local::at0014|No|",
+          "$gt0025|Liver Disease|=0|local::at0014|No|",
+          "$gt0026|Stroke History|=0|local::at0014|No|",
+          "$gt0027|Prior Major Bleeding or Predisposition to Bleeding|=0|local::at0014|No|",
+          "$gt0028|Labile INR|=0|local::at0014|No|",
+          "$gt0029|Age > 65|=0|local::at0014|No|",
+          "$gt0030|Medication Usage Predisposing to Bleeding|=0|local::at0014|No|",
+          "$gt0031|Alcohol or Drug Usage History|=0|local::at0014|No|"
+        ]
+      },
+      "gt0034": {
+        "id": "gt0034",
+        "priority": 17,
+        "when": [
+          "($gt0003|Systolic|>160,mm[Hg])||($gt0013|Hypertension History|==1|local::at0015|Yes|)"
+        ],
+        "then": [
+          "$gt0023|Hypertension History|=1|local::at0015|Yes|"
+        ]
+      },
+      "gt0035": {
+        "id": "gt0035",
+        "priority": 16,
+        "when": [
+          "!fired($gt0034)",
+          "($gt0003|Systolic|<=160,mm[Hg])||($gt0013|Hypertension History|==0|local::at0014|No|)"
+        ],
+        "then": [
+          "$gt0023|Hypertension History|=0|local::at0014|No|"
+        ]
+      },
+      "gt0036": {
+        "id": "gt0036",
+        "priority": 15,
+        "when": [
+          "($gt0011|Standard Drinks|>=8,/wk)||($gt0021|Alcohol or Drug Usage History|==1|local::at0015|Yes|)"
+        ],
+        "then": [
+          "$gt0031|Alcohol or Drug Usage History|=1|local::at0015|Yes|"
+        ]
+      },
+      "gt0037": {
+        "id": "gt0037",
+        "priority": 14,
+        "when": [
+          "!fired($gt0036)",
+          "($gt0011|Standard Drinks|<8,/wk)||($gt0021|Alcohol or Drug Usage History|==0|local::at0014|No|)"
+        ],
+        "then": [
+          "$gt0031|Alcohol or Drug Usage History|=0|local::at0014|No|"
+        ]
+      },
+      "gt0049": {
+        "id": "gt0049",
+        "priority": 13,
+        "when": [
+          "((($gt0007|Total Bilirubin|>2.4,mg/dl)||($gt0043|ALT Result|>165,U/l))||(($gt0042|ALP Result|>345,U/l)||($gt0048|AST Result|>144,U/l)))||($gt0015|Liver Disease|==1|local::at0015|Yes|)"
+        ],
+        "then": [
+          "$gt0025|Liver Disease|=1|local::at0015|Yes|"
+        ]
+      },
+      "gt0038": {
+        "id": "gt0038",
+        "priority": 12,
+        "when": [
+          "((($gt0048|AST Result|<=144,U/l)||($gt0042|ALP Result|<=345,U/l))||(($gt0043|ALT Result|<=165,U/l)||($gt0007|Total Bilirubin|<=2.4,mg/dl)))||($gt0015|Liver Disease|==0|local::at0014|No|)"
+        ],
+        "then": [
+          "$gt0025|Liver Disease|=0|local::at0014|No|"
+        ]
+      },
+      "gt0051": {
+        "id": "gt0051",
+        "priority": 11,
+        "when": [
+          "($gt0005|CR Result mircomol/L|>200)||($gt0014|Renal Disease|==1|local::at0015|Yes|)"
+        ],
+        "then": [
+          "$gt0024|Renal Disease|=1|local::at0015|Yes|"
+        ]
+      },
+      "gt0050": {
+        "id": "gt0050",
+        "priority": 10,
+        "when": [
+          "($gt0005|CR Result mircomol/L|<=200)||($gt0014|Renal Disease|==0|local::at0014|No|)",
+          "!fired($gt0051)"
+        ],
+        "then": [
+          "$gt0024|Renal Disease|=0|local::at0014|No|"
+        ]
+      },
+      "gt0052": {
+        "id": "gt0052",
+        "priority": 9,
+        "when": [
+          "$gt0016|Stroke History|!=null"
+        ],
+        "then": [
+          "$gt0026|Stroke History|=$gt0016|Stroke History|"
+        ]
+      },
+      "gt0053": {
+        "id": "gt0053",
+        "priority": 8,
+        "when": [
+          "$gt0017|Prior Major Bleeding or Predisposition to Bleeding|!=null"
+        ],
+        "then": [
+          "$gt0027|Prior Major Bleeding or Predisposition to Bleeding|=$gt0017|Prior Major Bleeding or Predisposition to Bleeding|"
+        ]
+      },
+      "gt0054": {
+        "id": "gt0054",
+        "priority": 7,
+        "when": [
+          "$gt0018|Labile INR|!=null"
+        ],
+        "then": [
+          "$gt0028|Labile INR|=$gt0018|Labile INR|"
+        ]
+      },
+      "gt0063": {
+        "id": "gt0063",
+        "priority": 6,
+        "when": [
+          "$gt0060|Birthdate|!=null"
+        ],
+        "then": [
+          "$gt0062|Age|.magnitude=$currentDateTime.year-$gt0060.year",
+          "$gt0062|Age|.unit='a'"
+        ]
+      },
+      "gt0055": {
+        "id": "gt0055",
+        "priority": 5,
+        "when": [
+          "fired($gt0063)",
+          "$gt0062|Age|<=65,a"
+        ],
+        "then": [
+          "$gt0029|Age > 65|=0|local::at0014|No|"
+        ]
+      },
+      "gt0056": {
+        "id": "gt0056",
+        "priority": 4,
+        "when": [
+          "fired($gt0063)",
+          "$gt0062|Age|>65,a"
+        ],
+        "then": [
+          "$gt0029|Age > 65|=1|local::at0015|Yes|"
+        ]
+      },
+      "gt0057": {
+        "id": "gt0057",
+        "priority": 3,
+        "when": [
+          "$gt0020|Medication Usage Predisposing to Bleeding|!=null"
+        ],
+        "then": [
+          "$gt0030|Medication Usage Predisposing to Bleeding|=$gt0020|Medication Usage Predisposing to Bleeding|"
+        ]
+      },
+      "gt0073": {
+        "id": "gt0073",
+        "priority": 1,
+        "then": [
+          "$gt0032|Total score|.magnitude=$gt0023.value+$gt0024.value+$gt0025.value+$gt0026.value+$gt0027.value+$gt0028.value+$gt0029.value+$gt0030.value+$gt0031.value"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "sv": {
+        "id": "sv",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "HAS-BLED",
+            "description": "HAS-BLED bleeding risk score - för uppskattning av blödningsrisk hos patienter som på grund av förmaksflimmer behandlas med antikoagulantia."
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "Systoliskt",
+            "description": "*(en) Peak systemic arterial blood pressure  - measured in systolic or contraction phase of the heart cycle."
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Kreatinin mikromol/L",
+            "description": "*(en) *"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Totalt Bilirubin",
+            "description": "*(en) Total Bilirubin measures the sum of both unconjugated and conjugated Bilirubin."
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Ålder",
+            "description": "*(en) Age in years, and for babies: months, weeks or days"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Standardglas",
+            "description": "*(en) Number of standard drinks of alcohol consumed."
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "Hypertoni",
+            "description": "*(en) (Uncontrolled, >160 mmHg systolic)"
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "Njurpåverkan",
+            "description": "*(en) Dialysis, transplant, Cr >2.26 mg/dL or >200 µmol/L"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "Leversjukdom",
+            "description": "*(en) Cirrhosis or Bilirubin >2x Normal or AST/ALT/AP >3x Normal"
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "Tidigare stroke",
+            "description": "*(en) *"
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "text": "Tidigare blödning eller blödningsrisk",
+            "description": "*(en) *"
+          },
+          "gt0018": {
+            "id": "gt0018",
+            "text": "Riskvärde PK (INR)",
+            "description": "*(en) (Unstable/high INRs), Time in Therapeutic Range < 60%"
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "text": "Ålder > 65",
+            "description": "*(en) *"
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "Koagulationshämmande läkemedel",
+            "description": "*(en) (Antiplatelet agents, NSAIDs)"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "text": "Bruk av alkohol",
+            "description": "*(en) ≥ 8 drinks/week"
+          },
+          "gt0023": {
+            "id": "gt0023",
+            "text": "Hypertoni",
+            "description": "*(en) (Uncontrolled, >160 mmHg systolic)"
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "text": "Njurpåverkan",
+            "description": "*(en) Dialysis, transplant, Cr >2.26 mg/dL or >200 µmol/L"
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "text": "Leverpåverkan",
+            "description": "*(en) Cirrhosis or Bilirubin >2x Normal or AST/ALT/AP >3x Normal"
+          },
+          "gt0026": {
+            "id": "gt0026",
+            "text": "Tidigare stroke",
+            "description": "*(en) *"
+          },
+          "gt0027": {
+            "id": "gt0027",
+            "text": "Tidigare blödning eller blödningsrisk",
+            "description": "*(en) *"
+          },
+          "gt0028": {
+            "id": "gt0028",
+            "text": "Riskvärde PK (INR)",
+            "description": "*(en) (Unstable/high INRs), Time in Therapeutic Range < 60%"
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "text": "Ålder > 65",
+            "description": "*(en) *"
+          },
+          "gt0030": {
+            "id": "gt0030",
+            "text": "Koagulationshämmande läkemedel",
+            "description": "*(en) (Antiplatelet agents, NSAIDs)"
+          },
+          "gt0031": {
+            "id": "gt0031",
+            "text": "Bruk av alkohol",
+            "description": "*(en) ≥ 8 drinks/week"
+          },
+          "gt0032": {
+            "id": "gt0032",
+            "text": "Resultat",
+            "description": "*(en) Sum of individual scores"
+          },
+          "gt0033": {
+            "id": "gt0033",
+            "text": "CDS standard"
+          },
+          "gt0034": {
+            "id": "gt0034",
+            "text": "CDS Hypertoni: ja"
+          },
+          "gt0035": {
+            "id": "gt0035",
+            "text": "CDS Hypertoni: nej"
+          },
+          "gt0036": {
+            "id": "gt0036",
+            "text": "CDS bruk av alkohol: ja"
+          },
+          "gt0037": {
+            "id": "gt0037",
+            "text": "CDS bruk av alkohol: nej"
+          },
+          "gt0038": {
+            "id": "gt0038",
+            "text": "CDS leverpåverkan: nej"
+          },
+          "gt0042": {
+            "id": "gt0042",
+            "text": "ALP Resultat",
+            "description": "*(en) The result of the test. Normal range for men: 45 to 115 U/L"
+          },
+          "gt0043": {
+            "id": "gt0043",
+            "text": "ALAT Resultat",
+            "description": "*(en) The result of the test. Normal range for men: 7 to 55 units per liter (U/L)"
+          },
+          "gt0044": {
+            "id": "gt0044"
+          },
+          "gt0046": {
+            "id": "gt0046"
+          },
+          "gt0048": {
+            "id": "gt0048",
+            "text": "ASAT Resultat",
+            "description": "*(en) The result of the test. Normal range for men: 8 to 48 U/L"
+          },
+          "gt0049": {
+            "id": "gt0049",
+            "text": "CDS leverpåverkan: ja"
+          },
+          "gt0050": {
+            "id": "gt0050",
+            "text": "CDS njurpåverkan: nej"
+          },
+          "gt0051": {
+            "id": "gt0051",
+            "text": "CDS njurpåverkan: nej"
+          },
+          "gt0052": {
+            "id": "gt0052",
+            "text": "CDS tidigare stroke"
+          },
+          "gt0053": {
+            "id": "gt0053",
+            "text": "CDS Tidigare blödning eller blödningsrisk"
+          },
+          "gt0054": {
+            "id": "gt0054",
+            "text": "CDS INR"
+          },
+          "gt0055": {
+            "id": "gt0055",
+            "text": "CDS ålder >65: nej"
+          },
+          "gt0056": {
+            "id": "gt0056",
+            "text": "CDS ålder >65: ja"
+          },
+          "gt0057": {
+            "id": "gt0057",
+            "text": "CDS Koagulationshämmande läkemedel"
+          },
+          "gt0058": {
+            "id": "gt0058",
+            "text": "Resultat"
+          },
+          "gt0059": {
+            "id": "gt0059",
+            "text": "Resultat"
+          },
+          "gt0060": {
+            "id": "gt0060",
+            "text": "Födelsedatum",
+            "description": "*(en) *"
+          },
+          "gt0062": {
+            "id": "gt0062",
+            "text": "Ålder",
+            "description": "*(en) Age in years, and for babies: months, weeks or days"
+          },
+          "gt0063": {
+            "id": "gt0063",
+            "text": "CDS ålder"
+          },
+          "gt0064": {
+            "id": "gt0064",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0065": {
+            "id": "gt0065",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0066": {
+            "id": "gt0066",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0067": {
+            "id": "gt0067",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0068": {
+            "id": "gt0068",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0069": {
+            "id": "gt0069",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0070": {
+            "id": "gt0070",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0071": {
+            "id": "gt0071",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0072": {
+            "id": "gt0072",
+            "text": "*(en) Event time",
+            "description": "*(en) The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0073": {
+            "id": "gt0073",
+            "text": "*(en) Total score",
+            "description": ""
+          }
+        }
+      },
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "HAS-BLED",
+            "description": "HAS-BLED bleeding risk score. Estimates risk of major bleeding for patients on anticoagulation for atrial fibrillation"
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "Systolic",
+            "description": "Peak systemic arterial blood pressure  - measured in systolic or contraction phase of the heart cycle."
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "CR Result mircomol/L",
+            "description": "*"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Total Bilirubin",
+            "description": "Total Bilirubin measures the sum of both unconjugated and conjugated Bilirubin."
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Age",
+            "description": "Age in years, and for babies: months, weeks or days"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "Standard Drinks",
+            "description": "Number of standard drinks of alcohol consumed."
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "Hypertension History",
+            "description": "(Uncontrolled, >160 mmHg systolic)"
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "Renal Disease",
+            "description": "Dialysis, transplant, Cr >2.26 mg/dL or >200 µmol/L"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "Liver Disease",
+            "description": "Cirrhosis or Bilirubin >2x Normal or AST/ALT/AP >3x Normal"
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "Stroke History",
+            "description": "*"
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "text": "Prior Major Bleeding or Predisposition to Bleeding",
+            "description": "*"
+          },
+          "gt0018": {
+            "id": "gt0018",
+            "text": "Labile INR",
+            "description": "(Unstable/high INRs), Time in Therapeutic Range < 60%"
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "text": "Age > 65",
+            "description": "*"
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "Medication Usage Predisposing to Bleeding",
+            "description": "(Antiplatelet agents, NSAIDs)"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "text": "Alcohol or Drug Usage History",
+            "description": "≥ 8 drinks/week"
+          },
+          "gt0023": {
+            "id": "gt0023",
+            "text": "Hypertension History",
+            "description": "(Uncontrolled, >160 mmHg systolic)"
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "text": "Renal Disease",
+            "description": "Dialysis, transplant, Cr >2.26 mg/dL or >200 µmol/L"
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "text": "Liver Disease",
+            "description": "Cirrhosis or Bilirubin >2x Normal or AST/ALT/AP >3x Normal"
+          },
+          "gt0026": {
+            "id": "gt0026",
+            "text": "Stroke History",
+            "description": "*"
+          },
+          "gt0027": {
+            "id": "gt0027",
+            "text": "Prior Major Bleeding or Predisposition to Bleeding",
+            "description": "*"
+          },
+          "gt0028": {
+            "id": "gt0028",
+            "text": "Labile INR",
+            "description": "(Unstable/high INRs), Time in Therapeutic Range < 60%"
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "text": "Age > 65",
+            "description": "*"
+          },
+          "gt0030": {
+            "id": "gt0030",
+            "text": "Medication Usage Predisposing to Bleeding",
+            "description": "(Antiplatelet agents, NSAIDs)"
+          },
+          "gt0031": {
+            "id": "gt0031",
+            "text": "Alcohol or Drug Usage History",
+            "description": "≥ 8 drinks/week"
+          },
+          "gt0032": {
+            "id": "gt0032",
+            "text": "Total score",
+            "description": "Sum of individual scores"
+          },
+          "gt0033": {
+            "id": "gt0033",
+            "text": "Set default"
+          },
+          "gt0034": {
+            "id": "gt0034",
+            "text": "Set HyperT: yes"
+          },
+          "gt0035": {
+            "id": "gt0035",
+            "text": "Set HyperT: no"
+          },
+          "gt0036": {
+            "id": "gt0036",
+            "text": "Set drinking: Yes"
+          },
+          "gt0037": {
+            "id": "gt0037",
+            "text": "Set drinking: no"
+          },
+          "gt0038": {
+            "id": "gt0038",
+            "text": "Set Liver disease: no"
+          },
+          "gt0042": {
+            "id": "gt0042",
+            "text": "ALP Result",
+            "description": "The result of the test. Normal range for men: 45 to 115 U/L"
+          },
+          "gt0043": {
+            "id": "gt0043",
+            "text": "ALT Result",
+            "description": "The result of the test. Normal range for men: 7 to 55 units per liter (U/L)"
+          },
+          "gt0044": {
+            "id": "gt0044"
+          },
+          "gt0046": {
+            "id": "gt0046"
+          },
+          "gt0048": {
+            "id": "gt0048",
+            "text": "AST Result",
+            "description": "The result of the test. Normal range for men: 8 to 48 U/L"
+          },
+          "gt0049": {
+            "id": "gt0049",
+            "text": "Set Liver disease: yes"
+          },
+          "gt0050": {
+            "id": "gt0050",
+            "text": "Set Renal disease: no"
+          },
+          "gt0051": {
+            "id": "gt0051",
+            "text": "Set Renal disease: yes"
+          },
+          "gt0052": {
+            "id": "gt0052",
+            "text": "Set stroke history"
+          },
+          "gt0053": {
+            "id": "gt0053",
+            "text": "Set prior bleeding"
+          },
+          "gt0054": {
+            "id": "gt0054",
+            "text": "Set INR"
+          },
+          "gt0055": {
+            "id": "gt0055",
+            "text": "Set Age >65: no"
+          },
+          "gt0056": {
+            "id": "gt0056",
+            "text": "Set Age >65: yes"
+          },
+          "gt0057": {
+            "id": "gt0057",
+            "text": "Set med usage"
+          },
+          "gt0058": {
+            "id": "gt0058",
+            "text": "Total score"
+          },
+          "gt0059": {
+            "id": "gt0059",
+            "text": "Total score"
+          },
+          "gt0060": {
+            "id": "gt0060",
+            "text": "Birthdate",
+            "description": "*"
+          },
+          "gt0062": {
+            "id": "gt0062",
+            "text": "Age",
+            "description": "Age in years, and for babies: months, weeks or days"
+          },
+          "gt0063": {
+            "id": "gt0063",
+            "text": "Set age"
+          },
+          "gt0064": {
+            "id": "gt0064",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0065": {
+            "id": "gt0065",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0066": {
+            "id": "gt0066",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0067": {
+            "id": "gt0067",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0068": {
+            "id": "gt0068",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0069": {
+            "id": "gt0069",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0070": {
+            "id": "gt0070",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0071": {
+            "id": "gt0071",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0072": {
+            "id": "gt0072",
+            "text": "Event time",
+            "description": "The exact time of a single timed event during the Observation. Can represent either a specific point-in-time or an interval event."
+          },
+          "gt0073": {
+            "id": "gt0073",
+            "text": "Total score"
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/HAS-BLED.v1.test.yml
+++ b/gdl2/HAS-BLED.v1.test.yml
@@ -289,10 +289,10 @@ test_cases:
       gt0026|Stroke History: 0|local::at0014|No|
       gt0031|Alcohol or Drug Usage History: 0|local::at0014|No|
       gt0030|Medication Usage Predisposing to Bleeding: 0|local::at0014|No|
-      gt0032|Total score: 1
+      gt0032|Total score: 0
       gt0028|Labile INR: 0|local::at0014|No|
       gt0027|Prior Major Bleeding or Predisposition to Bleeding: 0|local::at0014|No|
-      gt0025|Liver Disease: 1|local::at0015|Yes|
+      gt0025|Liver Disease: 0|local::at0014|No|
       gt0023|Hypertension History: 0|local::at0014|No|
       gt0062|Age: 60,a
 
@@ -331,10 +331,10 @@ test_cases:
       gt0026|Stroke History: 0|local::at0014|No|
       gt0031|Alcohol or Drug Usage History: 0|local::at0014|No|
       gt0030|Medication Usage Predisposing to Bleeding: 0|local::at0014|No|
-      gt0032|Total score: 1
+      gt0032|Total score: 0
       gt0028|Labile INR: 0|local::at0014|No|
       gt0027|Prior Major Bleeding or Predisposition to Bleeding: 0|local::at0014|No|
-      gt0025|Liver Disease: 1|local::at0015|Yes|
+      gt0025|Liver Disease: 0|local::at0014|No|
       gt0023|Hypertension History: 0|local::at0014|No|
       gt0062|Age: 60,a
 
@@ -373,10 +373,10 @@ test_cases:
       gt0026|Stroke History: 0|local::at0014|No|
       gt0031|Alcohol or Drug Usage History: 0|local::at0014|No|
       gt0030|Medication Usage Predisposing to Bleeding: 0|local::at0014|No|
-      gt0032|Total score: 1
+      gt0032|Total score: 0
       gt0028|Labile INR: 0|local::at0014|No|
       gt0027|Prior Major Bleeding or Predisposition to Bleeding: 0|local::at0014|No|
-      gt0025|Liver Disease: 1|local::at0015|Yes|
+      gt0025|Liver Disease: 0|local::at0014|No|
       gt0023|Hypertension History: 0|local::at0014|No|
       gt0062|Age: 60,a
 
@@ -416,10 +416,10 @@ test_cases:
       gt0026|Stroke History: 0|local::at0014|No|
       gt0031|Alcohol or Drug Usage History: 0|local::at0014|No|
       gt0030|Medication Usage Predisposing to Bleeding: 0|local::at0014|No|
-      gt0032|Total score: 1
+      gt0032|Total score: 0
       gt0028|Labile INR: 0|local::at0014|No|
       gt0027|Prior Major Bleeding or Predisposition to Bleeding: 0|local::at0014|No|
-      gt0025|Liver Disease: 1|local::at0015|Yes|
+      gt0025|Liver Disease: 0|local::at0014|No|
       gt0023|Hypertension History: 0|local::at0014|No|
       gt0062|Age: 60,a
 
@@ -458,10 +458,10 @@ test_cases:
       gt0026|Stroke History: 0|local::at0014|No|
       gt0031|Alcohol or Drug Usage History: 0|local::at0014|No|
       gt0030|Medication Usage Predisposing to Bleeding: 0|local::at0014|No|
-      gt0032|Total score: 1
+      gt0032|Total score: 0
       gt0028|Labile INR: 0|local::at0014|No|
       gt0027|Prior Major Bleeding or Predisposition to Bleeding: 0|local::at0014|No|
-      gt0025|Liver Disease: 1|local::at0015|Yes|
+      gt0025|Liver Disease: 0|local::at0014|No|
       gt0023|Hypertension History: 0|local::at0014|No|
       gt0062|Age: 60,a
 

--- a/gdl2/HAS-BLED.v1.test.yml
+++ b/gdl2/HAS-BLED.v1.test.yml
@@ -1,0 +1,510 @@
+guidelines:
+  1: HAS-BLED.v1
+test_cases:
+- id: All 0
+  input:
+    1:
+      gt0003|Systolic: 150,mm[Hg]
+      gt0064|Event time: 2019-06-30T07:55Z
+      gt0005|CR Result mircomol/L: 199,µmol/l
+      gt0065|Event time: 2019-06-30T07:55Z
+      gt0007|Total Bilirubin: 2,mg/dl
+      gt0066|Event time: 2019-06-30T07:55Z
+      gt0060|Birthdate: 1959-06-30T07:55Z
+      gt0067|Event time: 2019-06-30T07:55Z
+      gt0011|Standard Drinks: 7,/wk
+      gt0068|Event time: 2019-06-30T07:55Z
+      gt0013|Hypertension History: 0|local::at0014|No|
+      gt0014|Renal Disease: 0|local::at0014|No|
+      gt0015|Liver Disease: 0|local::at0014|No|
+      gt0016|Stroke History: 0|local::at0014|No|
+      gt0017|Prior Major Bleeding or Predisposition to Bleeding: 0|local::at0014|No|
+      gt0018|Labile INR: 0|local::at0014|No|
+      gt0020|Medication Usage Predisposing to Bleeding: 0|local::at0014|No|
+      gt0021|Alcohol or Drug Usage History: 0|local::at0014|No|
+      gt0069|Event time: 2019-06-30T07:55Z
+      gt0043|ALT Result: 120,U/l
+      gt0070|Event time: 2019-06-30T07:55Z
+      gt0042|ALP Result: 120,U/l
+      gt0072|Event time: 2019-06-30T07:55Z
+      gt0048|AST Result: 120,U/l
+      gt0071|Event time: 2019-06-30T07:55Z
+  expected_output:
+    1:
+      gt0024|Renal Disease: 0|local::at0014|No|
+      gt0029|Age > 65: 0|local::at0014|No|
+      gt0026|Stroke History: 0|local::at0014|No|
+      gt0031|Alcohol or Drug Usage History: 0|local::at0014|No|
+      gt0030|Medication Usage Predisposing to Bleeding: 0|local::at0014|No|
+      gt0032|Total score: 0
+      gt0028|Labile INR: 0|local::at0014|No|
+      gt0027|Prior Major Bleeding or Predisposition to Bleeding: 0|local::at0014|No|
+      gt0025|Liver Disease: 0|local::at0014|No|
+      gt0023|Hypertension History: 0|local::at0014|No|
+      gt0062|Age: 60,a
+
+
+- id: Systolic, CR
+  input:
+    1:
+      gt0003|Systolic: 170,mm[Hg]
+      gt0064|Event time: 2019-06-30T07:55Z
+      gt0005|CR Result mircomol/L: 201,µmol/l
+      gt0065|Event time: 2019-06-30T07:55Z
+      gt0007|Total Bilirubin: 2,mg/dl
+      gt0066|Event time: 2019-06-30T07:55Z
+      gt0060|Birthdate: 1959-06-30T07:55Z
+      gt0067|Event time: 2019-06-30T07:55Z
+      gt0011|Standard Drinks: 7,/wk
+      gt0068|Event time: 2019-06-30T07:55Z
+      gt0013|Hypertension History: 0|local::at0014|No|
+      gt0014|Renal Disease: 0|local::at0014|No|
+      gt0015|Liver Disease: 0|local::at0014|No|
+      gt0016|Stroke History: 0|local::at0014|No|
+      gt0017|Prior Major Bleeding or Predisposition to Bleeding: 0|local::at0014|No|
+      gt0018|Labile INR: 0|local::at0014|No|
+      gt0020|Medication Usage Predisposing to Bleeding: 0|local::at0014|No|
+      gt0021|Alcohol or Drug Usage History: 0|local::at0014|No|
+      gt0069|Event time: 2019-06-30T07:55Z
+      gt0043|ALT Result: 120,U/l
+      gt0070|Event time: 2019-06-30T07:55Z
+      gt0042|ALP Result: 120,U/l
+      gt0072|Event time: 2019-06-30T07:55Z
+      gt0048|AST Result: 120,U/l
+      gt0071|Event time: 2019-06-30T07:55Z
+  expected_output:
+    1:
+      gt0024|Renal Disease: 1|local::at0015|Yes|
+      gt0029|Age > 65: 0|local::at0014|No|
+      gt0026|Stroke History: 0|local::at0014|No|
+      gt0031|Alcohol or Drug Usage History: 0|local::at0014|No|
+      gt0030|Medication Usage Predisposing to Bleeding: 0|local::at0014|No|
+      gt0032|Total score: 2
+      gt0028|Labile INR: 0|local::at0014|No|
+      gt0027|Prior Major Bleeding or Predisposition to Bleeding: 0|local::at0014|No|
+      gt0025|Liver Disease: 0|local::at0014|No|
+      gt0023|Hypertension History: 1|local::at0015|Yes|
+      gt0062|Age: 60,a
+
+- id: Renal, HT history
+  input:
+    1:
+      gt0003|Systolic: 150,mm[Hg]
+      gt0064|Event time: 2019-06-30T07:55Z
+      gt0005|CR Result mircomol/L: 199,µmol/l
+      gt0065|Event time: 2019-06-30T07:55Z
+      gt0007|Total Bilirubin: 2,mg/dl
+      gt0066|Event time: 2019-06-30T07:55Z
+      gt0060|Birthdate: 1959-06-30T07:55Z
+      gt0067|Event time: 2019-06-30T07:55Z
+      gt0011|Standard Drinks: 7,/wk
+      gt0068|Event time: 2019-06-30T07:55Z
+      gt0013|Hypertension History: 1|local::at0015|Yes|
+      gt0014|Renal Disease: 1|local::at0015|Yes|
+      gt0015|Liver Disease: 0|local::at0014|No|
+      gt0016|Stroke History: 0|local::at0014|No|
+      gt0017|Prior Major Bleeding or Predisposition to Bleeding: 0|local::at0014|No|
+      gt0018|Labile INR: 0|local::at0014|No|
+      gt0020|Medication Usage Predisposing to Bleeding: 0|local::at0014|No|
+      gt0021|Alcohol or Drug Usage History: 0|local::at0014|No|
+      gt0069|Event time: 2019-06-30T07:55Z
+      gt0043|ALT Result: 120,U/l
+      gt0070|Event time: 2019-06-30T07:55Z
+      gt0042|ALP Result: 120,U/l
+      gt0072|Event time: 2019-06-30T07:55Z
+      gt0048|AST Result: 120,U/l
+      gt0071|Event time: 2019-06-30T07:55Z
+  expected_output:
+    1:
+      gt0024|Renal Disease: 1|local::at0015|Yes|
+      gt0029|Age > 65: 0|local::at0014|No|
+      gt0026|Stroke History: 0|local::at0014|No|
+      gt0031|Alcohol or Drug Usage History: 0|local::at0014|No|
+      gt0030|Medication Usage Predisposing to Bleeding: 0|local::at0014|No|
+      gt0032|Total score: 2
+      gt0028|Labile INR: 0|local::at0014|No|
+      gt0027|Prior Major Bleeding or Predisposition to Bleeding: 0|local::at0014|No|
+      gt0025|Liver Disease: 0|local::at0014|No|
+      gt0023|Hypertension History: 1|local::at0015|Yes|
+      gt0062|Age: 60,a
+
+- id: Both
+  input:
+    1:
+      gt0003|Systolic: 160,mm[Hg]
+      gt0064|Event time: 2019-06-30T07:55Z
+      gt0005|CR Result mircomol/L: 201,µmol/l
+      gt0065|Event time: 2019-06-30T07:55Z
+      gt0007|Total Bilirubin: 2,mg/dl
+      gt0066|Event time: 2019-06-30T07:55Z
+      gt0060|Birthdate: 1959-06-30T07:55Z
+      gt0067|Event time: 2019-06-30T07:55Z
+      gt0011|Standard Drinks: 7,/wk
+      gt0068|Event time: 2019-06-30T07:55Z
+      gt0013|Hypertension History: 1|local::at0015|Yes|
+      gt0014|Renal Disease: 1|local::at0015|Yes|
+      gt0015|Liver Disease: 0|local::at0014|No|
+      gt0016|Stroke History: 0|local::at0014|No|
+      gt0017|Prior Major Bleeding or Predisposition to Bleeding: 0|local::at0014|No|
+      gt0018|Labile INR: 0|local::at0014|No|
+      gt0020|Medication Usage Predisposing to Bleeding: 0|local::at0014|No|
+      gt0021|Alcohol or Drug Usage History: 0|local::at0014|No|
+      gt0069|Event time: 2019-06-30T07:55Z
+      gt0043|ALT Result: 120,U/l
+      gt0070|Event time: 2019-06-30T07:55Z
+      gt0042|ALP Result: 120,U/l
+      gt0072|Event time: 2019-06-30T07:55Z
+      gt0048|AST Result: 120,U/l
+      gt0071|Event time: 2019-06-30T07:55Z
+  expected_output:
+    1:
+      gt0024|Renal Disease: 1|local::at0015|Yes|
+      gt0029|Age > 65: 0|local::at0014|No|
+      gt0026|Stroke History: 0|local::at0014|No|
+      gt0031|Alcohol or Drug Usage History: 0|local::at0014|No|
+      gt0030|Medication Usage Predisposing to Bleeding: 0|local::at0014|No|
+      gt0032|Total score: 2
+      gt0028|Labile INR: 0|local::at0014|No|
+      gt0027|Prior Major Bleeding or Predisposition to Bleeding: 0|local::at0014|No|
+      gt0025|Liver Disease: 0|local::at0014|No|
+      gt0023|Hypertension History: 1|local::at0015|Yes|
+      gt0062|Age: 60,a
+
+- id: Stroke, Major bleeding, elderly, INR, medication, consumes alcohol but no abuse history
+  input:
+    1:
+      gt0003|Systolic: 160,mm[Hg]
+      gt0064|Event time: 2019-06-30T07:55Z
+      gt0005|CR Result mircomol/L: 201,µmol/l
+      gt0065|Event time: 2019-06-30T07:55Z
+      gt0007|Total Bilirubin: 2,mg/dl
+      gt0066|Event time: 2019-06-30T07:55Z
+      gt0060|Birthdate: 1939-06-30T07:55Z
+      gt0067|Event time: 2019-06-30T07:55Z
+      gt0011|Standard Drinks: 8,/wk
+      gt0068|Event time: 2019-06-30T07:55Z
+      gt0013|Hypertension History: 1|local::at0015|Yes|
+      gt0014|Renal Disease: 1|local::at0015|Yes|
+      gt0015|Liver Disease: 0|local::at0014|No|
+      gt0016|Stroke History: 1|local::at0015|Yes|
+      gt0017|Prior Major Bleeding or Predisposition to Bleeding: 1|local::at0015|Yes|
+      gt0018|Labile INR: 1|local::at0015|Yes|
+      gt0020|Medication Usage Predisposing to Bleeding: 1|local::at0015|Yes|
+      gt0021|Alcohol or Drug Usage History: 0|local::at0014|No|
+      gt0069|Event time: 2019-06-30T07:55Z
+      gt0043|ALT Result: 120,U/l
+      gt0070|Event time: 2019-06-30T07:55Z
+      gt0042|ALP Result: 120,U/l
+      gt0072|Event time: 2019-06-30T07:55Z
+      gt0048|AST Result: 120,U/l
+      gt0071|Event time: 2019-06-30T07:55Z
+  expected_output:
+    1:
+      gt0024|Renal Disease: 1|local::at0015|Yes|
+      gt0029|Age > 65: 1|local::at0015|Yes|
+      gt0026|Stroke History: 1|local::at0015|Yes|
+      gt0031|Alcohol or Drug Usage History: 1|local::at0015|Yes|
+      gt0030|Medication Usage Predisposing to Bleeding: 1|local::at0015|Yes|
+      gt0032|Total score: 8
+      gt0028|Labile INR: 1|local::at0015|Yes|
+      gt0027|Prior Major Bleeding or Predisposition to Bleeding: 1|local::at0015|Yes|
+      gt0025|Liver Disease: 0|local::at0014|No|
+      gt0023|Hypertension History: 1|local::at0015|Yes|
+      gt0062|Age: 80,a
+
+- id: Doesn't consume, but has history
+  input:
+    1:
+      gt0003|Systolic: 160,mm[Hg]
+      gt0064|Event time: 2019-06-30T07:55Z
+      gt0005|CR Result mircomol/L: 201,µmol/l
+      gt0065|Event time: 2019-06-30T07:55Z
+      gt0007|Total Bilirubin: 2,mg/dl
+      gt0066|Event time: 2019-06-30T07:55Z
+      gt0060|Birthdate: 1939-06-30T07:55Z
+      gt0067|Event time: 2019-06-30T07:55Z
+      gt0011|Standard Drinks: 1,/wk
+      gt0068|Event time: 2019-06-30T07:55Z
+      gt0013|Hypertension History: 1|local::at0015|Yes|
+      gt0014|Renal Disease: 1|local::at0015|Yes|
+      gt0015|Liver Disease: 0|local::at0014|No|
+      gt0016|Stroke History: 1|local::at0015|Yes|
+      gt0017|Prior Major Bleeding or Predisposition to Bleeding: 1|local::at0015|Yes|
+      gt0018|Labile INR: 1|local::at0015|Yes|
+      gt0020|Medication Usage Predisposing to Bleeding: 1|local::at0015|Yes|
+      gt0021|Alcohol or Drug Usage History: 1|local::at0015|Yes|
+      gt0069|Event time: 2019-06-30T07:55Z
+      gt0043|ALT Result: 120,U/l
+      gt0070|Event time: 2019-06-30T07:55Z
+      gt0042|ALP Result: 120,U/l
+      gt0072|Event time: 2019-06-30T07:55Z
+      gt0048|AST Result: 120,U/l
+      gt0071|Event time: 2019-06-30T07:55Z
+  expected_output:
+    1:
+      gt0024|Renal Disease: 1|local::at0015|Yes|
+      gt0029|Age > 65: 1|local::at0015|Yes|
+      gt0026|Stroke History: 1|local::at0015|Yes|
+      gt0031|Alcohol or Drug Usage History: 1|local::at0015|Yes|
+      gt0030|Medication Usage Predisposing to Bleeding: 1|local::at0015|Yes|
+      gt0032|Total score: 8
+      gt0028|Labile INR: 1|local::at0015|Yes|
+      gt0027|Prior Major Bleeding or Predisposition to Bleeding: 1|local::at0015|Yes|
+      gt0025|Liver Disease: 0|local::at0014|No|
+      gt0023|Hypertension History: 1|local::at0015|Yes|
+      gt0062|Age: 80,a
+
+- id: Bilirubin
+  input:
+    1:
+      gt0003|Systolic: 120,mm[Hg]
+      gt0064|Event time: 2019-06-30T07:55Z
+      gt0005|CR Result mircomol/L: 170,µmol/l
+      gt0065|Event time: 2019-06-30T07:55Z
+      gt0007|Total Bilirubin: 3,mg/dl
+      gt0066|Event time: 2019-06-30T07:55Z
+      gt0060|Birthdate: 1959-06-30T07:55Z
+      gt0067|Event time: 2019-06-30T07:55Z
+      gt0011|Standard Drinks: 1,/wk
+      gt0068|Event time: 2019-06-30T07:55Z
+      gt0013|Hypertension History: 0|local::at0014|No|
+      gt0014|Renal Disease: 0|local::at0014|No|
+      gt0015|Liver Disease: 0|local::at0014|No|
+      gt0016|Stroke History: 0|local::at0014|No|
+      gt0017|Prior Major Bleeding or Predisposition to Bleeding: 0|local::at0014|No|
+      gt0018|Labile INR: 0|local::at0014|No|
+      gt0020|Medication Usage Predisposing to Bleeding: 0|local::at0014|No|
+      gt0021|Alcohol or Drug Usage History: 0|local::at0014|No|
+      gt0069|Event time: 2019-06-30T07:55Z
+      gt0043|ALT Result: 120,U/l
+      gt0070|Event time: 2019-06-30T07:55Z
+      gt0042|ALP Result: 120,U/l
+      gt0072|Event time: 2019-06-30T07:55Z
+      gt0048|AST Result: 120,U/l
+      gt0071|Event time: 2019-06-30T07:55Z
+  expected_output:
+    1:
+      gt0024|Renal Disease: 0|local::at0014|No|
+      gt0029|Age > 65: 0|local::at0014|No|
+      gt0026|Stroke History: 0|local::at0014|No|
+      gt0031|Alcohol or Drug Usage History: 0|local::at0014|No|
+      gt0030|Medication Usage Predisposing to Bleeding: 0|local::at0014|No|
+      gt0032|Total score: 1
+      gt0028|Labile INR: 0|local::at0014|No|
+      gt0027|Prior Major Bleeding or Predisposition to Bleeding: 0|local::at0014|No|
+      gt0025|Liver Disease: 1|local::at0015|Yes|
+      gt0023|Hypertension History: 0|local::at0014|No|
+      gt0062|Age: 60,a
+
+- id: AST
+  input:
+    1:
+      gt0003|Systolic: 120,mm[Hg]
+      gt0064|Event time: 2019-06-30T07:55Z
+      gt0005|CR Result mircomol/L: 170,µmol/l
+      gt0065|Event time: 2019-06-30T07:55Z
+      gt0007|Total Bilirubin: 2,mg/dl
+      gt0066|Event time: 2019-06-30T07:55Z
+      gt0060|Birthdate: 1959-06-30T07:55Z
+      gt0067|Event time: 2019-06-30T07:55Z
+      gt0011|Standard Drinks: 1,/wk
+      gt0068|Event time: 2019-06-30T07:55Z
+      gt0013|Hypertension History: 0|local::at0014|No|
+      gt0014|Renal Disease: 0|local::at0014|No|
+      gt0015|Liver Disease: 0|local::at0014|No|
+      gt0016|Stroke History: 0|local::at0014|No|
+      gt0017|Prior Major Bleeding or Predisposition to Bleeding: 0|local::at0014|No|
+      gt0018|Labile INR: 0|local::at0014|No|
+      gt0020|Medication Usage Predisposing to Bleeding: 0|local::at0014|No|
+      gt0021|Alcohol or Drug Usage History: 0|local::at0014|No|
+      gt0069|Event time: 2019-06-30T07:55Z
+      gt0043|ALT Result: 120,U/l
+      gt0070|Event time: 2019-06-30T07:55Z
+      gt0042|ALP Result: 120,U/l
+      gt0072|Event time: 2019-06-30T07:55Z
+      gt0048|AST Result: 145,U/l
+      gt0071|Event time: 2019-06-30T07:55Z
+  expected_output:
+    1:
+      gt0024|Renal Disease: 0|local::at0014|No|
+      gt0029|Age > 65: 0|local::at0014|No|
+      gt0026|Stroke History: 0|local::at0014|No|
+      gt0031|Alcohol or Drug Usage History: 0|local::at0014|No|
+      gt0030|Medication Usage Predisposing to Bleeding: 0|local::at0014|No|
+      gt0032|Total score: 1
+      gt0028|Labile INR: 0|local::at0014|No|
+      gt0027|Prior Major Bleeding or Predisposition to Bleeding: 0|local::at0014|No|
+      gt0025|Liver Disease: 1|local::at0015|Yes|
+      gt0023|Hypertension History: 0|local::at0014|No|
+      gt0062|Age: 60,a
+
+- id: ALP
+  input:
+    1:
+      gt0003|Systolic: 120,mm[Hg]
+      gt0064|Event time: 2019-06-30T07:55Z
+      gt0005|CR Result mircomol/L: 170,µmol/l
+      gt0065|Event time: 2019-06-30T07:55Z
+      gt0007|Total Bilirubin: 2,mg/dl
+      gt0066|Event time: 2019-06-30T07:55Z
+      gt0060|Birthdate: 1959-06-30T07:55Z
+      gt0067|Event time: 2019-06-30T07:55Z
+      gt0011|Standard Drinks: 1,/wk
+      gt0068|Event time: 2019-06-30T07:55Z
+      gt0013|Hypertension History: 0|local::at0014|No|
+      gt0014|Renal Disease: 0|local::at0014|No|
+      gt0015|Liver Disease: 0|local::at0014|No|
+      gt0016|Stroke History: 0|local::at0014|No|
+      gt0017|Prior Major Bleeding or Predisposition to Bleeding: 0|local::at0014|No|
+      gt0018|Labile INR: 0|local::at0014|No|
+      gt0020|Medication Usage Predisposing to Bleeding: 0|local::at0014|No|
+      gt0021|Alcohol or Drug Usage History: 0|local::at0014|No|
+      gt0069|Event time: 2019-06-30T07:55Z
+      gt0043|ALT Result: 120,U/l
+      gt0070|Event time: 2019-06-30T07:55Z
+      gt0042|ALP Result: 350,U/l
+      gt0072|Event time: 2019-06-30T07:55Z
+      gt0048|AST Result: 130,U/l
+      gt0071|Event time: 2019-06-30T07:55Z
+  expected_output:
+    1:
+      gt0024|Renal Disease: 0|local::at0014|No|
+      gt0029|Age > 65: 0|local::at0014|No|
+      gt0026|Stroke History: 0|local::at0014|No|
+      gt0031|Alcohol or Drug Usage History: 0|local::at0014|No|
+      gt0030|Medication Usage Predisposing to Bleeding: 0|local::at0014|No|
+      gt0032|Total score: 1
+      gt0028|Labile INR: 0|local::at0014|No|
+      gt0027|Prior Major Bleeding or Predisposition to Bleeding: 0|local::at0014|No|
+      gt0025|Liver Disease: 1|local::at0015|Yes|
+      gt0023|Hypertension History: 0|local::at0014|No|
+      gt0062|Age: 60,a
+
+
+- id: ALT
+  input:
+    1:
+      gt0003|Systolic: 120,mm[Hg]
+      gt0064|Event time: 2019-06-30T07:55Z
+      gt0005|CR Result mircomol/L: 170,µmol/l
+      gt0065|Event time: 2019-06-30T07:55Z
+      gt0007|Total Bilirubin: 2,mg/dl
+      gt0066|Event time: 2019-06-30T07:55Z
+      gt0060|Birthdate: 1959-06-30T07:55Z
+      gt0067|Event time: 2019-06-30T07:55Z
+      gt0011|Standard Drinks: 1,/wk
+      gt0068|Event time: 2019-06-30T07:55Z
+      gt0013|Hypertension History: 0|local::at0014|No|
+      gt0014|Renal Disease: 0|local::at0014|No|
+      gt0015|Liver Disease: 0|local::at0014|No|
+      gt0016|Stroke History: 0|local::at0014|No|
+      gt0017|Prior Major Bleeding or Predisposition to Bleeding: 0|local::at0014|No|
+      gt0018|Labile INR: 0|local::at0014|No|
+      gt0020|Medication Usage Predisposing to Bleeding: 0|local::at0014|No|
+      gt0021|Alcohol or Drug Usage History: 0|local::at0014|No|
+      gt0069|Event time: 2019-06-30T07:55Z
+      gt0043|ALT Result: 170,U/l
+      gt0070|Event time: 2019-06-30T07:55Z
+      gt0042|ALP Result: 200,U/l
+      gt0072|Event time: 2019-06-30T07:55Z
+      gt0048|AST Result: 130,U/l
+      gt0071|Event time: 2019-06-30T07:55Z
+  expected_output:
+    1:
+      gt0024|Renal Disease: 0|local::at0014|No|
+      gt0029|Age > 65: 0|local::at0014|No|
+      gt0026|Stroke History: 0|local::at0014|No|
+      gt0031|Alcohol or Drug Usage History: 0|local::at0014|No|
+      gt0030|Medication Usage Predisposing to Bleeding: 0|local::at0014|No|
+      gt0032|Total score: 1
+      gt0028|Labile INR: 0|local::at0014|No|
+      gt0027|Prior Major Bleeding or Predisposition to Bleeding: 0|local::at0014|No|
+      gt0025|Liver Disease: 1|local::at0015|Yes|
+      gt0023|Hypertension History: 0|local::at0014|No|
+      gt0062|Age: 60,a
+
+- id: Liver d history
+  input:
+    1:
+      gt0003|Systolic: 120,mm[Hg]
+      gt0064|Event time: 2019-06-30T07:55Z
+      gt0005|CR Result mircomol/L: 170,µmol/l
+      gt0065|Event time: 2019-06-30T07:55Z
+      gt0007|Total Bilirubin: 2,mg/dl
+      gt0066|Event time: 2019-06-30T07:55Z
+      gt0060|Birthdate: 1959-06-30T07:55Z
+      gt0067|Event time: 2019-06-30T07:55Z
+      gt0011|Standard Drinks: 1,/wk
+      gt0068|Event time: 2019-06-30T07:55Z
+      gt0013|Hypertension History: 0|local::at0014|No|
+      gt0014|Renal Disease: 0|local::at0014|No|
+      gt0015|Liver Disease: 1|local::at0015|Yes|
+      gt0016|Stroke History: 0|local::at0014|No|
+      gt0017|Prior Major Bleeding or Predisposition to Bleeding: 0|local::at0014|No|
+      gt0018|Labile INR: 0|local::at0014|No|
+      gt0020|Medication Usage Predisposing to Bleeding: 0|local::at0014|No|
+      gt0021|Alcohol or Drug Usage History: 0|local::at0014|No|
+      gt0069|Event time: 2019-06-30T07:55Z
+      gt0043|ALT Result: 160,U/l
+      gt0070|Event time: 2019-06-30T07:55Z
+      gt0042|ALP Result: 200,U/l
+      gt0072|Event time: 2019-06-30T07:55Z
+      gt0048|AST Result: 130,U/l
+      gt0071|Event time: 2019-06-30T07:55Z
+  expected_output:
+    1:
+      gt0024|Renal Disease: 0|local::at0014|No|
+      gt0029|Age > 65: 0|local::at0014|No|
+      gt0026|Stroke History: 0|local::at0014|No|
+      gt0031|Alcohol or Drug Usage History: 0|local::at0014|No|
+      gt0030|Medication Usage Predisposing to Bleeding: 0|local::at0014|No|
+      gt0032|Total score: 1
+      gt0028|Labile INR: 0|local::at0014|No|
+      gt0027|Prior Major Bleeding or Predisposition to Bleeding: 0|local::at0014|No|
+      gt0025|Liver Disease: 1|local::at0015|Yes|
+      gt0023|Hypertension History: 0|local::at0014|No|
+      gt0062|Age: 60,a
+
+
+- id: allneg
+  input:
+    1:
+      gt0003|Systolic: 120,mm[Hg]
+      gt0064|Event time: 2019-06-30T07:55Z
+      gt0005|CR Result mircomol/L: 170,µmol/l
+      gt0065|Event time: 2019-06-30T07:55Z
+      gt0007|Total Bilirubin: 2,mg/dl
+      gt0066|Event time: 2019-06-30T07:55Z
+      gt0060|Birthdate: 1959-06-30T07:55Z
+      gt0067|Event time: 2019-06-30T07:55Z
+      gt0011|Standard Drinks: 1,/wk
+      gt0068|Event time: 2019-06-30T07:55Z
+      gt0013|Hypertension History: 0|local::at0014|No|
+      gt0014|Renal Disease: 0|local::at0014|No|
+      gt0015|Liver Disease: 0|local::at0014|No|
+      gt0016|Stroke History: 0|local::at0014|No|
+      gt0017|Prior Major Bleeding or Predisposition to Bleeding: 0|local::at0014|No|
+      gt0018|Labile INR: 0|local::at0014|No|
+      gt0020|Medication Usage Predisposing to Bleeding: 0|local::at0014|No|
+      gt0021|Alcohol or Drug Usage History: 0|local::at0014|No|
+      gt0069|Event time: 2019-06-30T07:55Z
+      gt0043|ALT Result: 160,U/l
+      gt0070|Event time: 2019-06-30T07:55Z
+      gt0042|ALP Result: 200,U/l
+      gt0072|Event time: 2019-06-30T07:55Z
+      gt0048|AST Result: 130,U/l
+      gt0071|Event time: 2019-06-30T07:55Z
+  expected_output:
+    1:
+      gt0024|Renal Disease: 0|local::at0014|No|
+      gt0029|Age > 65: 0|local::at0014|No|
+      gt0026|Stroke History: 0|local::at0014|No|
+      gt0031|Alcohol or Drug Usage History: 0|local::at0014|No|
+      gt0030|Medication Usage Predisposing to Bleeding: 0|local::at0014|No|
+      gt0032|Total score: 0
+      gt0028|Labile INR: 0|local::at0014|No|
+      gt0027|Prior Major Bleeding or Predisposition to Bleeding: 0|local::at0014|No|
+      gt0025|Liver Disease: 0|local::at0014|No|
+      gt0023|Hypertension History: 0|local::at0014|No|
+      gt0062|Age: 60,a
+

--- a/gdl2/HAS-BLED_Assessment.v1.gdl2.json
+++ b/gdl2/HAS-BLED_Assessment.v1.gdl2.json
@@ -1,0 +1,233 @@
+{
+  "id": "HAS-BLED_Assessment.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2016-02-21",
+      "name": "Syeeda S Farruque",
+      "organisation": "Cambio Healthcare Systems",
+      "email": "models@cambiocds.com"
+    },
+    "other_contributors": [
+      "Dennis Forslund",
+      "Jimmy Axelsson"
+    ],
+    "lifecycle_state": "Author draft",
+    "details": {
+      "sv": {
+        "id": "sv",
+        "purpose": "Att riskvärdera poäng genererad i enlighet med HAS-BLED.",
+        "keywords": [
+          "HAS-BLED",
+          "antikoagulantia",
+          "blödning",
+          "blödningsrisk"
+        ],
+        "use": "Använd för att utvärdering av poäng genererad i enlighet med HAS-BLED, vilken används för att uppskatta blödningsrisk hos antikoagulantia-behandlade patienter med förmaksflimmer.\r\n\r\nTolkning av resultat:\r\n\r\n0p - låg risk (0.6-1.13% blödningsrisk per 100 patientår)\r\n1p - mellanrisk (1.02-1.5% blödningsrisk per 100 patientår)\r\n2p - mellanrisk (1.88-3.2% blödningsrisk per 100 patientår)\r\n≥3p - hög risk (4.9-19.6% blödningsrisk per 100 patientår)",
+        "misuse": "Rekommendationen bör värderas som del i fullständig utredning.",
+        "copyright": "© Cambio Healthcare Systems"
+      },
+      "en": {
+        "id": "en",
+        "purpose": "To assess the HAS-BLED risk interpretation and score categories",
+        "keywords": [
+          "HAS-BLED risk assessment",
+          "anticoagulant",
+          "Haemorrhage",
+          "Bleeding risk"
+        ],
+        "use": "This assessment archetype allows for the categorisation of the HAS-BLED score into the following groups:\r\n\r\nScore of 0: Low Risk (0.6-1.13% risk of bleeding per 100 patient years)\r\nScore of 1: Intermediate risk (1.02-1.5% risk of bleeding per 100 patient years)\r\nScore of 2: Intermediate risk (1.88-3.2% risk of bleeding per 100 patient years)\r\nScore of ≥3: High risk (4.9-19.6% risk of bleeding per 100 patient years)\r\n",
+        "misuse": "The score categories should not be used alone to guide whether to treat with anticoagulants or not but should only constitute part of the assessment.",
+        "copyright": "© Cambio Healthcare Systems"
+      }
+    },
+    "other_details": {
+      "references": "Ref. 1: Pisters R, Lane DA, Nieuwlaat R, et al. A Novel User-Friendly Score (Has-Bled) To Assess 1-Year Risk Of Major Bleeding In Patients With Atrial Fibrillation: The Euro Heart Survey. Chest. 2010;138(5):1093-1100. \r\n\r\nRef. 2: Lip GY, Frison L, Halperin JL, Lane DA. Comparative validation of a novel risk score for predicting bleeding risk in anticoagulated patients with atrial fibrillation: the HAS-BLED (Hypertension, Abnormal Renal/Liver Function, Stroke, Bleeding History or Predisposition, Labile INR, Elderly, Drugs/Alcohol Concomitantly) score. J Am Coll Cardiol. 2011 Jan 11;57(2):173-80. doi: 10.1016/j.jacc.2010.09.024. Epub 2010 Nov 24."
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0002": {
+        "id": "gt0002",
+        "model_id": "openEHR-EHR-OBSERVATION.has_bled.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.has_bled.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0003": {
+            "id": "gt0003",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0013]"
+          }
+        }
+      },
+      "gt0004": {
+        "id": "gt0004",
+        "model_id": "openEHR-EHR-EVALUATION.has_bled_assessment.v1",
+        "template_id": "openEHR-EHR-EVALUATION.has_bled_assessment.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0005": {
+            "id": "gt0005",
+            "path": "/data[at0001]/items[at0002]"
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "path": "/data[at0001]/items[at0014]"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "path": "/data[at0001]/items[at0013]"
+          }
+        }
+      }
+    },
+    "rules": {
+      "gt0008": {
+        "id": "gt0008",
+        "priority": 3,
+        "when": [
+          "$gt0003|Total score|==0"
+        ],
+        "then": [
+          "$gt0005|HAS-BLED Risk assessment|=0|local::at0003|Low risk |",
+          "$gt0006|Percentage Bleeding risk per 100 patient-year|=0|local::at0015|(0.6-1.13%)|",
+          "$gt0007|Recommendation|=0|local::at0018|Anticoagulation should be considered|"
+        ]
+      },
+      "gt0009": {
+        "id": "gt0009",
+        "priority": 2,
+        "when": [
+          "$gt0003|Total score|>=1",
+          "$gt0003|Total score|<=2"
+        ],
+        "then": [
+          "$gt0005|HAS-BLED Risk assessment|=1|local::at0004|Intermediate risk |",
+          "$gt0006|Percentage Bleeding risk per 100 patient-year|=1|local::at0016|(1.02-3.2%)|",
+          "$gt0007|Recommendation|=1|local::at0019|Anticoagulation can be considered|"
+        ]
+      },
+      "gt0010": {
+        "id": "gt0010",
+        "priority": 1,
+        "when": [
+          "$gt0003|Total score|>=3"
+        ],
+        "then": [
+          "$gt0007|Recommendation|=2|local::at0020|Alternatives to anticoagulation should be considered|",
+          "$gt0006|Percentage Bleeding risk per 100 patient-year|=2|local::at0017|(4.9-19.6%) |",
+          "$gt0005|HAS-BLED Risk assessment|=2|local::at0006|High risk |"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "sv": {
+        "id": "sv",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "HAS-BLED utvärdering",
+            "description": "Utvärdering av poäng genererad i enlighet med HAS-BLED, vilken används för att uppskatta blödningsrisk hos antikoagulantia-behandlade patienter med förmaksflimmer."
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "Total poäng",
+            "description": "*(en) sum of individual scores"
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "HAS-BLED riskvärdering",
+            "description": "*(en) Score of 0: Low Risk (0.6-1.13% risk of bleeding per 100 patient years); Score of 1: Intermediate risk (1.02-1.5% risk of bleeding per 100 patient years); Score of 2: Intermediate risk (1.88-3.2% risk of bleeding per 100 patient years); Score of ≥3: High risk (4.9-19.6% risk of bleeding per 100 patient years)"
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Blödningsrisk per 100 patientår",
+            "description": "*(en) Percentage Bleeding risk per 100 patient-years"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Rekommendation",
+            "description": "*(en) Recommendation suggested for risk band. Not to be taken out of context but a part of a more fullsome investigation."
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "CDS blödningsrisk låg"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "CDS blödningsrisk mellan"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "CDS blödningsrisk hög"
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "Total poäng",
+            "description": "*(en) sum of individual scores"
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "*(en) Test eval"
+          }
+        }
+      },
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "HAS-BLED Assessment",
+            "description": "Evaluation of the HAS-BLED bleeding risk score, which estimates risk of major bleeding for patients on anticoagulation for atrial fibrillation"
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "Total score",
+            "description": "sum of individual scores"
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "HAS-BLED Risk assessment",
+            "description": "Score of 0: Low Risk (0.6-1.13% risk of bleeding per 100 patient years); Score of 1: Intermediate risk (1.02-1.5% risk of bleeding per 100 patient years); Score of 2: Intermediate risk (1.88-3.2% risk of bleeding per 100 patient years); Score of ≥3: High risk (4.9-19.6% risk of bleeding per 100 patient years)"
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Percentage Bleeding risk per 100 patient-year",
+            "description": "Percentage Bleeding risk per 100 patient-years"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Recommendation",
+            "description": "Recommendation suggested for risk band. Not to be taken out of context but a part of a more fullsome investigation."
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Set Risk assessment Low risk"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Set Risk assessment Intermediate"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Set Risk assessment High risk"
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "Total score",
+            "description": "sum of individual scores"
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "Test eval"
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/HAS-BLED_Assessment.v1.test.yml
+++ b/gdl2/HAS-BLED_Assessment.v1.test.yml
@@ -1,0 +1,39 @@
+guidelines:
+  1: HAS-BLED_Assessment.v1
+test_cases:
+- id: 0
+  input:
+    1:
+      gt0003|Total score: 0
+  expected_output:
+    1:
+      gt0005|HAS-BLED Risk assessment: 0|local::at0003|Low risk |
+      gt0007|Recommendation: 0|local::at0018|Anticoagulation should be considered|
+      gt0006|Percentage Bleeding risk per 100 patient-year: 0|local::at0015|(0.6-1.13%)|
+- id: 1
+  input:
+    1:
+      gt0003|Total score: 1
+  expected_output:
+    1:
+      gt0005|HAS-BLED Risk assessment: 1|local::at0004|Intermediate risk |
+      gt0007|Recommendation: 1|local::at0019|Anticoagulation can be considered|
+      gt0006|Percentage Bleeding risk per 100 patient-year: 1|local::at0016|(1.02-3.2%)|
+- id: 2
+  input:
+    1:
+      gt0003|Total score: 2
+  expected_output:
+    1:
+      gt0005|HAS-BLED Risk assessment: 1|local::at0004|Intermediate risk |
+      gt0007|Recommendation: 1|local::at0019|Anticoagulation can be considered|
+      gt0006|Percentage Bleeding risk per 100 patient-year: 1|local::at0016|(1.02-3.2%)|
+- id: 3
+  input:
+    1:
+      gt0003|Total score: 3
+  expected_output:
+    1:
+      gt0005|HAS-BLED Risk assessment: 2|local::at0006|High risk |
+      gt0007|Recommendation: 2|local::at0020|Alternatives to anticoagulation should be considered|
+      gt0006|Percentage Bleeding risk per 100 patient-year: 2|local::at0017|(4.9-19.6%) |


### PR DESCRIPTION
HAS-BLED migrated. Many changes, the original file was impossible to open either.
Changes (I remember):
(1) Event time, output -> input
(2) "'Yes' rule not fired" preconditions in "No" rules, since they were not the opposite. Now a condition is true, if any of the precondition is true. This was the intention of the writer, but this should be discussed with experts in the field, since the guideline doesn't say anything about this and I'm not sure, for example, if somebody had alcohol issues previously, but not now, should get an increased score because of that. (2) had to be fixed, since that was the reason the guideline fired the rules thousands of times in GDL1 if not all the conditions were true.
(3): CR is now compared without unit. Since the editor is unable to parse the "micro" sign. That was actually the reason it didn't open.
(4): Age rules modified that they work correctly.