### PR TITLE
REVEAL Registry Risk Score For Pulmonary Arterial Hypertension (PAH)

### DIFF
--- a/archetypes/openEHR-EHR-EVALUATION.reveal_registry_risk_score_for_pulmonary_arterial_hypertension.v1.adl
+++ b/archetypes/openEHR-EHR-EVALUATION.reveal_registry_risk_score_for_pulmonary_arterial_hypertension.v1.adl
@@ -25,7 +25,7 @@ WHO group 1 subgroup      Associated PAH-connective tissue disease              
                                                       Others                                                                                  0
 Renal insufficiency                    Yes                                                                                         1
                                                       No                                                                                          0
-Male age>60                               Yes                                                                                        1
+Male age>60                               Yes                                                                                        2
                                                       No                                                                                          0
 NYHA/WHO functional Class    I                                                                                             -2
                                                        II                                                                                            0
@@ -72,7 +72,7 @@ REVEAL Score           Risk Group             1-year predicted survival
 	lifecycle_state = <"AuthorDraft">
 	other_contributors = <>
 	other_details = <
-		["MD5-CAM-1.0.1"] = <"6BD14C1C08FD985431DC60C3BA11BDF0">
+		["licence"] = <"@CambioCDS">
 		["references"] = <"1. Benza RL, Gomberg-Maitland M, Miller DP, Frost A, Frantz RP, Foreman AJ, et al. The REVEAL Registry risk score calculator in patients newly diagnosed with pulmonary arterial hypertension. Chest. 2012 Feb;141(2):354–62. 
 
 2. Sitbon O, Benza RL, Badesch DB, Barst RJ, Elliott CG, Gressin V, et al. Validation of two predictive models for survival in pulmonary arterial hypertension. European Respiratory Journal. 2015 Jul 1;46(1):152–64. 
@@ -80,7 +80,7 @@ REVEAL Score           Risk Group             1-year predicted survival
 3. Benza RL, Farber HW, Frost A, Grünig E, Hoeper MM, Busse D, et al. REVEAL risk score in patients with chronic thromboembolic pulmonary hypertension receiving riociguat. J Heart Lung Transplant. 2018;37(7):836–43. 
 
 ">
-		["licence"] = <"@CambioCDS">
+		["MD5-CAM-1.0.1"] = <"6BD14C1C08FD985431DC60C3BA11BDF0">
 	>
 
 definition

