### PR TITLE
Modified SOAR score

### DIFF
--- a/archetypes/openEHR-EHR-EVALUATION.modified_soar_score_for_stroke.v0.adl
+++ b/archetypes/openEHR-EHR-EVALUATION.modified_soar_score_for_stroke.v0.adl
@@ -1,0 +1,138 @@
+archetype (adl_version=1.4)
+	openEHR-EHR-EVALUATION.modified_soar_score_for_stroke.v0
+
+concept
+	[at0000]	-- Modified soar score for stroke
+language
+	original_language = <[ISO_639-1::en]>
+description
+	original_author = <
+		["name"] = <"Jack Msonkho">
+		["email"] = <" models@cambiocds.com">
+		["organisation"] = <"Cambio CDS">
+		["date"] = <"2020-02-29">
+	>
+	details = <
+		["en"] = <
+			language = <[ISO_639-1::en]>
+			purpose = <"Predicts short-term mortality in acute ischemic stroke.">
+			use = <"Patients admitted with acute ischemic or hemorrhagic stroke that have mRS and NIH Stroke Scale assessments.
+
+Can be applied for both ischemic and hemorrhagic stroke.
+Component variables are familiar to most clinicians.
+Can be calculated quickly.
+Does not necessitate a weighting algorithm.
+Can be administered by non-MD personnel.
+Component variables are static over a given hospitalization.
+
+mSOAR can be calculated by adding of the selected points:
+		0 points	1 point		2 points
+Stroke type		Infarct		Hemorrhage	--
+Oxford Community Stroke Project classification	LACS/PACS	POCS		TACS
+Age (years)		≤65		66–85		>85
+Pre-stroke disability (Modified Rankin Score)	0–2		3–4		5
+NIH Stroke Scale Score		0–4		5–10		≥11
+
+LACS, lacunar circulation stroke. PACS, partial anterior circulation stroke. POCS, posterior circulation stroke. TACS, total anterior circulation stroke.
+Facts & Figures
+
+Interpretation:
+
+mSOAR	Inpatient mortality
+0	1.0%
+1	1.0%
+2	1.5%
+3	6.5%
+4	9.2%
+5	19.5%
+6	26.2%
+7	49.2%
+
+From Abdul-Rahim 2016. Scores >7 were not reported.">
+			keywords = <"Ischemic", "Stroke">
+			misuse = <"Do not use in patients with transient ischemic attack, subarachnoid hemorrhage, or subdural hemorrhage.
+
+Does not apply to patients with transient ischemic attack, subarachnoid hemorrhage, or subdural hemorrhage.">
+			copyright = <"@Cambio CDS">
+		>
+	>
+	lifecycle_state = <"0">
+	other_contributors = <>
+	other_details = <
+		["references"] = <"Myint PK, Clark AB, Kwok CS, et al. The SOAR (Stroke subtype, Oxford Community Stroke Project classification, Age, prestroke modified Rankin) score strongly predicts early outcomes in acute stroke. Int J Stroke. 2014;9(3):278-83.
+
+Validation
+Kwok CS, Potter JF, Dalton G, et al. The SOAR stroke score predicts inpatient and 7-day mortality in acute stroke. Stroke. 2013;44(7):2010-2.
+
+Abdul-rahim AH, Quinn TJ, Alder S, et al. Derivation and Validation of a Novel Prognostic Scale (Modified-Stroke Subtype, Oxfordshire Community Stroke Project Classification, Age, and Prestroke Modified Rankin) to Predict Early Mortality in Acute Stroke. Stroke. 2016;47(1):74-9.">
+		["MD5-CAM-1.0.1"] = <"9DFAE88767F2C6EED84ED10138A2F196">
+	>
+
+definition
+	EVALUATION[at0000] matches {	-- Modified soar score for stroke
+		data matches {
+			ITEM_TREE[at0001] matches {	-- Tree
+				items cardinality matches {0..*; unordered} matches {
+					ELEMENT[at0002] occurrences matches {0..1} matches {	-- Inpatient mortality
+						value matches {
+							0|[local::at0003], 	-- 1.0% Inpatient mortality
+							1|[local::at0004], 	-- 1.5% Inpatient mortality
+							2|[local::at0005], 	-- 6.5% Inpatient mortality
+							3|[local::at0006], 	-- 9.2% Inpatient mortality
+							4|[local::at0007], 	-- 19.5% Inpatient mortality
+							5|[local::at0008], 	-- 26.2% Inpatient mortality
+							6|[local::at0009]  	-- 49.2% Inpatient mortality
+						}
+					}
+				}
+			}
+		}
+	}
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"Modified soar score for stroke">
+					description = <"The SOAR Score was originally derived by Myint et al in a UK-based prospectively-collected analysis from 2013 that investigated whether 4 static variables at presentation (stroke type, age, premorbid functional status, and Oxfordshire Community Stroke Project (OCSP) classification) accurately predicted early mortality">
+				>
+				["at0001"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0002"] = <
+					text = <"Inpatient mortality">
+					description = <"*">
+				>
+				["at0003"] = <
+					text = <"1.0% Inpatient mortality">
+					description = <"*">
+				>
+				["at0004"] = <
+					text = <"1.5% Inpatient mortality">
+					description = <"*">
+				>
+				["at0005"] = <
+					text = <"6.5% Inpatient mortality">
+					description = <"*">
+				>
+				["at0006"] = <
+					text = <"9.2% Inpatient mortality">
+					description = <"*">
+				>
+				["at0007"] = <
+					text = <"19.5% Inpatient mortality">
+					description = <"*">
+				>
+				["at0008"] = <
+					text = <"26.2% Inpatient mortality">
+					description = <"*">
+				>
+				["at0009"] = <
+					text = <"49.2% Inpatient mortality">
+					description = <"*">
+				>
+			>
+		>
+	>

--- a/archetypes/openEHR-EHR-OBSERVATION.modified_soar_score_for_stroke.v0.adl
+++ b/archetypes/openEHR-EHR-OBSERVATION.modified_soar_score_for_stroke.v0.adl
@@ -1,0 +1,230 @@
+archetype (adl_version=1.4)
+	openEHR-EHR-OBSERVATION.modified_soar_score_for_stroke.v0
+
+concept
+	[at0000]	-- Modified soar score for stroke
+language
+	original_language = <[ISO_639-1::en]>
+description
+	original_author = <
+		["name"] = <"Jack Msonhko">
+		["email"] = <" models@cambiocds.com">
+		["organisation"] = <"Cambio CDS">
+		["date"] = <"2020-02-29">
+	>
+	details = <
+		["en"] = <
+			language = <[ISO_639-1::en]>
+			purpose = <"Predicts short-term mortality in acute ischemic stroke.">
+			use = <"Patients admitted with acute ischemic or hemorrhagic stroke that have mRS and NIH Stroke Scale assessments.
+
+Can be applied for both ischemic and hemorrhagic stroke.
+Component variables are familiar to most clinicians.
+Can be calculated quickly.
+Does not necessitate a weighting algorithm.
+Can be administered by non-MD personnel.
+Component variables are static over a given hospitalization.
+
+mSOAR can be calculated by adding of the selected points:
+		0 points	1 point		2 points
+Stroke type		Infarct		Hemorrhage	--
+Oxford Community Stroke Project classification	LACS/PACS	POCS		TACS
+Age (years)		≤65		66–85		>85
+Pre-stroke disability (Modified Rankin Score)	0–2		3–4		5
+NIH Stroke Scale Score		0–4		5–10		≥11
+
+LACS, lacunar circulation stroke. PACS, partial anterior circulation stroke. POCS, posterior circulation stroke. TACS, total anterior circulation stroke.
+Facts & Figures
+
+Interpretation:
+
+mSOAR	Inpatient mortality
+0	1.0%
+1	1.0%
+2	1.5%
+3	6.5%
+4	9.2%
+5	19.5%
+6	26.2%
+7	49.2%
+
+From Abdul-Rahim 2016. Scores >7 were not reported.">
+			keywords = <"ischemic", "Stroke">
+			misuse = <"Do not use in patients with transient ischemic attack, subarachnoid hemorrhage, or subdural hemorrhage.
+
+Does not apply to patients with transient ischemic attack, subarachnoid hemorrhage, or subdural hemorrhage.">
+			copyright = <"@Cambio CDS">
+		>
+	>
+	lifecycle_state = <"0">
+	other_contributors = <>
+	other_details = <
+		["references"] = <"Myint PK, Clark AB, Kwok CS, et al. The SOAR (Stroke subtype, Oxford Community Stroke Project classification, Age, prestroke modified Rankin) score strongly predicts early outcomes in acute stroke. Int J Stroke. 2014;9(3):278-83.
+
+Validation
+Kwok CS, Potter JF, Dalton G, et al. The SOAR stroke score predicts inpatient and 7-day mortality in acute stroke. Stroke. 2013;44(7):2010-2.
+
+Abdul-rahim AH, Quinn TJ, Alder S, et al. Derivation and Validation of a Novel Prognostic Scale (Modified-Stroke Subtype, Oxfordshire Community Stroke Project Classification, Age, and Prestroke Modified Rankin) to Predict Early Mortality in Acute Stroke. Stroke. 2016;47(1):74-9.">
+		["MD5-CAM-1.0.1"] = <"2297E27AD86A60E2E3A6EDDAB7735DA1">
+	>
+
+definition
+	OBSERVATION[at0000] matches {	-- Modified soar score for stroke
+		data matches {
+			HISTORY[at0001] matches {	-- Event Series
+				events cardinality matches {1..*; unordered} matches {
+					EVENT[at0002] occurrences matches {0..1} matches {	-- Any event
+						data matches {
+							ITEM_TREE[at0003] matches {	-- Tree
+								items cardinality matches {0..*; unordered} matches {
+									ELEMENT[at0004] occurrences matches {0..1} matches {	-- Stroke type
+										value matches {
+											0|[local::at0005], 	-- Infarct
+											1|[local::at0006]  	-- Hermorrage
+										}
+									}
+									ELEMENT[at0007] occurrences matches {0..1} matches {	-- Oxfordshire Community Stroke Project classification
+										value matches {
+											0|[local::at0008], 	-- LACS/PACS
+											1|[local::at0009], 	-- POCS
+											2|[local::at0010]  	-- TACS
+										}
+									}
+									ELEMENT[at0011] occurrences matches {0..1} matches {	-- Age
+										value matches {
+											0|[local::at0012], 	-- ≤65
+											1|[local::at0013], 	-- 66–85
+											2|[local::at0015]  	-- >85
+										}
+									}
+									ELEMENT[at0014] occurrences matches {0..1} matches {	-- Pre-stroke disability (Modified Rankin Score)
+										value matches {
+											0|[local::at0016], 	-- 0–2
+											1|[local::at0017], 	-- 3–4
+											2|[local::at0018]  	-- 5
+										}
+									}
+									ELEMENT[at0019] occurrences matches {0..1} matches {	-- NIH Stroke Scale Score
+										value matches {
+											0|[local::at0020], 	-- 0-4
+											1|[local::at0021], 	-- 5-10
+											2|[local::at0022]  	-- ≥11
+										}
+									}
+									ELEMENT[at0024] occurrences matches {0..1} matches {	-- Total Score
+										value matches {
+											DV_COUNT matches {*}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"Modified soar score for stroke">
+					description = <"The SOAR Score was originally derived by Myint et al in a UK-based prospectively-collected analysis from 2013 that investigated whether 4 static variables at presentation (stroke type, age, premorbid functional status, and Oxfordshire Community Stroke Project (OCSP) classification) accurately predicted early mortality">
+				>
+				["at0001"] = <
+					text = <"Event Series">
+					description = <"@ internal @">
+				>
+				["at0002"] = <
+					text = <"Any event">
+					description = <"*">
+				>
+				["at0003"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0004"] = <
+					text = <"Stroke type">
+					description = <"*">
+				>
+				["at0005"] = <
+					text = <"Infarct">
+					description = <"*">
+				>
+				["at0006"] = <
+					text = <"Hermorrage">
+					description = <"*">
+				>
+				["at0007"] = <
+					text = <"Oxfordshire Community Stroke Project classification">
+					description = <"*">
+				>
+				["at0008"] = <
+					text = <"LACS/PACS">
+					description = <"*">
+				>
+				["at0009"] = <
+					text = <"POCS">
+					description = <"*">
+				>
+				["at0010"] = <
+					text = <"TACS">
+					description = <"*">
+				>
+				["at0011"] = <
+					text = <"Age">
+					description = <"*">
+				>
+				["at0012"] = <
+					text = <"≤65">
+					description = <"*">
+				>
+				["at0013"] = <
+					text = <"66–85">
+					description = <"*">
+				>
+				["at0014"] = <
+					text = <"Pre-stroke disability (Modified Rankin Score)">
+					description = <"*">
+				>
+				["at0015"] = <
+					text = <">85">
+					description = <"*">
+				>
+				["at0016"] = <
+					text = <"0–2">
+					description = <"*">
+				>
+				["at0017"] = <
+					text = <"3–4">
+					description = <"*">
+				>
+				["at0018"] = <
+					text = <"5">
+					description = <"*">
+				>
+				["at0019"] = <
+					text = <"NIH Stroke Scale Score">
+					description = <"*">
+				>
+				["at0020"] = <
+					text = <"0-4">
+					description = <"*">
+				>
+				["at0021"] = <
+					text = <"5-10">
+					description = <"*">
+				>
+				["at0022"] = <
+					text = <"≥11">
+					description = <"*">
+				>
+				["at0024"] = <
+					text = <"Total Score">
+					description = <"*">
+				>
+			>
+		>
+	>

--- a/gdl2/Modified_SOAR_Score_for_Stroke.v1.gdl2.json
+++ b/gdl2/Modified_SOAR_Score_for_Stroke.v1.gdl2.json
@@ -1,0 +1,264 @@
+{
+  "id": "Modified_SOAR_Score_for_Stroke.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2020-02-29",
+      "name": "Jack MSonkho",
+      "organisation": "Cambio CDS",
+      "email": "models@cambiocds.com"
+    },
+    "lifecycle_state": "Not set",
+    "details": {
+      "en": {
+        "id": "en",
+        "purpose": "Predicts short-term mortality in acute ischemic stroke.",
+        "use": "Patients admitted with acute ischemic or hemorrhagic stroke that have mRS and NIH Stroke Scale assessments.\n\nCan be applied for both ischemic and hemorrhagic stroke.\nComponent variables are familiar to most clinicians.\nCan be calculated quickly.\nDoes not necessitate a weighting algorithm.\nCan be administered by non-MD personnel.\nComponent variables are static over a given hospitalization.\n\nmSOAR can be calculated by adding of the selected points:\n\t\t\t\t\t\t\t\t\t\t0 points\t\t1 point\t\t2 points\nStroke type\t\t\t\t\t\t\t\tInfarct\t\tHemorrhage\t--\nOxford Community Stroke Project classification\tLACS/PACS\tPOCS\t\tTACS\nAge (years)\t\t\t\t\t\t\t\t≤65\t\t\t66–85\t\t>85\nPre-stroke disability (Modified Rankin Score)\t\t0–2\t\t\t3–4\t\t\t5\nNIH Stroke Scale Score\t\t\t\t\t\t0–4\t\t\t5–10\t\t≥11\n\nLACS, lacunar circulation stroke. PACS, partial anterior circulation stroke. POCS, posterior circulation stroke. TACS, total anterior circulation stroke.\nFacts & Figures\n\nInterpretation:\n\nmSOAR\tInpatient mortality\n0\t\t1.0%\n1\t\t1.0%\n2\t\t1.5%\n3\t\t6.5%\n4\t\t9.2%\n5\t\t19.5%\n6\t\t26.2%\n7\t\t49.2%\n\nFrom Abdul-Rahim 2016. Scores >7 were not reported.",
+        "misuse": "Do not use in patients with transient ischemic attack, subarachnoid hemorrhage, or subdural hemorrhage.\n\nDoes not apply to patients with transient ischemic attack, subarachnoid hemorrhage, or subdural hemorrhage.\n",
+        "copyright": "@Cambio CDS"
+      }
+    },
+    "other_details": {
+      "references": "Myint PK, Clark AB, Kwok CS, et al. The SOAR (Stroke subtype, Oxford Community Stroke Project classification, Age, prestroke modified Rankin) score strongly predicts early outcomes in acute stroke. Int J Stroke. 2014;9(3):278-83.\n\nValidation\nKwok CS, Potter JF, Dalton G, et al. The SOAR stroke score predicts inpatient and 7-day mortality in acute stroke. Stroke. 2013;44(7):2010-2.\n\nAbdul-rahim AH, Quinn TJ, Alder S, et al. Derivation and Validation of a Novel Prognostic Scale (Modified-Stroke Subtype, Oxfordshire Community Stroke Project Classification, Age, and Prestroke Modified Rankin) to Predict Early Mortality in Acute Stroke. Stroke. 2016;47(1):74-9."
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0002": {
+        "id": "gt0002",
+        "model_id": "openEHR-EHR-OBSERVATION.modified_soar_score_for_stroke.v0",
+        "template_id": "openEHR-EHR-OBSERVATION.modified_soar_score_for_stroke.v0",
+        "type": "INPUT",
+        "elements": {
+          "gt0003": {
+            "id": "gt0003",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0007]"
+          },
+          "gt0004": {
+            "id": "gt0004",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0011]"
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0014]"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0004]"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0019]"
+          }
+        }
+      },
+      "gt0009": {
+        "id": "gt0009",
+        "model_id": "openEHR-EHR-EVALUATION.modified_soar_score_for_stroke.v0",
+        "template_id": "openEHR-EHR-EVALUATION.modified_soar_score_for_stroke.v0",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0010": {
+            "id": "gt0010",
+            "path": "/data[at0001]/items[at0002]"
+          }
+        }
+      },
+      "gt0012": {
+        "id": "gt0012",
+        "model_id": "openEHR-EHR-OBSERVATION.modified_soar_score_for_stroke.v0",
+        "template_id": "openEHR-EHR-OBSERVATION.modified_soar_score_for_stroke.v0",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0013": {
+            "id": "gt0013",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0024]"
+          }
+        }
+      }
+    },
+    "rules": {
+      "gt0014": {
+        "id": "gt0014",
+        "priority": 8,
+        "when": [
+          "$gt0003|Oxfordshire Community Stroke Project classification|!=null",
+          "$gt0004|Age|!=null",
+          "$gt0006|Pre-stroke disability (Modified Rankin Score)|!=null",
+          "$gt0008|NIH Stroke Scale Score|!=null",
+          "$gt0007|Stroke type|!=null"
+        ],
+        "then": [
+          "$gt0013|Total Score|.magnitude=$gt0003.value+$gt0004.value+$gt0006.value+$gt0007.value+$gt0008.value"
+        ]
+      },
+      "gt0015": {
+        "id": "gt0015",
+        "priority": 7,
+        "when": [
+          "$gt0013|Total Score|!=null",
+          "$gt0013|Total Score|<=1"
+        ],
+        "then": [
+          "$gt0010|Inpatient mortality|=0|local::at0003|1.0% Inpatient mortality|"
+        ]
+      },
+      "gt0016": {
+        "id": "gt0016",
+        "priority": 6,
+        "when": [
+          "$gt0013|Total Score|!=null",
+          "$gt0013|Total Score|==2"
+        ],
+        "then": [
+          "$gt0010|Inpatient mortality|=1|local::at0004|1.5% Inpatient mortality|"
+        ]
+      },
+      "gt0017": {
+        "id": "gt0017",
+        "priority": 5,
+        "when": [
+          "$gt0013|Total Score|!=null",
+          "$gt0013|Total Score|==3"
+        ],
+        "then": [
+          "$gt0010|Inpatient mortality|=2|local::at0005|6.5% Inpatient mortality|"
+        ]
+      },
+      "gt0018": {
+        "id": "gt0018",
+        "priority": 4,
+        "when": [
+          "$gt0013|Total Score|!=null",
+          "$gt0013|Total Score|==4"
+        ],
+        "then": [
+          "$gt0010|Inpatient mortality|=3|local::at0006|9.2% Inpatient mortality|"
+        ]
+      },
+      "gt0019": {
+        "id": "gt0019",
+        "priority": 3,
+        "when": [
+          "$gt0013|Total Score|!=null",
+          "$gt0013|Total Score|==5"
+        ],
+        "then": [
+          "$gt0010|Inpatient mortality|=4|local::at0007|19.5% Inpatient mortality|"
+        ]
+      },
+      "gt0020": {
+        "id": "gt0020",
+        "priority": 2,
+        "when": [
+          "$gt0013|Total Score|!=null",
+          "$gt0013|Total Score|==6"
+        ],
+        "then": [
+          "$gt0010|Inpatient mortality|=5|local::at0008|26.2% Inpatient mortality|"
+        ]
+      },
+      "gt0021": {
+        "id": "gt0021",
+        "priority": 1,
+        "when": [
+          "$gt0013|Total Score|!=null",
+          "$gt0013|Total Score|>=7"
+        ],
+        "then": [
+          "$gt0010|Inpatient mortality|=6|local::at0009|49.2% Inpatient mortality|"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Modified SOAR Score for Stroke",
+            "description": "The SOAR Score was originally derived by Myint et al in a UK-based prospectively-collected analysis from 2013 that investigated whether 4 static variables at presentation (stroke type, age, premorbid functional status, and Oxfordshire Community Stroke Project (OCSP) classification) accurately predicted early mortality"
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "Oxfordshire Community Stroke Project classification",
+            "description": "*"
+          },
+          "gt0004": {
+            "id": "gt0004",
+            "text": "Age",
+            "description": "*"
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Total Score",
+            "description": "*"
+          },
+          "gt0006": {
+            "id": "gt0006",
+            "text": "Pre-stroke disability (Modified Rankin Score)",
+            "description": "*"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Stroke type",
+            "description": "*"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "NIH Stroke Scale Score",
+            "description": "*"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Inpatient mortality",
+            "description": "*"
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "Total Score",
+            "description": "*"
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "Total Score"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "Inpatient Mortality 1.0%"
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "Inpatient Mortality 1.5%"
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "text": "Inpatient Mortality 6.5%"
+          },
+          "gt0018": {
+            "id": "gt0018",
+            "text": "Inpatient Mortality 9.2%"
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "text": "Inpatient Mortality 19.5%"
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "Inpatient Mortality 26.2%"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "text": "Inpatient Mortality 49.2%"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Based on Jack's work with the following modifications:
-Added a description, how to calculate the score (both in the archetypes and in the guideline)
-Deleted the unnecessary Total score from the OBSERVATION archetype (in fact there were two, and only one is needed)
-Added Element existence conditions (for Total score) in the rules calculating inpatient mortality.