--- a/archetypes/openEHR-EHR-EVALUATION.reveal_registry_risk_score_for_pulmonary_arterial_hypertension.v1.adl
+++ b/archetypes/openEHR-EHR-EVALUATION.reveal_registry_risk_score_for_pulmonary_arterial_hypertension.v1.adl
@@ -1,0 +1,176 @@
+archetype (adl_version=1.4)
+	openEHR-EHR-EVALUATION.reveal_registry_risk_score_for_pulmonary_arterial_hypertension.v1
+
+concept
+	[at0000]	-- Reveal registry risk score for pulmonary arterial hypertension
+language
+	original_language = <[ISO_639-1::en]>
+description
+	original_author = <
+		["name"] = <"Rashmi Damodaran">
+		["email"] = <"rashmidamu@gmail.com">
+		["organisation"] = <"Cambio CDS">
+		["date"] = <"2020-04-16">
+	>
+	details = <
+		["en"] = <
+			language = <[ISO_639-1::en]>
+			purpose = <"The purpose stratify the patients to different risk groups and predict the 1-year survival in patients with PAH based on the calculated REVEAL Registry Risk Score.">
+			use = <"It is a simplified calculator used to calculate the REVEAL Score and predict the 1-year survival in patients with PAH. 
+REVEAL Score is obtained adding the selected points of the 12 variables + 6. 
+Variables                                                                                                                              Points
+WHO group 1 subgroup      Associated PAH-connective tissue disease                         1
+                                                      Associated PAH-portopulmonary hypertension           2
+                                                      Familial PAH                                                                        2
+                                                      Others                                                                                  0
+Renal insufficiency                    Yes                                                                                         1
+                                                      No                                                                                          0
+Male age>60                               Yes                                                                                        1
+                                                      No                                                                                          0
+NYHA/WHO functional Class    I                                                                                             -2
+                                                       II                                                                                            0
+                                                       III                                                                                            1
+                                                       IV                                                                                            2
+Systolic BP                                   >=110 mmHg                                                                       0
+                                                      < 110mmHg                                                                          1
+Heart Rate                                   <=92/min                                                                              0
+                                                  >92/min                                                                                    1
+6-min walk test                      >=440m                                                                                     -1
+                                             165 – 440m                                                                                   0
+                                                   <165m                                                                                       1
+BNP, pg/ml                             <50                                                                                           -2
+                                              50-180                                                                                           0
+                                                    >180                                                                                          1
+N-terminal proBNP                   <300                                                                                       -2 
+(BNP not available)                 300-1500                                                                                    0
+                                                     >1500                                                                                       1
+Pericardial effusion on           Yes                                                                                              1
+Echocardiogram                         No                                                                                             0
+DLCO on Pulmonary              >=80%                                                                                         -1
+ Function Test                       33-79%                                                                                            0
+                                                  <=32%                                                                                          1
+Mean right atrial pressure            Yes                                                                                          1 
+>20 mmHg within 1 year             No                                                                                          0
+on right heart catheterization
+Pulmonary vascular resistance   Yes                                                                                         2
+ >32 Wood units on                      No                                                                                         0
+right heart catheterization
+
+Interpretation of REVEAL Score
+REVEAL Score           Risk Group             1-year predicted survival
+0-7                                 Low                           >=95%
+8                                   Average                     90% - <95%
+9                                  Moderate                  85% - <90%
+10-11                           High                            70% - <85%
+>=12                            Very high                     <70%           
+">
+			keywords = <"Pulmonary Arterial Hypertension", "PAH", "REVEAL Risk Score", "PAH survival prediction">
+			misuse = <"The REVEAL score can help to decide therapeutic strategies but has not been evaluated as a tool to monitor treatment response">
+			copyright = <"@CambioCDS">
+		>
+	>
+	lifecycle_state = <"AuthorDraft">
+	other_contributors = <>
+	other_details = <
+		["MD5-CAM-1.0.1"] = <"6BD14C1C08FD985431DC60C3BA11BDF0">
+		["references"] = <"1. Benza RL, Gomberg-Maitland M, Miller DP, Frost A, Frantz RP, Foreman AJ, et al. The REVEAL Registry risk score calculator in patients newly diagnosed with pulmonary arterial hypertension. Chest. 2012 Feb;141(2):354–62. 
+
+2. Sitbon O, Benza RL, Badesch DB, Barst RJ, Elliott CG, Gressin V, et al. Validation of two predictive models for survival in pulmonary arterial hypertension. European Respiratory Journal. 2015 Jul 1;46(1):152–64. 
+
+3. Benza RL, Farber HW, Frost A, Grünig E, Hoeper MM, Busse D, et al. REVEAL risk score in patients with chronic thromboembolic pulmonary hypertension receiving riociguat. J Heart Lung Transplant. 2018;37(7):836–43. 
+
+">
+		["licence"] = <"@CambioCDS">
+	>
+
+definition
+	EVALUATION[at0000] matches {	-- Reveal registry risk score for pulmonary arterial hypertension
+		data matches {
+			ITEM_TREE[at0001] matches {	-- Tree
+				items cardinality matches {0..*; unordered} matches {
+					ELEMENT[at0002] occurrences matches {0..1} matches {	-- Risk group
+						value matches {
+							0|[local::at0003], 	-- Low-Risk
+							1|[local::at0004], 	-- Average-Risk
+							2|[local::at0005], 	-- Moderate-Risk
+							3|[local::at0006], 	-- High-Risk
+							4|[local::at0007]  	-- Very high-Risk 
+						}
+					}
+					ELEMENT[at0008] occurrences matches {0..1} matches {	-- Predicted 1-year survival
+						value matches {
+							0|[local::at0009], 	-- ≥95%
+							1|[local::at0010], 	-- 90% to <95%
+							2|[local::at0011], 	-- 85% to <90%
+							3|[local::at0012], 	-- 70% - <85%
+							4|[local::at0013]  	-- <70%
+						}
+					}
+				}
+			}
+		}
+	}
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"Reveal registry risk score for pulmonary arterial hypertension">
+					description = <"REVEAL Registry (Registry for Evaluation of Early and Long-term PAH disease management) Risk Score predicts survival in patients with PAH which is important for optimizing therapeutic strategies.">
+				>
+				["at0001"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0002"] = <
+					text = <"Risk group">
+					description = <"Patients are stratified to different risk  groups based on the REVEAL Score">
+				>
+				["at0003"] = <
+					text = <"Low-Risk">
+					description = <"REVEAL Score 0-7">
+				>
+				["at0004"] = <
+					text = <"Average-Risk">
+					description = <"REVEAL Score - 8">
+				>
+				["at0005"] = <
+					text = <"Moderate-Risk">
+					description = <"REVEAL Score - 9">
+				>
+				["at0006"] = <
+					text = <"High-Risk">
+					description = <"REVEAL Score 10 - 11">
+				>
+				["at0007"] = <
+					text = <"Very high-Risk ">
+					description = <"REVEAL Score >=12">
+				>
+				["at0008"] = <
+					text = <"Predicted 1-year survival">
+					description = <"Predicted 1-year survival in patients diagnosed with PAH based on the REVEAL Score">
+				>
+				["at0009"] = <
+					text = <"≥95%">
+					description = <"REVEAL Score is 0-7">
+				>
+				["at0010"] = <
+					text = <"90% to <95%">
+					description = <"REVEAL Score is 8">
+				>
+				["at0011"] = <
+					text = <"85% to <90%">
+					description = <"REVEAL Score is 9">
+				>
+				["at0012"] = <
+					text = <"70% - <85%">
+					description = <"REVEAL Score is 10-11">
+				>
+				["at0013"] = <
+					text = <"<70%">
+					description = <"REVEAL Score is >=12">
+				>
+			>
+		>
+	>

--- a/archetypes/openEHR-EHR-OBSERVATION.reveal_registry_risk_score_for_pulmonary_arterial_hypertension.v1.adl
+++ b/archetypes/openEHR-EHR-OBSERVATION.reveal_registry_risk_score_for_pulmonary_arterial_hypertension.v1.adl
@@ -1,0 +1,426 @@
+archetype (adl_version=1.4)
+	openEHR-EHR-OBSERVATION.reveal_registry_risk_score_for_pulmonary_arterial_hypertension.v1
+
+concept
+	[at0000]	-- Reveal registry risk score for pulmonary arterial hypertension
+language
+	original_language = <[ISO_639-1::en]>
+description
+	original_author = <
+		["name"] = <"Rashmi Damodaran">
+		["email"] = <"rashmidamu@gmail.com">
+		["organisation"] = <"Cambio CDS">
+		["date"] = <"2020-04-16">
+	>
+	details = <
+		["en"] = <
+			language = <[ISO_639-1::en]>
+			purpose = <"The purpose is to calculate REVEAL Score and accordingly stratify the patients to different risk groups and predict the 1-year survival in patients with PAH.">
+			use = <"It is a simplified calculator used to calculate the REVEAL Score and predict the 1-year survival in patients with PAH. 
+REVEAL Score is obtained adding the selected points of the 12 variables + 6. 
+Variables                                                                                                Points
+WHO group 1 subgroup                                  Associated PAH-connective tissue disease              1
+                                                      Associated PAH-portopulmonary hypertension            2
+                                                      Familial PAH                                          2
+                                                      Others                                                0
+Renal insufficiency                                    Yes                                                  1
+                                                        No                                                  0
+Male age>60                                            Yes                                                  1
+                                                        No                                                  0
+NYHA/WHO functional Class                               I                                                  -2
+                                                        II                                                  0
+                                                       III                                                  1
+                                                       IV                                                   2
+Systolic BP                                            >=110 mmHg                                           0
+                                                      < 110mmHg                                             1
+Heart Rate                                             <=92/min                                             0
+                                                        >92/min                                             1
+6-min walk test                                         >=440m                                             -1
+                                                       165 – 440m                                           0
+                                                        <165m                                               1
+BNP, pg/ml                                              <50                                                 -2
+                                                         50-180                                             0
+                                                         >180                                               1
+N-terminal proBNP                                        <300                                               2 
+(BNP not available)                                    300-1500                                             0
+                                                        >1500                                               1
+Pericardial effusion on                                    Yes                                              1
+Echocardiogram                                             No                                               0
+DLCO on Pulmonary                                          >=80%                                            -1
+ Function Test                                            33-79%                                            0
+                                                          <=32%                                             1
+Mean right atrial pressure                                 Yes                                              1 
+>20 mmHg within 1 year                                      No                                              0
+on right heart catheterization
+Pulmonary vascular resistance                               Yes                                             2
+ >32 Wood units on                                          No                                              0
+right heart catheterization
+
+Interpretation of REVEAL Score
+REVEAL Score           Risk Group             1-year predicted survival
+0-7                                 Low                           >=95%
+8                                   Average                     90% - <95%
+9                                  Moderate                  85% - <90%
+10-11                           High                            70% - <85%
+>=12                            Very high                     <70%           
+">
+			keywords = <"Pulmonary Arterial Hypertension", "PAH", "REVEAL Score", "REVEAL Registry Risk score">
+			misuse = <"The REVEAL score can help to decide therapeutic strategies but has not been evaluated as a tool to monitor treatment response">
+			copyright = <"@CambioCDS">
+		>
+	>
+	lifecycle_state = <"AuthorDraft">
+	other_contributors = <>
+	other_details = <
+		["MD5-CAM-1.0.1"] = <"2321FF7246DB0150BD4B958766C76288">
+		["references"] = <"1. Benza RL, Gomberg-Maitland M, Miller DP, Frost A, Frantz RP, Foreman AJ, et al. The REVEAL Registry risk score calculator in patients newly diagnosed with pulmonary arterial hypertension. Chest. 2012 Feb;141(2):354–62. 
+
+2. Sitbon O, Benza RL, Badesch DB, Barst RJ, Elliott CG, Gressin V, et al. Validation of two predictive models for survival in pulmonary arterial hypertension. European Respiratory Journal. 2015 Jul 1;46(1):152–64. 
+
+3. Benza RL, Farber HW, Frost A, Grünig E, Hoeper MM, Busse D, et al. REVEAL risk score in patients with chronic thromboembolic pulmonary hypertension receiving riociguat. J Heart Lung Transplant. 2018;37(7):836–43. 
+
+">
+		["licence"] = <"@CambioCDS">
+	>
+
+definition
+	OBSERVATION[at0000] matches {	-- Reveal registry risk score for pulmonary arterial hypertension
+		data matches {
+			HISTORY[at0001] matches {	-- Event Series
+				events cardinality matches {1..*; unordered} matches {
+					EVENT[at0002] occurrences matches {0..1} matches {	-- Any event
+						data matches {
+							ITEM_TREE[at0003] matches {	-- Tree
+								items cardinality matches {0..*; unordered} matches {
+									ELEMENT[at0005] occurrences matches {0..1} matches {	-- WHO group 1 subgroup
+										value matches {
+											0|[local::at0009], 	-- Other
+											1|[local::at0006], 	-- Associated PAH-connective tissue disease
+											2|[local::at0007], 	-- Associated PAH-portopulmonary hypertension
+											2|[local::at0008]  	-- Familial PAH
+										}
+									}
+									ELEMENT[at0010] occurrences matches {0..1} matches {	-- Renal insufficiency
+										value matches {
+											0|[local::at0011], 	-- No
+											1|[local::at0012]  	-- Yes
+										}
+									}
+									ELEMENT[at0013] occurrences matches {0..1} matches {	-- Male age >60 years
+										value matches {
+											0|[local::at0014], 	-- No
+											2|[local::at0015]  	-- Yes
+										}
+									}
+									ELEMENT[at0016] occurrences matches {0..1} matches {	-- NYHA/WHO functional class
+										value matches {
+											-2|[local::at0017], 	-- I
+											0|[local::at0018], 	-- II
+											1|[local::at0019], 	-- III
+											2|[local::at0020]  	-- IV
+										}
+									}
+									ELEMENT[at0021] occurrences matches {0..1} matches {	-- Systolic BP, mmHg
+										value matches {
+											0|[local::at0022], 	-- >=110 mmHg
+											1|[local::at0023]  	-- < 110mmHg
+										}
+									}
+									ELEMENT[at0024] occurrences matches {0..1} matches {	-- Heart rate, bpm
+										value matches {
+											0|[local::at0025], 	-- <=92
+											1|[local::at0026]  	-- > 92
+										}
+									}
+									ELEMENT[at0027] occurrences matches {0..1} matches {	-- 6-minute walk test
+										value matches {
+											-1|[local::at0028], 	-- ≥440 m
+											0|[local::at0029], 	-- 165-440 m
+											1|[local::at0030]  	-- <165 m
+										}
+									}
+									ELEMENT[at0031] occurrences matches {0..1} matches {	-- BNP, pg/mL
+										value matches {
+											-2|[local::at0032], 	-- <50 
+											0|[local::at0033], 	-- 50 - 180 
+											1|[local::at0034]  	-- >180
+										}
+									}
+									ELEMENT[at0035] occurrences matches {0..1} matches {	-- N-terminal proBNP
+										value matches {
+											-2|[local::at0036], 	-- <300
+											0|[local::at0037], 	-- 300 - 1500 
+											1|[local::at0038]  	-- > 1500
+										}
+									}
+									ELEMENT[at0039] occurrences matches {0..1} matches {	-- Pericardial effusion on echocardiogram
+										value matches {
+											0|[local::at0040], 	-- No
+											1|[local::at0041]  	-- Yes
+										}
+									}
+									ELEMENT[at0042] occurrences matches {0..1} matches {	-- DLCO on pulmonary function test
+										value matches {
+											-1|[local::at0043], 	-- ≥80%
+											0|[local::at0044], 	-- 33-79%
+											1|[local::at0045]  	-- ≤32%
+										}
+									}
+									ELEMENT[at0046] occurrences matches {0..1} matches {	-- Mean right atrial pressure >20 mmHg within 1 year on right heart catheterization
+										value matches {
+											0|[local::at0047], 	-- No
+											1|[local::at0048]  	-- Yes
+										}
+									}
+									ELEMENT[at0049] occurrences matches {0..1} matches {	-- Pulmonary vascular resistance >32 Wood units on right heart catheterization
+										value matches {
+											0|[local::at0050], 	-- No
+											2|[local::at0051]  	-- Yes
+										}
+									}
+									ELEMENT[at0053] occurrences matches {0..1} matches {	-- Total Score
+										value matches {
+											DV_COUNT matches {
+												magnitude matches {|0..22|}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		protocol matches {
+			ITEM_TREE[at0004] matches {*}
+		}
+	}
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"Reveal registry risk score for pulmonary arterial hypertension">
+					description = <"REVEAL Registry (Registry for Evaluation of Early and Long-term PAH disease management) Risk Score predicts survival in patients with PAH which is important for optimizing therapeutic strategies.">
+				>
+				["at0001"] = <
+					text = <"Event Series">
+					description = <"@ internal @">
+				>
+				["at0002"] = <
+					text = <"Any event">
+					description = <"*">
+				>
+				["at0003"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0004"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0005"] = <
+					text = <"WHO group 1 subgroup">
+					description = <"WHO group 1 subgroup includes idiopathic Pulmonary Arterial Hypertension (PAH)">
+				>
+				["at0006"] = <
+					text = <"Associated PAH-connective tissue disease">
+					description = <"PAH associated with connective tissue disease">
+				>
+				["at0007"] = <
+					text = <"Associated PAH-portopulmonary hypertension">
+					description = <"PAH associated with portopulmonary hypertension">
+				>
+				["at0008"] = <
+					text = <"Familial PAH">
+					description = <"Familial PAH">
+				>
+				["at0009"] = <
+					text = <"Other">
+					description = <"Other etiologies">
+				>
+				["at0010"] = <
+					text = <"Renal insufficiency">
+					description = <"Records points given based on the presence or absence of renal insufficiency.">
+				>
+				["at0011"] = <
+					text = <"No">
+					description = <"No renal insufficiency ">
+				>
+				["at0012"] = <
+					text = <"Yes">
+					description = <"Renal insufficiency present">
+				>
+				["at0013"] = <
+					text = <"Male age >60 years">
+					description = <"Records if the patient is a male and above 60 yrs of age">
+				>
+				["at0014"] = <
+					text = <"No">
+					description = <"Patient is not male >60 yrs">
+				>
+				["at0015"] = <
+					text = <"Yes">
+					description = <"Patient is male >60 yrs">
+				>
+				["at0016"] = <
+					text = <"NYHA/WHO functional class">
+					description = <"Holds the points given for each class of NYHA/WHO functional class the patient belongs to. ">
+				>
+				["at0017"] = <
+					text = <"I">
+					description = <"Patient belongs to class I">
+				>
+				["at0018"] = <
+					text = <"II">
+					description = <"Patient belongs to class II">
+				>
+				["at0019"] = <
+					text = <"III">
+					description = <"Patient belongs to class III">
+				>
+				["at0020"] = <
+					text = <"IV">
+					description = <"Patient belongs to class IV">
+				>
+				["at0021"] = <
+					text = <"Systolic BP, mmHg">
+					description = <"Holds the points given based on patient's systolic BP">
+				>
+				["at0022"] = <
+					text = <">=110 mmHg">
+					description = <"sBP >= 110mmHg">
+				>
+				["at0023"] = <
+					text = <"< 110mmHg">
+					description = <"sBP < 110mmHg">
+				>
+				["at0024"] = <
+					text = <"Heart rate, bpm">
+					description = <"Holds the points given based on the Heart rate.">
+				>
+				["at0025"] = <
+					text = <"<=92">
+					description = <"Heart Rate <=92 Beats/min">
+				>
+				["at0026"] = <
+					text = <"> 92">
+					description = <"Heart Rate > 92 Beats/min">
+				>
+				["at0027"] = <
+					text = <"6-minute walk test">
+					description = <"Calculates reference values for distance walked, as a measure of functional status.Male patients:
+6MWD in meters = (7.57 × height in cm) – (5.02 × age) – (1.76 × weight in kg) – 309
+
+Lower limit of normal = 6MWD - 153
+
+Female patients:
+6MWD in meters = (2.11 × height in cm) – (2.29 × weight in kg)  – (5.78 × age) + 667
+
+Lower limit of normal = 6MWD - 139">
+				>
+				["at0028"] = <
+					text = <"≥440 m">
+					description = <"6-minute walk test ≥440 m">
+				>
+				["at0029"] = <
+					text = <"165-440 m">
+					description = <"6-minute walk test 165-440 m">
+				>
+				["at0030"] = <
+					text = <"<165 m">
+					description = <"6-minute walk test <165 m">
+				>
+				["at0031"] = <
+					text = <"BNP, pg/mL">
+					description = <"Hold the points given based on the BNP values">
+				>
+				["at0032"] = <
+					text = <"<50 ">
+					description = <"BNP is <50pg/ml">
+				>
+				["at0033"] = <
+					text = <"50 - 180 ">
+					description = <"BNP is 50 - 180 pg/ml">
+				>
+				["at0034"] = <
+					text = <">180">
+					description = <"BNP is > 180 pg/ml">
+				>
+				["at0035"] = <
+					text = <"N-terminal proBNP">
+					description = <"Holds the points given based on the value of N-terminal proBNP when BPN is not available">
+				>
+				["at0036"] = <
+					text = <"<300">
+					description = <"N-terminal proBNP is <300 pg/ml">
+				>
+				["at0037"] = <
+					text = <"300 - 1500 ">
+					description = <"N-terminal proBNP is between 300 - 1500 pg/ml">
+				>
+				["at0038"] = <
+					text = <"> 1500">
+					description = <"N-terminal proBNP is >1500 pg/ml">
+				>
+				["at0039"] = <
+					text = <"Pericardial effusion on echocardiogram">
+					description = <"Records if the patient has pericardial effusion on echocardiogram">
+				>
+				["at0040"] = <
+					text = <"No">
+					description = <"No pericardial effusion on echocardiogram">
+				>
+				["at0041"] = <
+					text = <"Yes">
+					description = <"Pericardial effusion on echocardiogram is present">
+				>
+				["at0042"] = <
+					text = <"DLCO on pulmonary function test">
+					description = <"Records the points given based on the DLCO on pulmonary function test">
+				>
+				["at0043"] = <
+					text = <"≥80%">
+					description = <"DLCO on pulmonary function test is ≥80%">
+				>
+				["at0044"] = <
+					text = <"33-79%">
+					description = <"DLCO on pulmonary function test is 33-79%">
+				>
+				["at0045"] = <
+					text = <"≤32%">
+					description = <"DLCO on pulmonary function test is ≤32%">
+				>
+				["at0046"] = <
+					text = <"Mean right atrial pressure >20 mmHg within 1 year on right heart catheterization">
+					description = <"Records if Mean right atrial pressure >20 mmHg within 1 year on right heart catheterization">
+				>
+				["at0047"] = <
+					text = <"No">
+					description = <"Mean right atrial pressure is not >20 mmHg within 1 year on right heart catheterization">
+				>
+				["at0048"] = <
+					text = <"Yes">
+					description = <"Mean right atrial pressure is >20 mmHg within 1 year on right heart catheterization">
+				>
+				["at0049"] = <
+					text = <"Pulmonary vascular resistance >32 Wood units on right heart catheterization">
+					description = <"Records if Pulmonary vascular resistance >32 Wood units on right heart catheterization">
+				>
+				["at0050"] = <
+					text = <"No">
+					description = <"Pulmonary vascular resistance is not >32 Wood units on right heart catheterization">
+				>
+				["at0051"] = <
+					text = <"Yes">
+					description = <"Pulmonary vascular resistance is >32 Wood units on right heart catheterization">
+				>
+				["at0053"] = <
+					text = <"Total Score">
+					description = <"Total score is obtained by adding the selected points of the variables">
+				>
+			>
+		>
+	>

--- a/archetypes/openEHR-EHR-OBSERVATION.reveal_registry_risk_score_for_pulmonary_arterial_hypertension.v1.adl
+++ b/archetypes/openEHR-EHR-OBSERVATION.reveal_registry_risk_score_for_pulmonary_arterial_hypertension.v1.adl
@@ -18,42 +18,42 @@ description
 			purpose = <"The purpose is to calculate REVEAL Score and accordingly stratify the patients to different risk groups and predict the 1-year survival in patients with PAH.">
 			use = <"It is a simplified calculator used to calculate the REVEAL Score and predict the 1-year survival in patients with PAH. 
 REVEAL Score is obtained adding the selected points of the 12 variables + 6. 
-Variables                                                                                                Points
+Variables                                                                                                                                                Points
 WHO group 1 subgroup                                  Associated PAH-connective tissue disease              1
-                                                      Associated PAH-portopulmonary hypertension            2
-                                                      Familial PAH                                          2
-                                                      Others                                                0
-Renal insufficiency                                    Yes                                                  1
-                                                        No                                                  0
-Male age>60                                            Yes                                                  1
-                                                        No                                                  0
-NYHA/WHO functional Class                               I                                                  -2
-                                                        II                                                  0
-                                                       III                                                  1
-                                                       IV                                                   2
-Systolic BP                                            >=110 mmHg                                           0
-                                                      < 110mmHg                                             1
-Heart Rate                                             <=92/min                                             0
-                                                        >92/min                                             1
-6-min walk test                                         >=440m                                             -1
-                                                       165 – 440m                                           0
-                                                        <165m                                               1
-BNP, pg/ml                                              <50                                                 -2
-                                                         50-180                                             0
-                                                         >180                                               1
-N-terminal proBNP                                        <300                                               2 
-(BNP not available)                                    300-1500                                             0
-                                                        >1500                                               1
-Pericardial effusion on                                    Yes                                              1
-Echocardiogram                                             No                                               0
-DLCO on Pulmonary                                          >=80%                                            -1
- Function Test                                            33-79%                                            0
-                                                          <=32%                                             1
-Mean right atrial pressure                                 Yes                                              1 
->20 mmHg within 1 year                                      No                                              0
+                                                                      Associated PAH-portopulmonary hypertension            2
+                                                                                               Familial PAH                                               2
+                                                                                               Others                                                         0
+Renal insufficiency                                                                 Yes                                                            1
+                                                                                                   No                                                           0
+Male age>60                                                                           Yes                                                            2
+                                                                                                   No                                                          0
+NYHA/WHO functional Class                                                 I                                                            -2
+                                                                                                     II                                                           0
+                                                                                                    III                                                           1
+                                                                                                    IV                                                          2
+Systolic BP                                                                  >=110 mmHg                                                   0
+                                                                                    < 110mmHg                                                       1
+Heart Rate                                                                  <=92/min                                                           0
+                                                                                     >92/min                                                             1
+6-min walk test                                                           >=440m                                                            -1
+                                                                                     165 – 440m                                                         0
+                                                                                      <165m                                                                1
+BNP, pg/ml                                                                  <50                                                                   -2
+                                                                                       50-180                                                               0
+                                                                                        >180                                                                  1
+N-terminal proBNP                                                      <300                                                                 2 
+(BNP not available)                                                    300-1500                                                            0
+                                                                                      >1500                                                                 1
+Pericardial effusion on                                              Yes                                                                       1
+Echocardiogram                                                         No                                                                       0
+DLCO on Pulmonary                                                >=80%                                                                -1
+ Function Test                                                            33-79%                                                                 0
+                                                                                    <=32%                                                                 1
+Mean right atrial pressure                                        Yes                                                                         1 
+>20 mmHg within 1 year                                         No                                                                         0
 on right heart catheterization
-Pulmonary vascular resistance                               Yes                                             2
- >32 Wood units on                                          No                                              0
+Pulmonary vascular resistance                               Yes                                                                         2
+ >32 Wood units on                                                 No                                                                         0
 right heart catheterization
 
 Interpretation of REVEAL Score
@@ -72,7 +72,7 @@ REVEAL Score           Risk Group             1-year predicted survival
 	lifecycle_state = <"AuthorDraft">
 	other_contributors = <>
 	other_details = <
-		["MD5-CAM-1.0.1"] = <"2321FF7246DB0150BD4B958766C76288">
+		["licence"] = <"@CambioCDS">
 		["references"] = <"1. Benza RL, Gomberg-Maitland M, Miller DP, Frost A, Frantz RP, Foreman AJ, et al. The REVEAL Registry risk score calculator in patients newly diagnosed with pulmonary arterial hypertension. Chest. 2012 Feb;141(2):354–62. 
 
 2. Sitbon O, Benza RL, Badesch DB, Barst RJ, Elliott CG, Gressin V, et al. Validation of two predictive models for survival in pulmonary arterial hypertension. European Respiratory Journal. 2015 Jul 1;46(1):152–64. 
@@ -80,7 +80,7 @@ REVEAL Score           Risk Group             1-year predicted survival
 3. Benza RL, Farber HW, Frost A, Grünig E, Hoeper MM, Busse D, et al. REVEAL risk score in patients with chronic thromboembolic pulmonary hypertension receiving riociguat. J Heart Lung Transplant. 2018;37(7):836–43. 
 
 ">
-		["licence"] = <"@CambioCDS">
+		["MD5-CAM-1.0.1"] = <"80056B3C7A00BA4CB19A7ED1DAE26CF5">
 	>
 
 definition
@@ -139,18 +139,11 @@ definition
 											1|[local::at0030]  	-- <165 m
 										}
 									}
-									ELEMENT[at0031] occurrences matches {0..1} matches {	-- BNP, pg/mL
+									ELEMENT[at0031] occurrences matches {0..1} matches {	-- BNP, pg/ml or N-terminal proBNP, pg/ml
 										value matches {
-											-2|[local::at0032], 	-- <50 
-											0|[local::at0033], 	-- 50 - 180 
-											1|[local::at0034]  	-- >180
-										}
-									}
-									ELEMENT[at0035] occurrences matches {0..1} matches {	-- N-terminal proBNP
-										value matches {
-											-2|[local::at0036], 	-- <300
-											0|[local::at0037], 	-- 300 - 1500 
-											1|[local::at0038]  	-- > 1500
+											-2|[local::at0032], 	-- BNP <50 or N-terminal proBNP <300
+											0|[local::at0033], 	-- BNP 50 - 180 or N-terminal proBNP 300-1500
+											1|[local::at0034]  	-- BNP >180 or N-terminal proBNP >1500
 										}
 									}
 									ELEMENT[at0039] occurrences matches {0..1} matches {	-- Pericardial effusion on echocardiogram
@@ -334,36 +327,20 @@ Lower limit of normal = 6MWD - 139">
 					description = <"6-minute walk test <165 m">
 				>
 				["at0031"] = <
-					text = <"BNP, pg/mL">
+					text = <"BNP, pg/ml or N-terminal proBNP, pg/ml">
 					description = <"Hold the points given based on the BNP values">
 				>
 				["at0032"] = <
-					text = <"<50 ">
-					description = <"BNP is <50pg/ml">
+					text = <"BNP <50 or N-terminal proBNP <300">
+					description = <"Either BNP is <50pg/ml or N-terminal <300 is available">
 				>
 				["at0033"] = <
-					text = <"50 - 180 ">
-					description = <"BNP is 50 - 180 pg/ml">
+					text = <"BNP 50 - 180 or N-terminal proBNP 300-1500">
+					description = <"Either BNP is 50 - 180 pg/ml or N-terminal 300-1500 is available">
 				>
 				["at0034"] = <
-					text = <">180">
-					description = <"BNP is > 180 pg/ml">
-				>
-				["at0035"] = <
-					text = <"N-terminal proBNP">
-					description = <"Holds the points given based on the value of N-terminal proBNP when BPN is not available">
-				>
-				["at0036"] = <
-					text = <"<300">
-					description = <"N-terminal proBNP is <300 pg/ml">
-				>
-				["at0037"] = <
-					text = <"300 - 1500 ">
-					description = <"N-terminal proBNP is between 300 - 1500 pg/ml">
-				>
-				["at0038"] = <
-					text = <"> 1500">
-					description = <"N-terminal proBNP is >1500 pg/ml">
+					text = <"BNP >180 or N-terminal proBNP >1500">
+					description = <"Either BNP is > 180 pg/ml or N-terminal >1500 is available">
 				>
 				["at0039"] = <
 					text = <"Pericardial effusion on echocardiogram">

--- a/gdl2/REVEAL_Score.v.1.gdl2.json
+++ b/gdl2/REVEAL_Score.v.1.gdl2.json
@@ -1,0 +1,466 @@
+{
+  "id": "new_guideline.v0",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2020-04-20",
+      "name": "Rashmi Damodaran",
+      "organisation": "Cambio CDS",
+      "email": "models@cambiocds.com"
+    },
+    "lifecycle_state": "Author draft",
+    "details": {
+      "en": {
+        "id": "en",
+        "purpose": "The purpose is to calculate REVEAL Score and accordingly stratify the patients to different risk groups and predict the 1-year survival in patients with PAH.",
+        "keywords": [
+          "Pulmonary Arterial Hypertension",
+          "PAH",
+          "PAH risk group",
+          "PAH survival prediction"
+        ],
+        "use": "It is a simplified calculator used to calculate the REVEAL Score and predict the 1-year survival in patients with PAH. \nREVEAL Score is obtained adding the selected points of the 12 variables + 6. \nVariables                                                                                                         Points\nWHO group 1 subgroup      Associated PAH-connective tissue disease                    1\n                                                      Associated PAH-portopulmonary hypertension           2\n                                                      Familial PAH                                                                        2\n                                                      Others                                                                                  0\nRenal insufficiency                    Yes                                                                                         1\n                                                      No                                                                                          0\nMale age>60                               Yes                                                                                        2\n                                                      No                                                                                          0\nNYHA/WHO functional Class    I                                                                                             -2\n                                                       II                                                                                            0\n                                                       III                                                                                            1\n                                                       IV                                                                                            2\nSystolic BP                                   >=110 mmHg                                                                       0\n                                                      < 110mmHg                                                                          1\nHeart Rate                                   <=92/min                                                                              0\n                                                  >92/min                                                                                    1\n6-min walk test                      >=440m                                                                                     -1\n                                             165 – 440m                                                                                   0\n                                                   <165m                                                                                       1\nBNP, pg/ml                                          <50                                                                                           -2\n                                              50-180                                                                                           0\n                                                    >180                                                                                          1\nN-terminal proBNP                   <300                                                                                       -2 \n(BNP not available)                 300-1500                                                                                  0\n                                                     >1500                                                                                       1\nPericardial effusion on           Yes                                                                                              1\nEchocardiogram                         No                                                                                             0\nDLCO on Pulmonary              >=80%                                                                                         -1\n Function Test                       33-79%                                                                                          0\n                                                  <=32%                                                                                          1\nMean right atrial pressure         Yes                                                                                          1 \n>20 mmHg within 1 year             No                                                                                          0\non right heart catheterization\nPulmonary vascular resistance   Yes                                                                                       2\n >32 Wood units on                      No                                                                                         0\nright heart catheterization\n\nInterpretation of REVEAL Score\nREVEAL Score           Risk Group             1-year predicted survival\n0-7                                 Low                           >=95%\n8                                   Average                     90% - <95%\n9                                  Moderate                  85% - <90%\n10-11                           High                            70% - <85%\n>=12                            Very high                     <70%           \n",
+        "misuse": "The REVEAL score can help to decide therapeutic strategies but has not been evaluated as a tool to monitor treatment response",
+        "copyright": "@CambioCDS"
+      }
+    },
+    "other_details": {
+      "references": "1. Benza RL, Gomberg-Maitland M, Miller DP, Frost A, Frantz RP, Foreman AJ, et al. The REVEAL Registry risk score calculator in patients newly diagnosed with pulmonary arterial hypertension. Chest. 2012 Feb;141(2):354–62. \n\n2. Sitbon O, Benza RL, Badesch DB, Barst RJ, Elliott CG, Gressin V, et al. Validation of two predictive models for survival in pulmonary arterial hypertension. European Respiratory Journal. 2015 Jul 1;46(1):152–64. \n\n3. Benza RL, Farber HW, Frost A, Grünig E, Hoeper MM, Busse D, et al. REVEAL risk score in patients with chronic thromboembolic pulmonary hypertension receiving riociguat. J Heart Lung Transplant. 2018;37(7):836–43. \n"
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0002": {
+        "id": "gt0002",
+        "model_id": "openEHR-EHR-OBSERVATION.basic_demographic.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.basic_demographic.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0003": {
+            "id": "gt0003",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0013]"
+          }
+        }
+      },
+      "gt0004": {
+        "id": "gt0004",
+        "model_id": "openEHR-EHR-OBSERVATION.blood_pressure.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.blood_pressure.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0005": {
+            "id": "gt0005",
+            "path": "/data[at0001]/events[at0006]/data[at0003]/items[at0004]"
+          }
+        }
+      },
+      "gt0006": {
+        "id": "gt0006",
+        "model_id": "openEHR-EHR-OBSERVATION.pulse.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.pulse.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0007": {
+            "id": "gt0007",
+            "path": "/data[at0002]/events[at0003]/data[at0001]/items[at0004]"
+          }
+        }
+      },
+      "gt0008": {
+        "id": "gt0008",
+        "model_id": "openEHR-EHR-OBSERVATION.reveal_registry_risk_score_for_pulmonary_arterial_hypertension.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.reveal_registry_risk_score_for_pulmonary_arterial_hypertension.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0009": {
+            "id": "gt0009",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0005]"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0010]"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0016]"
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0027]"
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0031]"
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0039]"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0042]"
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0046]"
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0049]"
+          }
+        }
+      },
+      "gt0018": {
+        "id": "gt0018",
+        "model_id": "openEHR-EHR-OBSERVATION.reveal_registry_risk_score_for_pulmonary_arterial_hypertension.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.reveal_registry_risk_score_for_pulmonary_arterial_hypertension.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0019": {
+            "id": "gt0019",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0013]"
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0021]"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0024]"
+          },
+          "gt0022": {
+            "id": "gt0022",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0053]"
+          }
+        }
+      },
+      "gt0023": {
+        "id": "gt0023",
+        "model_id": "openEHR-EHR-EVALUATION.reveal_registry_risk_score_for_pulmonary_arterial_hypertension.v1",
+        "template_id": "openEHR-EHR-EVALUATION.reveal_registry_risk_score_for_pulmonary_arterial_hypertension.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0024": {
+            "id": "gt0024",
+            "path": "/data[at0001]/items[at0002]"
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "path": "/data[at0001]/items[at0008]"
+          }
+        }
+      }
+    },
+    "rules": {
+      "gt0026": {
+        "id": "gt0026",
+        "priority": 12,
+        "when": [
+          "$gt0003|Male Age|!=null",
+          "$gt0003|Male Age|>60,a"
+        ],
+        "then": [
+          "$gt0019|Male age Score|=0|local::at0014|No|"
+        ]
+      },
+      "gt0027": {
+        "id": "gt0027",
+        "priority": 11,
+        "when": [
+          "$gt0003|Male Age|!=null",
+          "$gt0003|Male Age|<=60,a"
+        ],
+        "then": [
+          "$gt0019|Male age Score|=2|local::at0015|Yes|"
+        ]
+      },
+      "gt0028": {
+        "id": "gt0028",
+        "priority": 10,
+        "when": [
+          "$gt0005|Systolic BP|!=null",
+          "$gt0005|Systolic BP|>=110,mm[Hg]"
+        ],
+        "then": [
+          "$gt0020|Systolic BP Score|=0|local::at0022|>=110 mmHg|"
+        ]
+      },
+      "gt0029": {
+        "id": "gt0029",
+        "priority": 9,
+        "when": [
+          "$gt0005|Systolic BP|!=null",
+          "$gt0005|Systolic BP|<110,mm[Hg]"
+        ],
+        "then": [
+          "$gt0020|Systolic BP Score|=1|local::at0023|< 110mmHg|"
+        ]
+      },
+      "gt0030": {
+        "id": "gt0030",
+        "priority": 8,
+        "when": [
+          "$gt0007|Heart rate|!=null",
+          "$gt0007|Heart rate|<=92,/min"
+        ],
+        "then": [
+          "$gt0021|Heart rate Score|=0|local::at0025|<=92|"
+        ]
+      },
+      "gt0031": {
+        "id": "gt0031",
+        "priority": 7,
+        "when": [
+          "$gt0007|Heart rate|!=null",
+          "$gt0007|Heart rate|>92,/min"
+        ],
+        "then": [
+          "$gt0021|Heart rate Score|=1|local::at0026|> 92|"
+        ]
+      },
+      "gt0032": {
+        "id": "gt0032",
+        "priority": 6,
+        "when": [
+          "$gt0019|Male age Score|!=null",
+          "$gt0020|Systolic BP Score|!=null",
+          "$gt0021|Heart rate Score|!=null",
+          "$gt0009|WHO group 1 subgroup|!=null",
+          "$gt0010|Renal insufficiency|!=null",
+          "$gt0011|NYHA/WHO functional class|!=null",
+          "$gt0014|Pericardial effusion on echocardiogram|!=null",
+          "$gt0013|BNP, pg/ml or N-terminal proBNP, pg/ml|!=null",
+          "$gt0012|6-minute walk test|!=null",
+          "$gt0015|DLCO on pulmonary function test|!=null",
+          "$gt0016|Mean right atrial pressure >20 mmHg within 1 year on right heart catheterization|!=null",
+          "$gt0017|Pulmonary vascular resistance >32 Wood units on right heart catheterization|!=null"
+        ],
+        "then": [
+          "$gt0022|REVEAL Score|.magnitude=$gt0009.value+$gt0010.value+$gt0011.value+$gt0012.value+$gt0013.value+$gt0014.value+$gt0015.value+$gt0016.value+$gt0017.value+$gt0019.value+$gt0020.value+$gt0021.value+6"
+        ]
+      },
+      "gt0034": {
+        "id": "gt0034",
+        "priority": 5,
+        "when": [
+          "$gt0022|REVEAL Score|!=null",
+          "$gt0022|REVEAL Score|>=0",
+          "$gt0022|REVEAL Score|<=7"
+        ],
+        "then": [
+          "$gt0024|Risk group|=0|local::at0003|Low-Risk|",
+          "$gt0025|Predicted 1-year survival|=0|local::at0009|≥95%|"
+        ]
+      },
+      "gt0035": {
+        "id": "gt0035",
+        "priority": 4,
+        "when": [
+          "$gt0022|REVEAL Score|!=null",
+          "$gt0022|REVEAL Score|==8"
+        ],
+        "then": [
+          "$gt0024|Risk group|=1|local::at0004|Average-Risk|",
+          "$gt0025|Predicted 1-year survival|=1|local::at0010|90% to <95%|"
+        ]
+      },
+      "gt0036": {
+        "id": "gt0036",
+        "priority": 3,
+        "when": [
+          "$gt0022|REVEAL Score|!=null",
+          "$gt0022|REVEAL Score|==9"
+        ],
+        "then": [
+          "$gt0024|Risk group|=2|local::at0005|Moderate-Risk|",
+          "$gt0025|Predicted 1-year survival|=2|local::at0011|85% to <90%|"
+        ]
+      },
+      "gt0037": {
+        "id": "gt0037",
+        "priority": 2,
+        "when": [
+          "$gt0022|REVEAL Score|!=null",
+          "$gt0022|REVEAL Score|>=10",
+          "$gt0022|REVEAL Score|<=11"
+        ],
+        "then": [
+          "$gt0024|Risk group|=3|local::at0006|High-Risk|",
+          "$gt0025|Predicted 1-year survival|=3|local::at0012|70% - <85%|"
+        ]
+      },
+      "gt0038": {
+        "id": "gt0038",
+        "priority": 1,
+        "when": [
+          "$gt0022|REVEAL Score|!=null",
+          "$gt0022|REVEAL Score|>=12"
+        ],
+        "then": [
+          "$gt0024|Risk group|=4|local::at0007|Very high-Risk |",
+          "$gt0025|Predicted 1-year survival|=4|local::at0013|<70%|"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "REVEAL Registry Risk Score For Pulmonary Arterial Hypertension (PAH)",
+            "description": "REVEAL Registry (Registry for Evaluation of Early and Long-term PAH disease management) Risk Score predicts survival in patients with PAH which is important for optimizing therapeutic strategies."
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "Male Age",
+            "description": "Age in years, and for babies: months, weeks or days"
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Systolic BP",
+            "description": "Peak systemic arterial blood pressure  - measured in systolic or contraction phase of the heart cycle."
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Heart rate",
+            "description": "The rate, measured in beats per minute."
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "WHO group 1 subgroup",
+            "description": "WHO group 1 subgroup includes idiopathic Pulmonary Arterial Hypertension (PAH)"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "Renal insufficiency",
+            "description": "Records points given based on the presence or absence of renal insufficiency."
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "NYHA/WHO functional class",
+            "description": "Holds the points given for each class of NYHA/WHO functional class the patient belongs to. "
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "6-minute walk test",
+            "description": "Calculates reference values for distance walked, as a measure of functional status.Male patients:\r\n6MWD in meters = (7.57 × height in cm) – (5.02 × age) – (1.76 × weight in kg) – 309\r\n\r\nLower limit of normal = 6MWD - 153\r\n\r\nFemale patients:\r\n6MWD in meters = (2.11 × height in cm) – (2.29 × weight in kg)  – (5.78 × age) + 667\r\n\r\nLower limit of normal = 6MWD - 139"
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "BNP, pg/ml or N-terminal proBNP, pg/ml",
+            "description": "Hold the points given based on the BNP values"
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "Pericardial effusion on echocardiogram",
+            "description": "Records if the patient has pericardial effusion on echocardiogram"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "DLCO on pulmonary function test",
+            "description": "Records the points given based on the DLCO on pulmonary function test"
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "Mean right atrial pressure >20 mmHg within 1 year on right heart catheterization",
+            "description": "Records if Mean right atrial pressure >20 mmHg within 1 year on right heart catheterization"
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "text": "Pulmonary vascular resistance >32 Wood units on right heart catheterization",
+            "description": "Records if Pulmonary vascular resistance >32 Wood units on right heart catheterization"
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "text": "Male age Score",
+            "description": "Records if the patient is a male and above 60 yrs of age"
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "Systolic BP Score",
+            "description": "Holds the points given based on patient's systolic BP"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "text": "Heart rate Score",
+            "description": "Holds the points given based on the Heart rate."
+          },
+          "gt0022": {
+            "id": "gt0022",
+            "text": "REVEAL Score",
+            "description": "Total score is obtained by adding the selected points of the variables"
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "text": "Risk group",
+            "description": "Patients are stratified to different risk  groups based on the REVEAL Score"
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "text": "Predicted 1-year survival",
+            "description": "Predicted 1-year survival in patients diagnosed with PAH based on the REVEAL Score"
+          },
+          "gt0026": {
+            "id": "gt0026",
+            "text": "Set Male Age Score to 0"
+          },
+          "gt0027": {
+            "id": "gt0027",
+            "text": "Set Male Age to 2"
+          },
+          "gt0028": {
+            "id": "gt0028",
+            "text": "Set sBP to 0"
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "text": "Set sBP Score to 1"
+          },
+          "gt0030": {
+            "id": "gt0030",
+            "text": "Set HR Score to 0"
+          },
+          "gt0031": {
+            "id": "gt0031",
+            "text": "Set HR Score to 1"
+          },
+          "gt0032": {
+            "id": "gt0032",
+            "text": "Calculate REVEAL Score"
+          },
+          "gt0033": {
+            "id": "gt0033",
+            "text": "Low-Risk Rule"
+          },
+          "gt0034": {
+            "id": "gt0034",
+            "text": "Low-Risk Rule"
+          },
+          "gt0035": {
+            "id": "gt0035",
+            "text": "Average-Risk Rule"
+          },
+          "gt0036": {
+            "id": "gt0036",
+            "text": "Moderate-Risk Rule"
+          },
+          "gt0037": {
+            "id": "gt0037",
+            "text": "High-Risk Rule"
+          },
+          "gt0038": {
+            "id": "gt0038",
+            "text": "Very High-Risk Rule"
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/REVEAL_Score.v1.gdl2.json
+++ b/gdl2/REVEAL_Score.v1.gdl2.json
@@ -1,0 +1,448 @@
+{
+  "id": "REVEAL_Score.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2020-04-17",
+      "name": "Rashmi Damodaran",
+      "organisation": "Cambio CDS",
+      "email": "models@cambiocds.com"
+    },
+    "lifecycle_state": "Author draft",
+    "details": {
+      "en": {
+        "id": "en",
+        "purpose": "The purpose is to calculate REVEAL Score and accordingly stratify the patients to different risk groups and predict the 1-year survival in patients with PAH.",
+        "keywords": [
+          "Pulmonary Arterial Hypertension",
+          "PAH",
+          "PAH survival prediction",
+          "REVEAL Score"
+        ],
+        "use": "It is a simplified calculator used to calculate the REVEAL Score and predict the 1-year survival in patients with PAH. \nREVEAL Score is obtained adding the selected points of the 12 variables + 6. \nVariables                                                                                                         Points\nWHO group 1 subgroup      Associated PAH-connective tissue disease                    1\n                                                      Associated PAH-portopulmonary hypertension           2\n                                                      Familial PAH                                                                        2\n                                                      Others                                                                                  0\nRenal insufficiency                    Yes                                                                                         1\n                                                      No                                                                                          0\nMale age>60                               Yes                                                                                        1\n                                                      No                                                                                          0\nNYHA/WHO functional Class    I                                                                                             -2\n                                                       II                                                                                            0\n                                                       III                                                                                            1\n                                                       IV                                                                                            2\nSystolic BP                                   >=110 mmHg                                                                       0\n                                                      < 110mmHg                                                                          1\nHeart Rate                                   <=92/min                                                                              0\n                                                  >92/min                                                                                    1\n6-min walk test                      >=440m                                                                                     -1\n                                             165 – 440m                                                                                   0\n                                                   <165m                                                                                       1\nBNP, pg/ml                                          <50                                                                                           -2\n                                              50-180                                                                                           0\n                                                    >180                                                                                          1\nN-terminal proBNP                   <300                                                                                       -2 \n(BNP not available)                 300-1500                                                                                  0\n                                                     >1500                                                                                       1\nPericardial effusion on           Yes                                                                                              1\nEchocardiogram                         No                                                                                             0\nDLCO on Pulmonary              >=80%                                                                                         -1\n Function Test                       33-79%                                                                                          0\n                                                  <=32%                                                                                          1\nMean right atrial pressure         Yes                                                                                          1 \n>20 mmHg within 1 year             No                                                                                          0\non right heart catheterization\nPulmonary vascular resistance   Yes                                                                                       2\n >32 Wood units on                      No                                                                                         0\nright heart catheterization\n\nInterpretation of REVEAL Score\nREVEAL Score           Risk Group             1-year predicted survival\n0-7                                 Low                           >=95%\n8                                   Average                     90% - <95%\n9                                  Moderate                  85% - <90%\n10-11                           High                            70% - <85%\n>=12                            Very high                     <70%           \n",
+        "misuse": "The REVEAL score can help to decide therapeutic strategies but has not been evaluated as a tool to monitor treatment response",
+        "copyright": "@CambioCDS"
+      }
+    },
+    "other_details": {
+      "references": "1. Benza RL, Gomberg-Maitland M, Miller DP, Frost A, Frantz RP, Foreman AJ, et al. The REVEAL Registry risk score calculator in patients newly diagnosed with pulmonary arterial hypertension. Chest. 2012 Feb;141(2):354–62. \n\n2. Sitbon O, Benza RL, Badesch DB, Barst RJ, Elliott CG, Gressin V, et al. Validation of two predictive models for survival in pulmonary arterial hypertension. European Respiratory Journal. 2015 Jul 1;46(1):152–64. \n\n3. Benza RL, Farber HW, Frost A, Grünig E, Hoeper MM, Busse D, et al. REVEAL risk score in patients with chronic thromboembolic pulmonary hypertension receiving riociguat. J Heart Lung Transplant. 2018;37(7):836–43. \n\n"
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0002": {
+        "id": "gt0002",
+        "model_id": "openEHR-EHR-OBSERVATION.pulse.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.pulse.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0003": {
+            "id": "gt0003",
+            "path": "/data[at0002]/events[at0003]/data[at0001]/items[at0004]"
+          }
+        }
+      },
+      "gt0004": {
+        "id": "gt0004",
+        "model_id": "openEHR-EHR-OBSERVATION.blood_pressure.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.blood_pressure.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0005": {
+            "id": "gt0005",
+            "path": "/data[at0001]/events[at0006]/data[at0003]/items[at0004]"
+          }
+        }
+      },
+      "gt0006": {
+        "id": "gt0006",
+        "model_id": "openEHR-EHR-OBSERVATION.reveal_registry_risk_score_for_pulmonary_arterial_hypertension.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.reveal_registry_risk_score_for_pulmonary_arterial_hypertension.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0007": {
+            "id": "gt0007",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0005]"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0010]"
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0013]"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0016]"
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0027]"
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0031]"
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0035]"
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0039]"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0042]"
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0046]"
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0049]"
+          }
+        }
+      },
+      "gt0018": {
+        "id": "gt0018",
+        "model_id": "openEHR-EHR-OBSERVATION.reveal_registry_risk_score_for_pulmonary_arterial_hypertension.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.reveal_registry_risk_score_for_pulmonary_arterial_hypertension.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0019": {
+            "id": "gt0019",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0024]"
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0021]"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0053]"
+          }
+        }
+      },
+      "gt0022": {
+        "id": "gt0022",
+        "model_id": "openEHR-EHR-EVALUATION.reveal_registry_risk_score_for_pulmonary_arterial_hypertension.v1",
+        "template_id": "openEHR-EHR-EVALUATION.reveal_registry_risk_score_for_pulmonary_arterial_hypertension.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0023": {
+            "id": "gt0023",
+            "path": "/data[at0001]/items[at0002]"
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "path": "/data[at0001]/items[at0008]"
+          }
+        }
+      }
+    },
+    "rules": {
+      "gt0025": {
+        "id": "gt0025",
+        "priority": 11,
+        "when": [
+          "$gt0005|Systolic BP|!=null",
+          "$gt0005|Systolic BP|>=110,mm[Hg]"
+        ],
+        "then": [
+          "$gt0020|Systolic BP score|=0|local::at0022|>=110 mmHg|"
+        ]
+      },
+      "gt0026": {
+        "id": "gt0026",
+        "priority": 10,
+        "when": [
+          "$gt0005|Systolic BP|!=null",
+          "$gt0005|Systolic BP|<110,mm[Hg]"
+        ],
+        "then": [
+          "$gt0020|Systolic BP score|=1|local::at0023|< 110mmHg|"
+        ]
+      },
+      "gt0027": {
+        "id": "gt0027",
+        "priority": 9,
+        "when": [
+          "$gt0003|Heart rate|!=null",
+          "$gt0003|Heart rate|<=92,/min"
+        ],
+        "then": [
+          "$gt0019|Heart rate score|=0|local::at0025|<=92|"
+        ]
+      },
+      "gt0028": {
+        "id": "gt0028",
+        "priority": 8,
+        "when": [
+          "$gt0003|Heart rate|!=null",
+          "$gt0003|Heart rate|>92,/min"
+        ],
+        "then": [
+          "$gt0019|Heart rate score|=1|local::at0026|> 92|"
+        ]
+      },
+      "gt0029": {
+        "id": "gt0029",
+        "priority": 7,
+        "when": [
+          "$gt0007|WHO group 1 subgroup|!=null",
+          "$gt0008|Renal insufficiency|!=null",
+          "$gt0009|Male age >60 years|!=null",
+          "$gt0010|NYHA/WHO functional class|!=null",
+          "$gt0011|6-minute walk test|!=null",
+          "$gt0012|BNP, pg/mL|!=null",
+          "$gt0013|N-terminal proBNP|==null",
+          "$gt0014|Pericardial effusion on echocardiogram|!=null",
+          "$gt0015|DLCO on pulmonary function test|!=null",
+          "$gt0016|Mean right atrial pressure >20 mmHg within 1 year on right heart catheterization|!=null",
+          "$gt0017|Pulmonary vascular resistance >32 Wood units on right heart catheterization|!=null"
+        ],
+        "then": [
+          "$gt0021|REVEAL Score|.magnitude=6+$gt0007.value+$gt0008.value+$gt0009.value+$gt0010.value+$gt0011.value+$gt0012.value+$gt0014.value+$gt0015.value+$gt0016.value+$gt0017.value+$gt0019.value+$gt0020.value"
+        ]
+      },
+      "gt0030": {
+        "id": "gt0030",
+        "priority": 6,
+        "when": [
+          "$gt0007|WHO group 1 subgroup|!=null",
+          "$gt0008|Renal insufficiency|!=null",
+          "$gt0009|Male age >60 years|!=null",
+          "$gt0010|NYHA/WHO functional class|!=null",
+          "$gt0011|6-minute walk test|!=null",
+          "$gt0012|BNP, pg/mL|==null",
+          "$gt0013|N-terminal proBNP|!=null",
+          "$gt0014|Pericardial effusion on echocardiogram|!=null",
+          "$gt0015|DLCO on pulmonary function test|!=null",
+          "$gt0016|Mean right atrial pressure >20 mmHg within 1 year on right heart catheterization|!=null",
+          "$gt0019|Heart rate score|!=null",
+          "$gt0020|Systolic BP score|!=null"
+        ],
+        "then": [
+          "$gt0021|REVEAL Score|.magnitude=6+$gt0007.value+$gt0008.value+$gt0010.value+$gt0013.value+$gt0011.value+$gt0014.value+$gt0015.value+$gt0016.value+$gt0017.value+$gt0019.value+$gt0020.value+$gt0009.value"
+        ]
+      },
+      "gt0031": {
+        "id": "gt0031",
+        "priority": 5,
+        "when": [
+          "$gt0021|REVEAL Score|!=null",
+          "$gt0021|REVEAL Score|>=0",
+          "$gt0021|REVEAL Score|<=7"
+        ],
+        "then": [
+          "$gt0023|Risk group|=0|local::at0003|Low-Risk|",
+          "$gt0024|Predicted 1-year survival|=0|local::at0009|≥95%|"
+        ]
+      },
+      "gt0032": {
+        "id": "gt0032",
+        "priority": 4,
+        "when": [
+          "$gt0021|REVEAL Score|!=null",
+          "$gt0021|REVEAL Score|==8"
+        ],
+        "then": [
+          "$gt0023|Risk group|=1|local::at0004|Average-Risk|",
+          "$gt0024|Predicted 1-year survival|=1|local::at0010|90% to <95%|"
+        ]
+      },
+      "gt0033": {
+        "id": "gt0033",
+        "priority": 3,
+        "when": [
+          "$gt0021|REVEAL Score|!=null",
+          "$gt0021|REVEAL Score|==9"
+        ],
+        "then": [
+          "$gt0023|Risk group|=2|local::at0005|Moderate-Risk|",
+          "$gt0024|Predicted 1-year survival|=2|local::at0011|85% to <90%|"
+        ]
+      },
+      "gt0034": {
+        "id": "gt0034",
+        "priority": 2,
+        "when": [
+          "$gt0021|REVEAL Score|!=null",
+          "$gt0021|REVEAL Score|>=10",
+          "$gt0021|REVEAL Score|<=11"
+        ],
+        "then": [
+          "$gt0023|Risk group|=3|local::at0006|High-Risk|",
+          "$gt0024|Predicted 1-year survival|=3|local::at0012|70% - <85%|"
+        ]
+      },
+      "gt0035": {
+        "id": "gt0035",
+        "priority": 1,
+        "when": [
+          "$gt0021|REVEAL Score|!=null",
+          "$gt0021|REVEAL Score|>=12"
+        ],
+        "then": [
+          "$gt0023|Risk group|=4|local::at0007|Very high-Risk |",
+          "$gt0024|Predicted 1-year survival|=4|local::at0013|<70%|"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "REVEAL Registry Risk Score For Pulmonary Arterial Hypertension (PAH)",
+            "description": "REVEAL Registry (Registry for Evaluation of Early and Long-term PAH disease management) Risk Score predicts survival in patients with PAH which is important for optimizing therapeutic strategies."
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "Heart rate",
+            "description": "The rate, measured in beats per minute."
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "Systolic BP",
+            "description": "Peak systemic arterial blood pressure  - measured in systolic or contraction phase of the heart cycle."
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "WHO group 1 subgroup",
+            "description": "WHO group 1 subgroup includes idiopathic Pulmonary Arterial Hypertension (PAH)"
+          },
+          "gt0008": {
+            "id": "gt0008",
+            "text": "Renal insufficiency",
+            "description": "Records points given based on the presence or absence of renal insufficiency."
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Male age >60 years",
+            "description": "Records if the patient is a male and above 60 yrs of age"
+          },
+          "gt0010": {
+            "id": "gt0010",
+            "text": "NYHA/WHO functional class",
+            "description": "Holds the points given for each class of NYHA/WHO functional class the patient belongs to. "
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "6-minute walk test",
+            "description": "Calculates reference values for distance walked, as a measure of functional status.Male patients:\r\n6MWD in meters = (7.57 × height in cm) – (5.02 × age) – (1.76 × weight in kg) – 309\r\n\r\nLower limit of normal = 6MWD - 153\r\n\r\nFemale patients:\r\n6MWD in meters = (2.11 × height in cm) – (2.29 × weight in kg)  – (5.78 × age) + 667\r\n\r\nLower limit of normal = 6MWD - 139"
+          },
+          "gt0012": {
+            "id": "gt0012",
+            "text": "BNP, pg/mL",
+            "description": "Hold the points given based on the BNP values"
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "N-terminal proBNP",
+            "description": "Holds the points given based on the value of N-terminal proBNP when BPN is not available"
+          },
+          "gt0014": {
+            "id": "gt0014",
+            "text": "Pericardial effusion on echocardiogram",
+            "description": "Records if the patient has pericardial effusion on echocardiogram"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "DLCO on pulmonary function test",
+            "description": "Records the points given based on the DLCO on pulmonary function test"
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "Mean right atrial pressure >20 mmHg within 1 year on right heart catheterization",
+            "description": "Records if Mean right atrial pressure >20 mmHg within 1 year on right heart catheterization"
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "text": "Pulmonary vascular resistance >32 Wood units on right heart catheterization",
+            "description": "Records if Pulmonary vascular resistance >32 Wood units on right heart catheterization"
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "text": "Heart rate score",
+            "description": "Holds the points given based on the Heart rate."
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "Systolic BP score",
+            "description": "Holds the points given based on patient's systolic BP"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "text": "REVEAL Score",
+            "description": "Total score is obtained by adding the selected points of the variables"
+          },
+          "gt0023": {
+            "id": "gt0023",
+            "text": "Risk group",
+            "description": "Patients are stratified to different risk  groups based on the REVEAL Score"
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "text": "Predicted 1-year survival",
+            "description": "Predicted 1-year survival in patients diagnosed with PAH based on the REVEAL Score"
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "text": "Set sBP >=110 to 0"
+          },
+          "gt0026": {
+            "id": "gt0026",
+            "text": "Set sBP <110 to 1"
+          },
+          "gt0027": {
+            "id": "gt0027",
+            "text": "Set HR <=92/min to 0"
+          },
+          "gt0028": {
+            "id": "gt0028",
+            "text": "Set HR >92/min to 1"
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "text": "Calculate REVEAL Score (BNP) "
+          },
+          "gt0030": {
+            "id": "gt0030",
+            "text": "Calculate REVEAL Score (N-terminal proBNP)"
+          },
+          "gt0031": {
+            "id": "gt0031",
+            "text": "Low-Risk Rule"
+          },
+          "gt0032": {
+            "id": "gt0032",
+            "text": "Average-Risk Rule"
+          },
+          "gt0033": {
+            "id": "gt0033",
+            "text": "Moderate-Risk Rule"
+          },
+          "gt0034": {
+            "id": "gt0034",
+            "text": "High-Risk Rule"
+          },
+          "gt0035": {
+            "id": "gt0035",
+            "text": "Very High-Risk Rule"
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/REVEAL_Score.v1.test.yml
+++ b/gdl2/REVEAL_Score.v1.test.yml
@@ -1,0 +1,241 @@
+guidelines:
+  1: REVEAL_Score.v1
+test_cases:
+- id: case_1   Low-Risk, BNP available
+  input:
+    1:
+      gt0003|Heart rate: 91,/min
+      gt0005|Systolic BP: 120,mm[Hg]
+      gt0007|WHO group 1 subgroup: 0|local::at0009|Other|
+      gt0008|Renal insufficiency: 0|local::at0011|No|
+      gt0009|Male age >60 years: 2|local::at0015|Yes|
+      gt0010|NYHA/WHO functional class: -2|local::at0017|I|
+      gt0011|6-minute walk test: 0|local::at0029|165-440 m|
+      gt0012|BNP, pg/mL: 0|local::at0033|50 - 180 |
+      gt0014|Pericardial effusion on echocardiogram: 0|local::at0040|No|
+      gt0015|DLCO on pulmonary function test: 0|local::at0044|33-79%|
+      gt0016|Mean right atrial pressure >20 mmHg within 1 year on right heart catheterization: 0|local::at0047|No|
+      gt0017|Pulmonary vascular resistance >32 Wood units on right heart catheterization: 0|local::at0050|No|
+  expected_output:
+    1:
+      gt0021|REVEAL Score: 6
+      gt0020|Systolic BP Score: 0|local::at0022|>=110 mmHg|
+      gt0019|Heart rate Score: 0|local::at0025|<=92|
+      gt0024|Predicted 1-year survival: 0|local::at0009|≥95%|
+      gt0023|Risk group: 0|local::at0003|Low-Risk|
+
+- id: case_2  Average-Risk, BNP available
+  input:
+    1:
+      gt0003|Heart rate: 91,/min
+      gt0005|Systolic BP: 120,mm[Hg]
+      gt0007|WHO group 1 subgroup: 0|local::at0009|Other|
+      gt0008|Renal insufficiency: 0|local::at0011|No|
+      gt0009|Male age >60 years: 2|local::at0015|Yes|
+      gt0010|NYHA/WHO functional class: 0|local::at0018|II|
+      gt0011|6-minute walk test: 0|local::at0029|165-440 m|
+      gt0012|BNP, pg/mL: 0|local::at0033|50 - 180 |
+      gt0014|Pericardial effusion on echocardiogram: 0|local::at0040|No|
+      gt0015|DLCO on pulmonary function test: 0|local::at0044|33-79%|
+      gt0016|Mean right atrial pressure >20 mmHg within 1 year on right heart catheterization: 0|local::at0047|No|
+      gt0017|Pulmonary vascular resistance >32 Wood units on right heart catheterization: 0|local::at0050|No|
+  expected_output:
+    1:
+      gt0021|REVEAL Score: 8
+      gt0020|Systolic BP Score: 0|local::at0022|>=110 mmHg|
+      gt0019|Heart rate Score: 0|local::at0025|<=92|
+      gt0024|Predicted 1-year survival: 1|local::at0010|90% to <95%|
+      gt0023|Risk group: 1|local::at0004|Average-Risk|
+
+- id: case_3  Moderate-Risk, BNP available
+  input:
+    1:
+      gt0003|Heart rate: 91,/min
+      gt0005|Systolic BP: 108,mm[Hg]
+      gt0007|WHO group 1 subgroup: 0|local::at0009|Other|
+      gt0008|Renal insufficiency: 0|local::at0011|No|
+      gt0009|Male age >60 years: 2|local::at0015|Yes|
+      gt0010|NYHA/WHO functional class: 0|local::at0018|II|
+      gt0011|6-minute walk test: 0|local::at0029|165-440 m|
+      gt0012|BNP, pg/mL: 0|local::at0033|50 - 180 |
+      gt0014|Pericardial effusion on echocardiogram: 0|local::at0040|No|
+      gt0015|DLCO on pulmonary function test: 0|local::at0044|33-79%|
+      gt0016|Mean right atrial pressure >20 mmHg within 1 year on right heart catheterization: 0|local::at0047|No|
+      gt0017|Pulmonary vascular resistance >32 Wood units on right heart catheterization: 0|local::at0050|No|
+  expected_output:
+    1:
+      gt0021|REVEAL Score: 9
+      gt0020|Systolic BP Score: 1|local::at0023|< 110mmHg|
+      gt0019|Heart rate Score: 0|local::at0025|<=92|
+      gt0024|Predicted 1-year survival: 2|local::at0011|85% to <90%|
+      gt0023|Risk group: 2|local::at0005|Moderate-Risk|
+
+- id: case_4  High-Risk, BNP available
+  input:
+    1:
+      gt0003|Heart rate: 94,/min
+      gt0005|Systolic BP: 108,mm[Hg]
+      gt0007|WHO group 1 subgroup: 1|local::at0006|Associated PAH-connective tissue\
+        \ disease|
+      gt0008|Renal insufficiency: 0|local::at0011|No|
+      gt0009|Male age >60 years: 2|local::at0015|Yes|
+      gt0010|NYHA/WHO functional class: 0|local::at0018|II|
+      gt0011|6-minute walk test: 0|local::at0029|165-440 m|
+      gt0012|BNP, pg/mL: 0|local::at0033|50 - 180 |
+      gt0014|Pericardial effusion on echocardiogram: 0|local::at0040|No|
+      gt0015|DLCO on pulmonary function test: 0|local::at0044|33-79%|
+      gt0016|Mean right atrial pressure >20 mmHg within 1 year on right heart catheterization: 0|local::at0047|No|
+      gt0017|Pulmonary vascular resistance >32 Wood units on right heart catheterization: 0|local::at0050|No|
+  expected_output:
+    1:
+      gt0021|REVEAL Score: 11
+      gt0020|Systolic BP Score: 1|local::at0023|< 110mmHg|
+      gt0019|Heart rate Score: 1|local::at0026|> 92|
+      gt0024|Predicted 1-year survival: 3|local::at0012|70% - <85%|
+      gt0023|Risk group: 3|local::at0006|High-Risk|
+
+- id: case_5  Very high-Risk, BNP available
+  input:
+    1:
+      gt0003|Heart rate: 94,/min
+      gt0005|Systolic BP: 108,mm[Hg]
+      gt0007|WHO group 1 subgroup: 1|local::at0006|Associated PAH-connective tissue\
+        \ disease|
+      gt0008|Renal insufficiency: 0|local::at0011|No|
+      gt0009|Male age >60 years: 2|local::at0015|Yes|
+      gt0010|NYHA/WHO functional class: 0|local::at0018|II|
+      gt0011|6-minute walk test: 0|local::at0029|165-440 m|
+      gt0012|BNP, pg/mL: 1|local::at0034|>180|
+      gt0014|Pericardial effusion on echocardiogram: 0|local::at0040|No|
+      gt0015|DLCO on pulmonary function test: 1|local::at0045|≤32%|
+      gt0016|Mean right atrial pressure >20 mmHg within 1 year on right heart catheterization: 1|local::at0048|Yes|
+      gt0017|Pulmonary vascular resistance >32 Wood units on right heart catheterization: 0|local::at0050|No|
+  expected_output:
+    1:
+      gt0021|REVEAL Score: 14
+      gt0020|Systolic BP Score: 1|local::at0023|< 110mmHg|
+      gt0019|Heart rate Score: 1|local::at0026|> 92|
+      gt0024|Predicted 1-year survival: 4|local::at0013|<70%|
+      gt0023|Risk group: 4|local::at0007|Very high-Risk |
+
+- id: case_6  Low-Risk, N-terminal proBNP available
+  input:
+    1:
+      gt0003|Heart rate: 90,/min
+      gt0005|Systolic BP: 110,mm[Hg]
+      gt0007|WHO group 1 subgroup: 0|local::at0009|Other|
+      gt0008|Renal insufficiency: 0|local::at0011|No|
+      gt0009|Male age >60 years: 0|local::at0014|No|
+      gt0010|NYHA/WHO functional class: -2|local::at0017|I|
+      gt0011|6-minute walk test: -1|local::at0028|≥440 m|
+      gt0013|N-terminal proBNP: -2|local::at0036|<300|
+      gt0014|Pericardial effusion on echocardiogram: 0|local::at0040|No|
+      gt0015|DLCO on pulmonary function test: 0|local::at0044|33-79%|
+      gt0016|Mean right atrial pressure >20 mmHg within 1 year on right heart catheterization: 0|local::at0047|No|
+      gt0017|Pulmonary vascular resistance >32 Wood units on right heart catheterization: 0|local::at0050|No|
+  expected_output:
+    1:
+      gt0021|REVEAL Score: 1
+      gt0020|Systolic BP Score: 0|local::at0022|>=110 mmHg|
+      gt0019|Heart rate Score: 0|local::at0025|<=92|
+      gt0024|Predicted 1-year survival: 0|local::at0009|≥95%|
+      gt0023|Risk group: 0|local::at0003|Low-Risk|
+
+- id: case_7   Average-Risk, N-terminal proBNP available
+  input:
+    1:
+      gt0003|Heart rate: 90,/min
+      gt0005|Systolic BP: 110,mm[Hg]
+      gt0007|WHO group 1 subgroup: 0|local::at0009|Other|
+      gt0008|Renal insufficiency: 0|local::at0011|No|
+      gt0009|Male age >60 years: 2|local::at0015|Yes|
+      gt0010|NYHA/WHO functional class: 0|local::at0018|II|
+      gt0011|6-minute walk test: 0|local::at0029|165-440 m|
+      gt0013|N-terminal proBNP: 0|local::at0037|300 - 1500 |
+      gt0014|Pericardial effusion on echocardiogram: 0|local::at0040|No|
+      gt0015|DLCO on pulmonary function test: 0|local::at0044|33-79%|
+      gt0016|Mean right atrial pressure >20 mmHg within 1 year on right heart catheterization: 0|local::at0047|No|
+      gt0017|Pulmonary vascular resistance >32 Wood units on right heart catheterization: 0|local::at0050|No|
+  expected_output:
+    1:
+      gt0021|REVEAL Score: 8
+      gt0020|Systolic BP Score: 0|local::at0022|>=110 mmHg|
+      gt0019|Heart rate Score: 0|local::at0025|<=92|
+      gt0024|Predicted 1-year survival: 1|local::at0010|90% to <95%|
+      gt0023|Risk group: 1|local::at0004|Average-Risk|
+
+- id: case_8   Moderate-Risk, N-terminal proBNP available
+  input:
+    1:
+      gt0003|Heart rate: 90,/min
+      gt0005|Systolic BP: 108,mm[Hg]
+      gt0007|WHO group 1 subgroup: 0|local::at0009|Other|
+      gt0008|Renal insufficiency: 0|local::at0011|No|
+      gt0009|Male age >60 years: 2|local::at0015|Yes|
+      gt0010|NYHA/WHO functional class: 0|local::at0018|II|
+      gt0011|6-minute walk test: 0|local::at0029|165-440 m|
+      gt0013|N-terminal proBNP: 0|local::at0037|300 - 1500 |
+      gt0014|Pericardial effusion on echocardiogram: 0|local::at0040|No|
+      gt0015|DLCO on pulmonary function test: 0|local::at0044|33-79%|
+      gt0016|Mean right atrial pressure >20 mmHg within 1 year on right heart catheterization: 0|local::at0047|No|
+      gt0017|Pulmonary vascular resistance >32 Wood units on right heart catheterization: 0|local::at0050|No|
+  expected_output:
+    1:
+      gt0021|REVEAL Score: 9
+      gt0020|Systolic BP Score: 1|local::at0023|< 110mmHg|
+      gt0019|Heart rate Score: 0|local::at0025|<=92|
+      gt0024|Predicted 1-year survival: 2|local::at0011|85% to <90%|
+      gt0023|Risk group: 2|local::at0005|Moderate-Risk|
+
+- id: case_9  High-Risk, N-terminal proBNP available
+  input:
+    1:
+      gt0003|Heart rate: 94,/min
+      gt0005|Systolic BP: 108,mm[Hg]
+      gt0007|WHO group 1 subgroup: 1|local::at0006|Associated PAH-connective tissue\
+        \ disease|
+      gt0008|Renal insufficiency: 0|local::at0011|No|
+      gt0009|Male age >60 years: 2|local::at0015|Yes|
+      gt0010|NYHA/WHO functional class: 0|local::at0018|II|
+      gt0011|6-minute walk test: 0|local::at0029|165-440 m|
+      gt0013|N-terminal proBNP: 0|local::at0037|300 - 1500 |
+      gt0014|Pericardial effusion on echocardiogram: 0|local::at0040|No|
+      gt0015|DLCO on pulmonary function test: 0|local::at0044|33-79%|
+      gt0016|Mean right atrial pressure >20 mmHg within 1 year on right heart catheterization: 0|local::at0047|No|
+      gt0017|Pulmonary vascular resistance >32 Wood units on right heart catheterization: 0|local::at0050|No|
+  expected_output:
+    1:
+      gt0021|REVEAL Score: 11
+      gt0020|Systolic BP Score: 1|local::at0023|< 110mmHg|
+      gt0019|Heart rate Score: 1|local::at0026|> 92|
+      gt0024|Predicted 1-year survival: 3|local::at0012|70% - <85%|
+      gt0023|Risk group: 3|local::at0006|High-Risk|
+
+- id: case_10  Very high-Risk, N-terminal proBNP available
+  input:
+    1:
+      gt0003|Heart rate: 94,/min
+      gt0005|Systolic BP: 108,mm[Hg]
+      gt0007|WHO group 1 subgroup: 1|local::at0006|Associated PAH-connective tissue\
+        \ disease|
+      gt0008|Renal insufficiency: 1|local::at0012|Yes|
+      gt0009|Male age >60 years: 2|local::at0015|Yes|
+      gt0010|NYHA/WHO functional class: 1|local::at0019|III|
+      gt0011|6-minute walk test: 1|local::at0030|<165 m|
+      gt0013|N-terminal proBNP: 1|local::at0038|> 1500|
+      gt0014|Pericardial effusion on echocardiogram: 1|local::at0041|Yes|
+      gt0015|DLCO on pulmonary function test: 0|local::at0044|33-79%|
+      gt0016|Mean right atrial pressure >20 mmHg within 1 year on right heart catheterization: 1|local::at0048|Yes|
+      gt0017|Pulmonary vascular resistance >32 Wood units on right heart catheterization: 2|local::at0051|Yes|
+  expected_output:
+    1:
+      gt0021|REVEAL Score: 19
+      gt0020|Systolic BP Score: 1|local::at0023|< 110mmHg|
+      gt0019|Heart rate Score: 1|local::at0026|> 92|
+      gt0024|Predicted 1-year survival: 4|local::at0013|<70%|
+      gt0023|Risk group: 4|local::at0007|Very high-Risk |
+
+
+
+
+

--- a/gdl2/REVEAL_Score.v1.test.yml
+++ b/gdl2/REVEAL_Score.v1.test.yml
@@ -1,240 +1,260 @@
 guidelines:
-  1: REVEAL_Score.v1
+  1: new_guideline.v0
 test_cases:
-- id: case_1   Low-Risk, BNP available
+- id: case_1 Low-Risk Group
   input:
     1:
-      gt0003|Heart rate: 91,/min
+      gt0003|Male Age: 56,a
       gt0005|Systolic BP: 120,mm[Hg]
-      gt0007|WHO group 1 subgroup: 0|local::at0009|Other|
-      gt0008|Renal insufficiency: 0|local::at0011|No|
-      gt0009|Male age >60 years: 2|local::at0015|Yes|
-      gt0010|NYHA/WHO functional class: -2|local::at0017|I|
-      gt0011|6-minute walk test: 0|local::at0029|165-440 m|
-      gt0012|BNP, pg/mL: 0|local::at0033|50 - 180 |
+      gt0007|Heart rate: 91,/min
+      gt0009|WHO group 1 subgroup: 0|local::at0009|Other|
+      gt0010|Renal insufficiency: 0|local::at0011|No|
+      gt0011|NYHA/WHO functional class: -2|local::at0017|I|
+      gt0012|6-minute walk test: 0|local::at0029|165-440 m|
+      gt0013|BNP, pg/ml or N-terminal proBNP, pg/ml: 0|local::at0033|BNP 50 - 180\
+        \ or N-terminal proBNP 300-1500|
       gt0014|Pericardial effusion on echocardiogram: 0|local::at0040|No|
       gt0015|DLCO on pulmonary function test: 0|local::at0044|33-79%|
       gt0016|Mean right atrial pressure >20 mmHg within 1 year on right heart catheterization: 0|local::at0047|No|
       gt0017|Pulmonary vascular resistance >32 Wood units on right heart catheterization: 0|local::at0050|No|
   expected_output:
     1:
-      gt0021|REVEAL Score: 6
+      gt0021|Heart rate Score: 0|local::at0025|<=92|
+      gt0022|REVEAL Score: 6
       gt0020|Systolic BP Score: 0|local::at0022|>=110 mmHg|
-      gt0019|Heart rate Score: 0|local::at0025|<=92|
-      gt0024|Predicted 1-year survival: 0|local::at0009|≥95%|
-      gt0023|Risk group: 0|local::at0003|Low-Risk|
+      gt0019|Male age Score: 2|local::at0015|Yes|
+      gt0025|Predicted 1-year survival: 0|local::at0009|≥95%|
+      gt0024|Risk group: 0|local::at0003|Low-Risk|
 
-- id: case_2  Average-Risk, BNP available
+- id: case_2  Low-Risk Group
   input:
     1:
-      gt0003|Heart rate: 91,/min
+      gt0003|Male Age: 61,a
+      gt0005|Systolic BP: 110,mm[Hg]
+      gt0007|Heart rate: 90,/min
+      gt0009|WHO group 1 subgroup: 0|local::at0009|Other|
+      gt0010|Renal insufficiency: 0|local::at0011|No|
+      gt0011|NYHA/WHO functional class: -2|local::at0017|I|
+      gt0012|6-minute walk test: -1|local::at0028|≥440 m|
+      gt0013|BNP, pg/ml or N-terminal proBNP, pg/ml: -2|local::at0032|BNP <50 or\
+        \ N-terminal proBNP <300|
+      gt0014|Pericardial effusion on echocardiogram: 0|local::at0040|No|
+      gt0015|DLCO on pulmonary function test: 0|local::at0044|33-79%|
+      gt0016|Mean right atrial pressure >20 mmHg within 1 year on right heart catheterization: 0|local::at0047|No|
+      gt0017|Pulmonary vascular resistance >32 Wood units on right heart catheterization: 0|local::at0050|No|
+  expected_output:
+    1:
+      gt0021|Heart rate Score: 0|local::at0025|<=92|
+      gt0022|REVEAL Score: 1
+      gt0020|Systolic BP Score: 0|local::at0022|>=110 mmHg|
+      gt0019|Male age Score: 0|local::at0014|No|
+      gt0025|Predicted 1-year survival: 0|local::at0009|≥95%|
+      gt0024|Risk group: 0|local::at0003|Low-Risk|
+
+
+- id: case_3  Average-Risk Group
+  input:
+    1:
+      gt0003|Male Age: 56,a
       gt0005|Systolic BP: 120,mm[Hg]
-      gt0007|WHO group 1 subgroup: 0|local::at0009|Other|
-      gt0008|Renal insufficiency: 0|local::at0011|No|
-      gt0009|Male age >60 years: 2|local::at0015|Yes|
-      gt0010|NYHA/WHO functional class: 0|local::at0018|II|
-      gt0011|6-minute walk test: 0|local::at0029|165-440 m|
-      gt0012|BNP, pg/mL: 0|local::at0033|50 - 180 |
+      gt0007|Heart rate: 91,/min
+      gt0009|WHO group 1 subgroup: 0|local::at0009|Other|
+      gt0010|Renal insufficiency: 0|local::at0011|No|
+      gt0011|NYHA/WHO functional class: 0|local::at0018|II|
+      gt0012|6-minute walk test: 0|local::at0029|165-440 m|
+      gt0013|BNP, pg/ml or N-terminal proBNP, pg/ml: 0|local::at0033|BNP 50 - 180\
+        \ or N-terminal proBNP 300-1500|
       gt0014|Pericardial effusion on echocardiogram: 0|local::at0040|No|
       gt0015|DLCO on pulmonary function test: 0|local::at0044|33-79%|
       gt0016|Mean right atrial pressure >20 mmHg within 1 year on right heart catheterization: 0|local::at0047|No|
       gt0017|Pulmonary vascular resistance >32 Wood units on right heart catheterization: 0|local::at0050|No|
   expected_output:
     1:
-      gt0021|REVEAL Score: 8
+      gt0021|Heart rate Score: 0|local::at0025|<=92|
+      gt0022|REVEAL Score: 8
       gt0020|Systolic BP Score: 0|local::at0022|>=110 mmHg|
-      gt0019|Heart rate Score: 0|local::at0025|<=92|
-      gt0024|Predicted 1-year survival: 1|local::at0010|90% to <95%|
-      gt0023|Risk group: 1|local::at0004|Average-Risk|
+      gt0019|Male age Score: 2|local::at0015|Yes|
+      gt0025|Predicted 1-year survival: 1|local::at0010|90% to <95%|
+      gt0024|Risk group: 1|local::at0004|Average-Risk|
 
-- id: case_3  Moderate-Risk, BNP available
+- id: case_4 Average-Risk Group
   input:
     1:
-      gt0003|Heart rate: 91,/min
-      gt0005|Systolic BP: 108,mm[Hg]
-      gt0007|WHO group 1 subgroup: 0|local::at0009|Other|
-      gt0008|Renal insufficiency: 0|local::at0011|No|
-      gt0009|Male age >60 years: 2|local::at0015|Yes|
-      gt0010|NYHA/WHO functional class: 0|local::at0018|II|
-      gt0011|6-minute walk test: 0|local::at0029|165-440 m|
-      gt0012|BNP, pg/mL: 0|local::at0033|50 - 180 |
+      gt0003|Male Age: 61,a
+      gt0005|Systolic BP: 104,mm[Hg]
+      gt0007|Heart rate: 93,/min
+      gt0009|WHO group 1 subgroup: 0|local::at0009|Other|
+      gt0010|Renal insufficiency: 0|local::at0011|No|
+      gt0011|NYHA/WHO functional class: 0|local::at0018|II|
+      gt0012|6-minute walk test: 0|local::at0029|165-440 m|
+      gt0013|BNP, pg/ml or N-terminal proBNP, pg/ml: 0|local::at0033|BNP 50 - 180\
+        \ or N-terminal proBNP 300-1500|
       gt0014|Pericardial effusion on echocardiogram: 0|local::at0040|No|
       gt0015|DLCO on pulmonary function test: 0|local::at0044|33-79%|
       gt0016|Mean right atrial pressure >20 mmHg within 1 year on right heart catheterization: 0|local::at0047|No|
       gt0017|Pulmonary vascular resistance >32 Wood units on right heart catheterization: 0|local::at0050|No|
   expected_output:
     1:
-      gt0021|REVEAL Score: 9
+      gt0021|Heart rate Score: 1|local::at0026|> 92|
+      gt0022|REVEAL Score: 8
       gt0020|Systolic BP Score: 1|local::at0023|< 110mmHg|
-      gt0019|Heart rate Score: 0|local::at0025|<=92|
-      gt0024|Predicted 1-year survival: 2|local::at0011|85% to <90%|
-      gt0023|Risk group: 2|local::at0005|Moderate-Risk|
+      gt0019|Male age Score: 0|local::at0014|No|
+      gt0025|Predicted 1-year survival: 1|local::at0010|90% to <95%|
+      gt0024|Risk group: 1|local::at0004|Average-Risk|
 
-- id: case_4  High-Risk, BNP available
+- id: case_5  Moderate-Risk Group
   input:
     1:
-      gt0003|Heart rate: 94,/min
-      gt0005|Systolic BP: 108,mm[Hg]
-      gt0007|WHO group 1 subgroup: 1|local::at0006|Associated PAH-connective tissue\
-        \ disease|
-      gt0008|Renal insufficiency: 0|local::at0011|No|
-      gt0009|Male age >60 years: 2|local::at0015|Yes|
-      gt0010|NYHA/WHO functional class: 0|local::at0018|II|
-      gt0011|6-minute walk test: 0|local::at0029|165-440 m|
-      gt0012|BNP, pg/mL: 0|local::at0033|50 - 180 |
+      gt0003|Male Age: 61,a
+      gt0005|Systolic BP: 104,mm[Hg]
+      gt0007|Heart rate: 93,/min
+      gt0009|WHO group 1 subgroup: 0|local::at0009|Other|
+      gt0010|Renal insufficiency: 0|local::at0011|No|
+      gt0011|NYHA/WHO functional class: 1|local::at0019|III|
+      gt0012|6-minute walk test: 0|local::at0029|165-440 m|
+      gt0013|BNP, pg/ml or N-terminal proBNP, pg/ml: 0|local::at0033|BNP 50 - 180\
+        \ or N-terminal proBNP 300-1500|
       gt0014|Pericardial effusion on echocardiogram: 0|local::at0040|No|
       gt0015|DLCO on pulmonary function test: 0|local::at0044|33-79%|
       gt0016|Mean right atrial pressure >20 mmHg within 1 year on right heart catheterization: 0|local::at0047|No|
       gt0017|Pulmonary vascular resistance >32 Wood units on right heart catheterization: 0|local::at0050|No|
   expected_output:
     1:
-      gt0021|REVEAL Score: 11
+      gt0021|Heart rate Score: 1|local::at0026|> 92|
+      gt0022|REVEAL Score: 9
       gt0020|Systolic BP Score: 1|local::at0023|< 110mmHg|
-      gt0019|Heart rate Score: 1|local::at0026|> 92|
-      gt0024|Predicted 1-year survival: 3|local::at0012|70% - <85%|
-      gt0023|Risk group: 3|local::at0006|High-Risk|
+      gt0019|Male age Score: 0|local::at0014|No|
+      gt0025|Predicted 1-year survival: 2|local::at0011|85% to <90%|
+      gt0024|Risk group: 2|local::at0005|Moderate-Risk|
 
-- id: case_5  Very high-Risk, BNP available
+- id: case_6  Moderate-Risk Group
   input:
     1:
-      gt0003|Heart rate: 94,/min
+      gt0003|Male Age: 56,a
       gt0005|Systolic BP: 108,mm[Hg]
-      gt0007|WHO group 1 subgroup: 1|local::at0006|Associated PAH-connective tissue\
+      gt0007|Heart rate: 91,/min
+      gt0009|WHO group 1 subgroup: 0|local::at0009|Other|
+      gt0010|Renal insufficiency: 0|local::at0011|No|
+      gt0011|NYHA/WHO functional class: 0|local::at0018|II|
+      gt0012|6-minute walk test: 0|local::at0029|165-440 m|
+      gt0013|BNP, pg/ml or N-terminal proBNP, pg/ml: 0|local::at0033|BNP 50 - 180\
+        \ or N-terminal proBNP 300-1500|
+      gt0014|Pericardial effusion on echocardiogram: 0|local::at0040|No|
+      gt0015|DLCO on pulmonary function test: 0|local::at0044|33-79%|
+      gt0016|Mean right atrial pressure >20 mmHg within 1 year on right heart catheterization: 0|local::at0047|No|
+      gt0017|Pulmonary vascular resistance >32 Wood units on right heart catheterization: 0|local::at0050|No|
+  expected_output:
+    1:
+      gt0021|Heart rate Score: 0|local::at0025|<=92|
+      gt0022|REVEAL Score: 9
+      gt0020|Systolic BP Score: 1|local::at0023|< 110mmHg|
+      gt0019|Male age Score: 2|local::at0015|Yes|
+      gt0025|Predicted 1-year survival: 2|local::at0011|85% to <90%|
+      gt0024|Risk group: 2|local::at0005|Moderate-Risk|
+
+
+- id: case_7  High-Risk Group
+  input:
+    1:
+      gt0003|Male Age: 56,a
+      gt0005|Systolic BP: 108,mm[Hg]
+      gt0007|Heart rate: 94,/min
+      gt0009|WHO group 1 subgroup: 1|local::at0006|Associated PAH-connective tissue\
         \ disease|
-      gt0008|Renal insufficiency: 0|local::at0011|No|
-      gt0009|Male age >60 years: 2|local::at0015|Yes|
-      gt0010|NYHA/WHO functional class: 0|local::at0018|II|
-      gt0011|6-minute walk test: 0|local::at0029|165-440 m|
-      gt0012|BNP, pg/mL: 1|local::at0034|>180|
+      gt0010|Renal insufficiency: 0|local::at0011|No|
+      gt0011|NYHA/WHO functional class: 0|local::at0018|II|
+      gt0012|6-minute walk test: 0|local::at0029|165-440 m|
+      gt0013|BNP, pg/ml or N-terminal proBNP, pg/ml: 0|local::at0033|BNP 50 - 180\
+        \ or N-terminal proBNP 300-1500|
+      gt0014|Pericardial effusion on echocardiogram: 0|local::at0040|No|
+      gt0015|DLCO on pulmonary function test: 0|local::at0044|33-79%|
+      gt0016|Mean right atrial pressure >20 mmHg within 1 year on right heart catheterization: 0|local::at0047|No|
+      gt0017|Pulmonary vascular resistance >32 Wood units on right heart catheterization: 0|local::at0050|No|
+  expected_output:
+    1:
+      gt0021|Heart rate Score: 1|local::at0026|> 92|
+      gt0022|REVEAL Score: 11
+      gt0020|Systolic BP Score: 1|local::at0023|< 110mmHg|
+      gt0019|Male age Score: 2|local::at0015|Yes|
+      gt0025|Predicted 1-year survival: 3|local::at0012|70% - <85%|
+      gt0024|Risk group: 3|local::at0006|High-Risk|
+
+- id: case_8  High-Risk Group
+  input:
+    1:
+      gt0003|Male Age: 61,a
+      gt0005|Systolic BP: 104,mm[Hg]
+      gt0007|Heart rate: 93,/min
+      gt0009|WHO group 1 subgroup: 1|local::at0006|Associated PAH-connective tissue\
+        \ disease|
+      gt0010|Renal insufficiency: 0|local::at0011|No|
+      gt0011|NYHA/WHO functional class: 1|local::at0019|III|
+      gt0012|6-minute walk test: 0|local::at0029|165-440 m|
+      gt0013|BNP, pg/ml or N-terminal proBNP, pg/ml: 0|local::at0033|BNP 50 - 180\
+        \ or N-terminal proBNP 300-1500|
+      gt0014|Pericardial effusion on echocardiogram: 0|local::at0040|No|
+      gt0015|DLCO on pulmonary function test: 0|local::at0044|33-79%|
+      gt0016|Mean right atrial pressure >20 mmHg within 1 year on right heart catheterization: 0|local::at0047|No|
+      gt0017|Pulmonary vascular resistance >32 Wood units on right heart catheterization: 0|local::at0050|No|
+  expected_output:
+    1:
+      gt0021|Heart rate Score: 1|local::at0026|> 92|
+      gt0022|REVEAL Score: 10
+      gt0020|Systolic BP Score: 1|local::at0023|< 110mmHg|
+      gt0019|Male age Score: 0|local::at0014|No|
+      gt0025|Predicted 1-year survival: 3|local::at0012|70% - <85%|
+      gt0024|Risk group: 3|local::at0006|High-Risk|
+
+- id: case_9  Very High-Risk Group
+  input:
+    1:
+      gt0003|Male Age: 56,a
+      gt0005|Systolic BP: 108,mm[Hg]
+      gt0007|Heart rate: 94,/min
+      gt0009|WHO group 1 subgroup: 1|local::at0006|Associated PAH-connective tissue\
+        \ disease|
+      gt0010|Renal insufficiency: 0|local::at0011|No|
+      gt0011|NYHA/WHO functional class: 0|local::at0018|II|
+      gt0012|6-minute walk test: 0|local::at0029|165-440 m|
+      gt0013|BNP, pg/ml or N-terminal proBNP, pg/ml: 1|local::at0034|BNP >180 or\
+        \ N-terminal proBNP >180|
       gt0014|Pericardial effusion on echocardiogram: 0|local::at0040|No|
       gt0015|DLCO on pulmonary function test: 1|local::at0045|≤32%|
       gt0016|Mean right atrial pressure >20 mmHg within 1 year on right heart catheterization: 1|local::at0048|Yes|
       gt0017|Pulmonary vascular resistance >32 Wood units on right heart catheterization: 0|local::at0050|No|
   expected_output:
     1:
-      gt0021|REVEAL Score: 14
+      gt0021|Heart rate Score: 1|local::at0026|> 92|
+      gt0022|REVEAL Score: 14
       gt0020|Systolic BP Score: 1|local::at0023|< 110mmHg|
-      gt0019|Heart rate Score: 1|local::at0026|> 92|
-      gt0024|Predicted 1-year survival: 4|local::at0013|<70%|
-      gt0023|Risk group: 4|local::at0007|Very high-Risk |
+      gt0019|Male age Score: 2|local::at0015|Yes|
+      gt0025|Predicted 1-year survival: 4|local::at0013|<70%|
+      gt0024|Risk group: 4|local::at0007|Very high-Risk |
 
-- id: case_6  Low-Risk, N-terminal proBNP available
+- id: case_10 Very High-Risk Group
   input:
     1:
-      gt0003|Heart rate: 90,/min
-      gt0005|Systolic BP: 110,mm[Hg]
-      gt0007|WHO group 1 subgroup: 0|local::at0009|Other|
-      gt0008|Renal insufficiency: 0|local::at0011|No|
-      gt0009|Male age >60 years: 0|local::at0014|No|
-      gt0010|NYHA/WHO functional class: -2|local::at0017|I|
-      gt0011|6-minute walk test: -1|local::at0028|≥440 m|
-      gt0013|N-terminal proBNP: -2|local::at0036|<300|
+      gt0003|Male Age: 61,a
+      gt0005|Systolic BP: 104,mm[Hg]
+      gt0007|Heart rate: 93,/min
+      gt0009|WHO group 1 subgroup: 2|local::at0008|Familial PAH|
+      gt0010|Renal insufficiency: 0|local::at0011|No|
+      gt0011|NYHA/WHO functional class: 1|local::at0019|III|
+      gt0012|6-minute walk test: 0|local::at0029|165-440 m|
+      gt0013|BNP, pg/ml or N-terminal proBNP, pg/ml: 1|local::at0034|BNP >180 or\
+        \ N-terminal proBNP >180|
       gt0014|Pericardial effusion on echocardiogram: 0|local::at0040|No|
       gt0015|DLCO on pulmonary function test: 0|local::at0044|33-79%|
       gt0016|Mean right atrial pressure >20 mmHg within 1 year on right heart catheterization: 0|local::at0047|No|
       gt0017|Pulmonary vascular resistance >32 Wood units on right heart catheterization: 0|local::at0050|No|
   expected_output:
     1:
-      gt0021|REVEAL Score: 1
-      gt0020|Systolic BP Score: 0|local::at0022|>=110 mmHg|
-      gt0019|Heart rate Score: 0|local::at0025|<=92|
-      gt0024|Predicted 1-year survival: 0|local::at0009|≥95%|
-      gt0023|Risk group: 0|local::at0003|Low-Risk|
-
-- id: case_7   Average-Risk, N-terminal proBNP available
-  input:
-    1:
-      gt0003|Heart rate: 90,/min
-      gt0005|Systolic BP: 110,mm[Hg]
-      gt0007|WHO group 1 subgroup: 0|local::at0009|Other|
-      gt0008|Renal insufficiency: 0|local::at0011|No|
-      gt0009|Male age >60 years: 2|local::at0015|Yes|
-      gt0010|NYHA/WHO functional class: 0|local::at0018|II|
-      gt0011|6-minute walk test: 0|local::at0029|165-440 m|
-      gt0013|N-terminal proBNP: 0|local::at0037|300 - 1500 |
-      gt0014|Pericardial effusion on echocardiogram: 0|local::at0040|No|
-      gt0015|DLCO on pulmonary function test: 0|local::at0044|33-79%|
-      gt0016|Mean right atrial pressure >20 mmHg within 1 year on right heart catheterization: 0|local::at0047|No|
-      gt0017|Pulmonary vascular resistance >32 Wood units on right heart catheterization: 0|local::at0050|No|
-  expected_output:
-    1:
-      gt0021|REVEAL Score: 8
-      gt0020|Systolic BP Score: 0|local::at0022|>=110 mmHg|
-      gt0019|Heart rate Score: 0|local::at0025|<=92|
-      gt0024|Predicted 1-year survival: 1|local::at0010|90% to <95%|
-      gt0023|Risk group: 1|local::at0004|Average-Risk|
-
-- id: case_8   Moderate-Risk, N-terminal proBNP available
-  input:
-    1:
-      gt0003|Heart rate: 90,/min
-      gt0005|Systolic BP: 108,mm[Hg]
-      gt0007|WHO group 1 subgroup: 0|local::at0009|Other|
-      gt0008|Renal insufficiency: 0|local::at0011|No|
-      gt0009|Male age >60 years: 2|local::at0015|Yes|
-      gt0010|NYHA/WHO functional class: 0|local::at0018|II|
-      gt0011|6-minute walk test: 0|local::at0029|165-440 m|
-      gt0013|N-terminal proBNP: 0|local::at0037|300 - 1500 |
-      gt0014|Pericardial effusion on echocardiogram: 0|local::at0040|No|
-      gt0015|DLCO on pulmonary function test: 0|local::at0044|33-79%|
-      gt0016|Mean right atrial pressure >20 mmHg within 1 year on right heart catheterization: 0|local::at0047|No|
-      gt0017|Pulmonary vascular resistance >32 Wood units on right heart catheterization: 0|local::at0050|No|
-  expected_output:
-    1:
-      gt0021|REVEAL Score: 9
+      gt0021|Heart rate Score: 1|local::at0026|> 92|
+      gt0022|REVEAL Score: 12
       gt0020|Systolic BP Score: 1|local::at0023|< 110mmHg|
-      gt0019|Heart rate Score: 0|local::at0025|<=92|
-      gt0024|Predicted 1-year survival: 2|local::at0011|85% to <90%|
-      gt0023|Risk group: 2|local::at0005|Moderate-Risk|
-
-- id: case_9  High-Risk, N-terminal proBNP available
-  input:
-    1:
-      gt0003|Heart rate: 94,/min
-      gt0005|Systolic BP: 108,mm[Hg]
-      gt0007|WHO group 1 subgroup: 1|local::at0006|Associated PAH-connective tissue\
-        \ disease|
-      gt0008|Renal insufficiency: 0|local::at0011|No|
-      gt0009|Male age >60 years: 2|local::at0015|Yes|
-      gt0010|NYHA/WHO functional class: 0|local::at0018|II|
-      gt0011|6-minute walk test: 0|local::at0029|165-440 m|
-      gt0013|N-terminal proBNP: 0|local::at0037|300 - 1500 |
-      gt0014|Pericardial effusion on echocardiogram: 0|local::at0040|No|
-      gt0015|DLCO on pulmonary function test: 0|local::at0044|33-79%|
-      gt0016|Mean right atrial pressure >20 mmHg within 1 year on right heart catheterization: 0|local::at0047|No|
-      gt0017|Pulmonary vascular resistance >32 Wood units on right heart catheterization: 0|local::at0050|No|
-  expected_output:
-    1:
-      gt0021|REVEAL Score: 11
-      gt0020|Systolic BP Score: 1|local::at0023|< 110mmHg|
-      gt0019|Heart rate Score: 1|local::at0026|> 92|
-      gt0024|Predicted 1-year survival: 3|local::at0012|70% - <85%|
-      gt0023|Risk group: 3|local::at0006|High-Risk|
-
-- id: case_10  Very high-Risk, N-terminal proBNP available
-  input:
-    1:
-      gt0003|Heart rate: 94,/min
-      gt0005|Systolic BP: 108,mm[Hg]
-      gt0007|WHO group 1 subgroup: 1|local::at0006|Associated PAH-connective tissue\
-        \ disease|
-      gt0008|Renal insufficiency: 1|local::at0012|Yes|
-      gt0009|Male age >60 years: 2|local::at0015|Yes|
-      gt0010|NYHA/WHO functional class: 1|local::at0019|III|
-      gt0011|6-minute walk test: 1|local::at0030|<165 m|
-      gt0013|N-terminal proBNP: 1|local::at0038|> 1500|
-      gt0014|Pericardial effusion on echocardiogram: 1|local::at0041|Yes|
-      gt0015|DLCO on pulmonary function test: 0|local::at0044|33-79%|
-      gt0016|Mean right atrial pressure >20 mmHg within 1 year on right heart catheterization: 1|local::at0048|Yes|
-      gt0017|Pulmonary vascular resistance >32 Wood units on right heart catheterization: 2|local::at0051|Yes|
-  expected_output:
-    1:
-      gt0021|REVEAL Score: 19
-      gt0020|Systolic BP Score: 1|local::at0023|< 110mmHg|
-      gt0019|Heart rate Score: 1|local::at0026|> 92|
-      gt0024|Predicted 1-year survival: 4|local::at0013|<70%|
-      gt0023|Risk group: 4|local::at0007|Very high-Risk |
-
+      gt0019|Male age Score: 0|local::at0014|No|
+      gt0025|Predicted 1-year survival: 4|local::at0013|<70%|
+      gt0024|Risk group: 4|local::at0007|Very high-Risk |
 
 
 


### PR DESCRIPTION
Adding Archetype (observation and evaluation) files, GDL2 files and test fixture file for REVEAL Score