### PR TITLE
Glasgow Alcoholic Hepatitis Score

### DIFF
--- a/archetypes/openEHR-EHR-EVALUATION.glasgow_alcoholic_hepatitis_score.v1.adl
+++ b/archetypes/openEHR-EHR-EVALUATION.glasgow_alcoholic_hepatitis_score.v1.adl
@@ -1,0 +1,101 @@
+archetype (adl_version=1.4)
+	openEHR-EHR-EVALUATION.glasgow_alcoholic_hepatitis_score.v1
+
+concept
+	[at0000]	-- Glasgow alcoholic hepatitis score
+language
+	original_language = <[ISO_639-1::en]>
+description
+	original_author = <
+		["name"] = <"Winner Ng">
+		["email"] = <"dokter.winner@gmail.com">
+		["organisation"] = <"Cambio CDS">
+		["date"] = <"2020-04-10">
+	>
+	details = <
+		["en"] = <
+			language = <[ISO_639-1::en]>
+			purpose = <"To provide interpretation of the outcome prediction in patients with alcoholic hepatitis.">
+			use = <"Glasgow Alcoholic score is calculated by the addition of the following points:
+- age : <50 yrs: 1p, ≥50 yrs: 2p
+- white blood cell counts: <15*10^9: 1p, ≥15*10^9: 2p
+- urea level: <5 mmol/L: 1p, ≥5 mmol/L: 2p
+- PT ratio: < 1.5: 1p, 1.5-2: 2p, >2: 3p
+- bilirubin: <125 μmol/L: 1p, 125-250 μmol/L: 2p, >250 μmol/L: 3p
+The Glasgow Alcoholic Hepatitis Score ranges  from 5 to 12 as the minimum and maximum score, respectively.
+The assessment is to be performed on day 1 of admission and day 6-9.
+
+Scores of less than 9 show a much better 28- and 84-day survival than scores above 9 or above (87%/79% vs. 46%/40%). The score is less sensitive but more accurate than the Modified Discriminant Function or MELD scores.">
+			keywords = <"GAHS", "Glasgow", "alcoholic hepatitis", "outcome", "survival", "prediction">
+			misuse = <"Not to be used in other causes of hepatitis.">
+			copyright = <"@CambioCDS">
+		>
+	>
+	lifecycle_state = <"AuthorDraft">
+	other_contributors = <>
+	other_details = <
+		["references"] = <"1. Forrest EH, Evans CD, Stewart S, Phillips M, Oo YH, McAvoy NC, Fisher NC, Singhal S, Brind A, Haydon G, O'Grady J, Day CP, Hayes PC, Murray LS, Morris AJ. Analysis of factors predictive of mortality in alcoholic hepatitis and derivation and validation of the Glasgow alcoholic hepatitis score. Gut. 2005 Aug;54(8):1174-9. PubMed PMID: 16009691; PubMed Central PMCID: PMC1774903.">
+		["MD5-CAM-1.0.1"] = <"E058B683EED86636E040CAD0C5E1CAB5">
+	>
+
+definition
+	EVALUATION[at0000] matches {	-- Glasgow alcoholic hepatitis score
+		data matches {
+			ITEM_TREE[at0001] matches {	-- Tree
+				items cardinality matches {0..*; unordered} matches {
+					ELEMENT[at0002] occurrences matches {0..1} matches {	-- Day 28 survival rate
+						value matches {
+							0|[local::at0003], 	-- Low (46%)
+							1|[local::at0004]  	-- High (87%)
+						}
+					}
+					ELEMENT[at0005] occurrences matches {0..1} matches {	-- Day 84 survival rate
+						value matches {
+							0|[local::at0006], 	-- Low (40%)
+							1|[local::at0007]  	-- High (79%)
+						}
+					}
+				}
+			}
+		}
+	}
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"Glasgow alcoholic hepatitis score">
+					description = <"The tool to assess the condition and predict the 28-day and 84-day survival rate outcomes in patients with alcoholic hepatitis.">
+				>
+				["at0001"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0002"] = <
+					text = <"Day 28 survival rate">
+					description = <"*">
+				>
+				["at0003"] = <
+					text = <"Low (46%)">
+					description = <"*">
+				>
+				["at0004"] = <
+					text = <"High (87%)">
+					description = <"*">
+				>
+				["at0005"] = <
+					text = <"Day 84 survival rate">
+					description = <"*">
+				>
+				["at0006"] = <
+					text = <"Low (40%)">
+					description = <"*">
+				>
+				["at0007"] = <
+					text = <"High (79%)">
+					description = <"*">
+				>
+			>
+		>
+	>

--- a/archetypes/openEHR-EHR-OBSERVATION.glasgow_alcoholic_hepatitis_score.v1.adl
+++ b/archetypes/openEHR-EHR-OBSERVATION.glasgow_alcoholic_hepatitis_score.v1.adl
@@ -1,0 +1,218 @@
+archetype (adl_version=1.4)
+	openEHR-EHR-OBSERVATION.glasgow_alcoholic_hepatitis_score.v1
+
+concept
+	[at0000]	-- Glasgow alcoholic hepatitis score
+language
+	original_language = <[ISO_639-1::en]>
+description
+	original_author = <
+		["name"] = <"Winner Ng">
+		["email"] = <"dokter.winner@gmail.com">
+		["organisation"] = <"Cambio CDS">
+		["date"] = <"2020-04-10">
+	>
+	details = <
+		["en"] = <
+			language = <[ISO_639-1::en]>
+			purpose = <"To record the parameters for predicting outcomes in patients with alcoholic hepatitis.">
+			use = <"Glasgow Alcoholic score is calculated by the addition of the following points:
+- age : <50 yrs: 1p, ≥50 yrs: 2p
+- white blood cell counts: <15*10^9: 1p, ≥15*10^9: 2p
+- urea level: <5 mmol/L: 1p, ≥5 mmol/L: 2p
+- PT ratio: < 1.5: 1p, 1.5-2: 2p, >2: 3p
+- bilirubin: <125 μmol/L: 1p, 125-250 μmol/L: 2p, >250 μmol/L: 3p
+The Glasgow Alcoholic Hepatitis Score ranges  from 5 to 12 as the minimum and maximum score, respectively.
+The assessment is to be performed on day 1 of admission and day 6-9.
+
+Scores of less than 9 show a much better 28- and 84-day survival than scores above 9 or above (87%/79% vs. 46%/40%). The score is less sensitive but more accurate than the Modified Discriminant Function or MELD scores.">
+			keywords = <"GAHS", "Glasgow", "alcoholic hepatitis", "outcome", "survival", "prediction">
+			misuse = <"Not to be used in other causes of hepatitis.">
+			copyright = <"@CambioCDS">
+		>
+	>
+	lifecycle_state = <"AuthorDraft">
+	other_contributors = <>
+	other_details = <
+		["references"] = <"1. Forrest EH, Evans CD, Stewart S, Phillips M, Oo YH, McAvoy NC, Fisher NC, Singhal S, Brind A, Haydon G, O'Grady J, Day CP, Hayes PC, Murray LS, Morris AJ. Analysis of factors predictive of mortality in alcoholic hepatitis and derivation and validation of the Glasgow alcoholic hepatitis score. Gut. 2005 Aug;54(8):1174-9. PubMed PMID: 16009691; PubMed Central PMCID: PMC1774903.">
+		["MD5-CAM-1.0.1"] = <"3B54D9F36F060263DEAD6B27A11D5589">
+	>
+
+definition
+	OBSERVATION[at0000] matches {	-- Glasgow alcoholic hepatitis score
+		data matches {
+			HISTORY[at0001] matches {	-- Event Series
+				events cardinality matches {1..*; unordered} matches {
+					EVENT[at0002] occurrences matches {0..1} matches {	-- Any event
+						data matches {
+							ITEM_TREE[at0003] matches {	-- Tree
+								items cardinality matches {0..*; unordered} matches {
+									ELEMENT[at0004] occurrences matches {0..1} matches {	-- Age
+										value matches {
+											1|[local::at0005], 	-- < 50 years
+											2|[local::at0006]  	-- ≥ 50 years
+										}
+									}
+									ELEMENT[at0007] occurrences matches {0..1} matches {	-- White Blood Cell Count
+										value matches {
+											1|[local::at0008], 	-- < 15 * 10^9/L
+											2|[local::at0009]  	-- ≥ 15 * 10^9/L
+										}
+									}
+									ELEMENT[at0010] occurrences matches {0..1} matches {	-- Urea
+										value matches {
+											1|[local::at0011], 	-- < 5 mmol/L
+											2|[local::at0012]  	-- ≥ 5 mmol/L
+										}
+									}
+									ELEMENT[at0022] occurrences matches {0..1} matches {	-- normal lab PT reference
+										value matches {
+											C_DV_QUANTITY <
+												property = <[openehr::128]>
+												list = <
+													["1"] = <
+														units = <"s">
+														magnitude = <|>=0.0|>
+														precision = <|0|>
+													>
+												>
+											>
+										}
+									}
+									ELEMENT[at0023] occurrences matches {0..1} matches {	-- PT ratio
+										value matches {
+											C_DV_QUANTITY <
+											>
+										}
+									}
+									ELEMENT[at0013] occurrences matches {0..1} matches {	-- PT ratio ordinal
+										value matches {
+											1|[local::at0014], 	-- < 1.5
+											2|[local::at0015], 	-- 1.5 - 2.0
+											3|[local::at0016]  	-- > 2.0
+										}
+									}
+									ELEMENT[at0017] occurrences matches {0..1} matches {	-- Bilirubin
+										value matches {
+											1|[local::at0018], 	-- < 125 umol/L
+											2|[local::at0019], 	-- 125 - 250 umol/L
+											3|[local::at0020]  	-- > 250 umol/L
+										}
+									}
+									ELEMENT[at0021] occurrences matches {0..1} matches {	-- Glasgow alcoholic hepatitis score
+										value matches {
+											DV_COUNT matches {*}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"Glasgow alcoholic hepatitis score">
+					description = <"The tool to assess the condition and predict the 28-day and 84-day survival rate outcomes in patients with alcoholic hepatitis.">
+				>
+				["at0001"] = <
+					text = <"Event Series">
+					description = <"@ internal @">
+				>
+				["at0002"] = <
+					text = <"Any event">
+					description = <"*">
+				>
+				["at0003"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0004"] = <
+					text = <"Age">
+					description = <"*">
+				>
+				["at0005"] = <
+					text = <"< 50 years">
+					description = <"*">
+				>
+				["at0006"] = <
+					text = <"≥ 50 years">
+					description = <"*">
+				>
+				["at0007"] = <
+					text = <"White Blood Cell Count">
+					description = <"*">
+				>
+				["at0008"] = <
+					text = <"< 15 * 10^9/L">
+					description = <"*">
+				>
+				["at0009"] = <
+					text = <"≥ 15 * 10^9/L">
+					description = <"*">
+				>
+				["at0010"] = <
+					text = <"Urea">
+					description = <"*">
+				>
+				["at0011"] = <
+					text = <"< 5 mmol/L">
+					description = <"*">
+				>
+				["at0012"] = <
+					text = <"≥ 5 mmol/L">
+					description = <"*">
+				>
+				["at0013"] = <
+					text = <"PT ratio ordinal">
+					description = <"*">
+				>
+				["at0014"] = <
+					text = <"< 1.5">
+					description = <"*">
+				>
+				["at0015"] = <
+					text = <"1.5 - 2.0">
+					description = <"*">
+				>
+				["at0016"] = <
+					text = <"> 2.0">
+					description = <"*">
+				>
+				["at0017"] = <
+					text = <"Bilirubin">
+					description = <"*">
+				>
+				["at0018"] = <
+					text = <"< 125 umol/L">
+					description = <"*">
+				>
+				["at0019"] = <
+					text = <"125 - 250 umol/L">
+					description = <"*">
+				>
+				["at0020"] = <
+					text = <"> 250 umol/L">
+					description = <"*">
+				>
+				["at0021"] = <
+					text = <"Glasgow alcoholic hepatitis score">
+					description = <"*">
+				>
+				["at0022"] = <
+					text = <"normal lab PT reference">
+					description = <"*">
+				>
+				["at0023"] = <
+					text = <"PT ratio">
+					description = <"*">
+				>
+			>
+		>
+	>

--- a/gdl2/Glasgow_alcoholic_hepatitis_score.v1.gdl2.json
+++ b/gdl2/Glasgow_alcoholic_hepatitis_score.v1.gdl2.json
@@ -1,0 +1,553 @@
+{
+  "id": "Glasgow_alcoholic_hepatitis_score.v1",
+  "gdl_version": "2.0",
+  "concept": "gt0001",
+  "language": {
+    "original_language": "ISO_639-1::en"
+  },
+  "description": {
+    "original_author": {
+      "date": "2020-04-10",
+      "name": "Winner Ng",
+      "organisation": "Cambio CDS",
+      "email": "dokter.winner@gmail.com"
+    },
+    "lifecycle_state": "Author draft",
+    "details": {
+      "en": {
+        "id": "en",
+        "purpose": "To predict the 28-day and 84-day survival rate outcomes in patients with alcoholic hepatitis.",
+        "keywords": [
+          "GAHS",
+          "Glasgow",
+          "alcoholic hepatitis",
+          "outcome",
+          "survival",
+          "prediction"
+        ],
+        "use": "Glasgow Alcoholic score is calculated by the addition of the following points:\n- age : <50 yrs: 1p, ≥50 yrs: 2p\n- white blood cell counts: <15*10^9: 1p, ≥15*10^9: 2p\n- urea level: <5 mmol/L: 1p, ≥5 mmol/L: 2p\n- PT ratio: < 1.5: 1p, 1.5-2: 2p, >2: 3p\n- bilirubin: <125 μmol/L: 1p, 125-250 μmol/L: 2p, >250 μmol/L: 3p\nThe Glasgow Alcoholic Hepatitis Score ranges  from 5 to 12 as the minimum and maximum score, respectively.\nThe assessment is to be performed on day 1 of admission and day 6-9.\n\nScores of less than 9 show a much better 28- and 84-day survival than scores above 9 or above (87%/79% vs. 46%/40%). The score is less sensitive but more accurate than the Modified Discriminant Function or MELD scores.",
+        "misuse": "Not to be used in other causes of hepatitis.",
+        "copyright": "@CambioCDS"
+      }
+    },
+    "other_details": {
+      "references": "1. Forrest EH, Evans CD, Stewart S, Phillips M, Oo YH, McAvoy NC, Fisher NC, Singhal S, Brind A, Haydon G, O'Grady J, Day CP, Hayes PC, Murray LS, Morris AJ. Analysis of factors predictive of mortality in alcoholic hepatitis and derivation and validation of the Glasgow alcoholic hepatitis score. Gut. 2005 Aug;54(8):1174-9. PubMed PMID: 16009691; PubMed Central PMCID: PMC1774903."
+    }
+  },
+  "definition": {
+    "data_bindings": {
+      "gt0002": {
+        "id": "gt0002",
+        "model_id": "openEHR-EHR-OBSERVATION.basic_demographic.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.basic_demographic.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0003": {
+            "id": "gt0003",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0013]"
+          }
+        }
+      },
+      "gt0004": {
+        "id": "gt0004",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-full_blood_count.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-full_blood_count.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0005": {
+            "id": "gt0005",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.13]"
+          }
+        }
+      },
+      "gt0006": {
+        "id": "gt0006",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-urea_and_electrolytes.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-urea_and_electrolytes.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0007": {
+            "id": "gt0007",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.1]"
+          }
+        }
+      },
+      "gt0008": {
+        "id": "gt0008",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-liver_function.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-liver_function.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0009": {
+            "id": "gt0009",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0078.4]"
+          }
+        }
+      },
+      "gt0010": {
+        "id": "gt0010",
+        "model_id": "openEHR-EHR-OBSERVATION.lab_test-coagulation_profile.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.lab_test-coagulation_profile.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0011": {
+            "id": "gt0011",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0.91]"
+          }
+        }
+      },
+      "gt0012": {
+        "id": "gt0012",
+        "model_id": "openEHR-EHR-OBSERVATION.glasgow_alcoholic_hepatitis_score.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.glasgow_alcoholic_hepatitis_score.v1",
+        "type": "INPUT",
+        "elements": {
+          "gt0013": {
+            "id": "gt0013",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0022]"
+          }
+        }
+      },
+      "gt0014": {
+        "id": "gt0014",
+        "model_id": "openEHR-EHR-OBSERVATION.glasgow_alcoholic_hepatitis_score.v1",
+        "template_id": "openEHR-EHR-OBSERVATION.glasgow_alcoholic_hepatitis_score.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0015": {
+            "id": "gt0015",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0004]"
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0007]"
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0010]"
+          },
+          "gt0018": {
+            "id": "gt0018",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0023]"
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0013]"
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0017]"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "path": "/data[at0001]/events[at0002]/data[at0003]/items[at0021]"
+          }
+        }
+      },
+      "gt0044": {
+        "id": "gt0044",
+        "model_id": "openEHR-EHR-EVALUATION.glasgow_alcoholic_hepatitis_score.v1",
+        "template_id": "openEHR-EHR-EVALUATION.glasgow_alcoholic_hepatitis_score.v1",
+        "type": "OUTPUT",
+        "elements": {
+          "gt0045": {
+            "id": "gt0045",
+            "path": "/data[at0001]/items[at0002]"
+          },
+          "gt0046": {
+            "id": "gt0046",
+            "path": "/data[at0001]/items[at0005]"
+          }
+        }
+      }
+    },
+    "pre_conditions": [
+      "$gt0003|Age|.unit=='a'"
+    ],
+    "rules": {
+      "gt0025": {
+        "id": "gt0025",
+        "priority": 19,
+        "when": [
+          "$gt0003|Age|<50,a"
+        ],
+        "then": [
+          "$gt0015|Age|=1|local::at0005|< 50 years|"
+        ]
+      },
+      "gt0026": {
+        "id": "gt0026",
+        "priority": 18,
+        "when": [
+          "$gt0003|Age|>=50,a"
+        ],
+        "then": [
+          "$gt0015|Age|=2|local::at0006|≥ 50 years|"
+        ]
+      },
+      "gt0027": {
+        "id": "gt0027",
+        "priority": 17,
+        "when": [
+          "$gt0005|White cell count|<15,10*9/l"
+        ],
+        "then": [
+          "$gt0016|White Blood Cell Count|=1|local::at0008|< 15 * 10^9/L|"
+        ]
+      },
+      "gt0028": {
+        "id": "gt0028",
+        "priority": 16,
+        "when": [
+          "$gt0005|White cell count|>=15,10*9/l"
+        ],
+        "then": [
+          "$gt0016|White Blood Cell Count|=2|local::at0009|≥ 15 * 10^9/L|"
+        ]
+      },
+      "gt0029": {
+        "id": "gt0029",
+        "priority": 15,
+        "when": [
+          "($gt0007|Urea|<5,mmol/l)||($gt0007|Urea|<14,mg/dl)"
+        ],
+        "then": [
+          "$gt0017|Urea|=1|local::at0011|< 5 mmol/L|"
+        ]
+      },
+      "gt0030": {
+        "id": "gt0030",
+        "priority": 14,
+        "when": [
+          "($gt0007|Urea|>=5,mmol/l)||($gt0007|Urea|>=14,mg/dl)"
+        ],
+        "then": [
+          "$gt0017|Urea|=2|local::at0012|≥ 5 mmol/L|"
+        ]
+      },
+      "gt0031": {
+        "id": "gt0031",
+        "priority": 13,
+        "when": [
+          "$gt0011|PT|!=null",
+          "$gt0013|normal lab PT reference|!=null"
+        ],
+        "then": [
+          "$gt0018|PT ratio|.magnitude=$gt0011.magnitude/$gt0013.magnitude",
+          "$gt0018|PT ratio|.precision=2"
+        ]
+      },
+      "gt0032": {
+        "id": "gt0032",
+        "priority": 12,
+        "when": [
+          "$gt0018|PT ratio|<'1.5'"
+        ],
+        "then": [
+          "$gt0019|PT ratio ordinal|=1|local::at0014|< 1.5|"
+        ]
+      },
+      "gt0033": {
+        "id": "gt0033",
+        "priority": 11,
+        "when": [
+          "$gt0018|PT ratio|>='1.5'",
+          "$gt0018|PT ratio|<='2.0'"
+        ],
+        "then": [
+          "$gt0019|PT ratio ordinal|=2|local::at0015|1.5 - 2.0|"
+        ]
+      },
+      "gt0034": {
+        "id": "gt0034",
+        "priority": 10,
+        "when": [
+          "$gt0018|PT ratio|>'2.0'"
+        ],
+        "then": [
+          "$gt0019|PT ratio ordinal|=3|local::at0016|> 2.0|"
+        ]
+      },
+      "gt0035": {
+        "id": "gt0035",
+        "priority": 9,
+        "when": [
+          "$gt0009|Total bilirubin|<125",
+          "$gt0009|Total bilirubin|.unit=='µmol/l'"
+        ],
+        "then": [
+          "$gt0020|Bilirubin|=1|local::at0018|< 125 umol/L|"
+        ]
+      },
+      "gt0036": {
+        "id": "gt0036",
+        "priority": 8,
+        "when": [
+          "$gt0009|Total bilirubin|>=125",
+          "$gt0009|Total bilirubin|<=250",
+          "$gt0009|Total bilirubin|.unit=='µmol/l'"
+        ],
+        "then": [
+          "$gt0020|Bilirubin|=2|local::at0019|125 - 250 umol/L|"
+        ]
+      },
+      "gt0037": {
+        "id": "gt0037",
+        "priority": 7,
+        "when": [
+          "$gt0009|Total bilirubin|>250",
+          "$gt0009|Total bilirubin|.unit=='µmol/l'"
+        ],
+        "then": [
+          "$gt0020|Bilirubin|=3|local::at0020|> 250 umol/L|"
+        ]
+      },
+      "gt0039": {
+        "id": "gt0039",
+        "priority": 6,
+        "when": [
+          "$gt0009|Total bilirubin|.unit=='mg/dl'",
+          "$gt0009|Total bilirubin|.magnitude<7.31"
+        ],
+        "then": [
+          "$gt0020|Bilirubin|=1|local::at0018|< 125 umol/L|"
+        ]
+      },
+      "gt0040": {
+        "id": "gt0040",
+        "priority": 5,
+        "when": [
+          "$gt0009|Total bilirubin|.unit=='mg/dl'",
+          "$gt0009|Total bilirubin|.magnitude>=7.31",
+          "$gt0009|Total bilirubin|.magnitude<=14.62"
+        ],
+        "then": [
+          "$gt0020|Bilirubin|=2|local::at0019|125 - 250 umol/L|"
+        ]
+      },
+      "gt0041": {
+        "id": "gt0041",
+        "priority": 4,
+        "when": [
+          "$gt0009|Total bilirubin|.unit=='mg/dl'",
+          "$gt0009|Total bilirubin|.magnitude>14.62"
+        ],
+        "then": [
+          "$gt0020|Bilirubin|=3|local::at0020|> 250 umol/L|"
+        ]
+      },
+      "gt0038": {
+        "id": "gt0038",
+        "priority": 3,
+        "when": [
+          "$gt0003|Age|!=null",
+          "$gt0005|White cell count|!=null",
+          "$gt0007|Urea|!=null",
+          "$gt0009|Total bilirubin|!=null",
+          "$gt0011|PT|!=null",
+          "$gt0013|normal lab PT reference|!=null"
+        ],
+        "then": [
+          "$gt0021|Glasgow alcoholic hepatitis score|.magnitude=$gt0015.value+$gt0016.value+$gt0017.value+$gt0019.value+$gt0020.value"
+        ]
+      },
+      "gt0042": {
+        "id": "gt0042",
+        "priority": 2,
+        "when": [
+          "$gt0021|Glasgow alcoholic hepatitis score|<9"
+        ],
+        "then": [
+          "$gt0045|Day 28 survival rate|=1|local::at0004|High (87%)|",
+          "$gt0046|Day 84 survival rate|=1|local::at0007|High (79%)|"
+        ]
+      },
+      "gt0043": {
+        "id": "gt0043",
+        "priority": 1,
+        "when": [
+          "$gt0021|Glasgow alcoholic hepatitis score|>=9"
+        ],
+        "then": [
+          "$gt0045|Day 28 survival rate|=0|local::at0003|Low (46%)|",
+          "$gt0046|Day 84 survival rate|=0|local::at0006|Low (40%)|"
+        ]
+      }
+    }
+  },
+  "ontology": {
+    "term_definitions": {
+      "en": {
+        "id": "en",
+        "terms": {
+          "gt0001": {
+            "id": "gt0001",
+            "text": "Glasgow_alcoholic_hepatitis_score",
+            "description": "The tool to assess the condition and predict the 28-day and 84-day survival rate outcomes in patients with alcoholic hepatitis."
+          },
+          "gt0003": {
+            "id": "gt0003",
+            "text": "Age",
+            "description": "Age in years, and for babies: months, weeks or days"
+          },
+          "gt0005": {
+            "id": "gt0005",
+            "text": "White cell count",
+            "description": "The number of white cells per litre"
+          },
+          "gt0007": {
+            "id": "gt0007",
+            "text": "Urea",
+            "description": "Urea level in this specimen."
+          },
+          "gt0009": {
+            "id": "gt0009",
+            "text": "Total bilirubin",
+            "description": "Concentration of bilirubin (conjugated and unconjugated) in the serum."
+          },
+          "gt0011": {
+            "id": "gt0011",
+            "text": "PT",
+            "description": "Prothrombin time."
+          },
+          "gt0013": {
+            "id": "gt0013",
+            "text": "normal lab PT reference",
+            "description": "*"
+          },
+          "gt0015": {
+            "id": "gt0015",
+            "text": "Age",
+            "description": "*"
+          },
+          "gt0016": {
+            "id": "gt0016",
+            "text": "White Blood Cell Count",
+            "description": "*"
+          },
+          "gt0017": {
+            "id": "gt0017",
+            "text": "Urea",
+            "description": "*"
+          },
+          "gt0018": {
+            "id": "gt0018",
+            "text": "PT ratio",
+            "description": "*"
+          },
+          "gt0019": {
+            "id": "gt0019",
+            "text": "PT ratio ordinal",
+            "description": "*"
+          },
+          "gt0020": {
+            "id": "gt0020",
+            "text": "Bilirubin",
+            "description": "*"
+          },
+          "gt0021": {
+            "id": "gt0021",
+            "text": "Glasgow alcoholic hepatitis score",
+            "description": "*"
+          },
+          "gt0023": {
+            "id": "gt0023",
+            "text": "Day 28 survival rate",
+            "description": "*"
+          },
+          "gt0024": {
+            "id": "gt0024",
+            "text": "Day 84 survival rate",
+            "description": "*"
+          },
+          "gt0025": {
+            "id": "gt0025",
+            "text": "Set age value < 50 years"
+          },
+          "gt0026": {
+            "id": "gt0026",
+            "text": "Set age value >= 50 years"
+          },
+          "gt0027": {
+            "id": "gt0027",
+            "text": "Set WBC value < 15 * 10^9/L"
+          },
+          "gt0028": {
+            "id": "gt0028",
+            "text": "Set WBC value >= 15 * 10^9/L"
+          },
+          "gt0029": {
+            "id": "gt0029",
+            "text": "Set urea value < 5 mmol/L"
+          },
+          "gt0030": {
+            "id": "gt0030",
+            "text": "Set urea value >= 5 mmol/L"
+          },
+          "gt0031": {
+            "id": "gt0031",
+            "text": "Calculate PT ratio"
+          },
+          "gt0032": {
+            "id": "gt0032",
+            "text": "Set PT ratio value < 1.5"
+          },
+          "gt0033": {
+            "id": "gt0033",
+            "text": "Set PT ratio value 1.5 - 2.0"
+          },
+          "gt0034": {
+            "id": "gt0034",
+            "text": "Set PT ratio value 2.0"
+          },
+          "gt0035": {
+            "id": "gt0035",
+            "text": "Set bilirubin value < 125 umol/L"
+          },
+          "gt0036": {
+            "id": "gt0036",
+            "text": "Set bilirubin value 125 - 250 umol/L"
+          },
+          "gt0037": {
+            "id": "gt0037",
+            "text": "Set bilirubin value > 250 umol/L"
+          },
+          "gt0038": {
+            "id": "gt0038",
+            "text": "Calculate GAHS"
+          },
+          "gt0039": {
+            "id": "gt0039",
+            "text": "Set bilirubin value < 7.31 mg/dL"
+          },
+          "gt0040": {
+            "id": "gt0040",
+            "text": "Set bilirubin value 7.31 - 14.62 mg/dL"
+          },
+          "gt0041": {
+            "id": "gt0041",
+            "text": "Set bilirubin value > 14.62 mg/dL"
+          },
+          "gt0042": {
+            "id": "gt0042",
+            "text": "Set output GAHS < 9"
+          },
+          "gt0043": {
+            "id": "gt0043",
+            "text": "Set output GAHS >= 9"
+          },
+          "gt0045": {
+            "id": "gt0045",
+            "text": "Day 28 survival rate",
+            "description": "*"
+          },
+          "gt0046": {
+            "id": "gt0046",
+            "text": "Day 84 survival rate",
+            "description": "*"
+          }
+        }
+      }
+    }
+  }
+}

--- a/gdl2/Glasgow_alcoholic_hepatitis_score.v1.test.yml
+++ b/gdl2/Glasgow_alcoholic_hepatitis_score.v1.test.yml
@@ -1,0 +1,234 @@
+guidelines:
+  1: Glasgow_alcoholic_hepatitis_score.v1
+test_cases:
+- id: minimum GAHS score (5), inputs in default measurement unit
+  input:
+    1:
+      gt0003|Age: 49,a
+      gt0005|White cell count: 14,10*9/l
+      gt0007|Urea: 4.9,mmol/l
+      gt0009|Total bilirubin: 124,µmol/l
+      gt0011|PT: 16,s
+      gt0013|normal lab PT reference: 12,s
+  expected_output:
+    1:
+      gt0015|Age: 1|local::at0005|< 50 years|
+      gt0017|Urea: 1|local::at0011|< 5 mmol/L|
+      gt0020|Bilirubin: 1|local::at0018|< 125 umol/L|
+      gt0018|PT ratio: 1.33
+      gt0021|Glasgow alcoholic hepatitis score: 5
+      gt0016|White Blood Cell Count: 1|local::at0008|< 15 * 10^9/L|
+      gt0019|PT ratio ordinal: 1|local::at0014|< 1.5|
+      gt0046|Day 84 survival rate: 1|local::at0007|High (79%)|
+      gt0045|Day 28 survival rate: 1|local::at0004|High (87%)|
+
+- id: GAHS 8, inputs in default measurement unit
+  input:
+    1:
+      gt0003|Age: 50,a
+      gt0005|White cell count: 14,10*9/l
+      gt0007|Urea: 5,mmol/l
+      gt0009|Total bilirubin: 125,µmol/l
+      gt0011|PT: 16,s
+      gt0013|normal lab PT reference: 11,s
+  expected_output:
+    1:
+      gt0015|Age: 2|local::at0006|≥ 50 years|
+      gt0017|Urea: 2|local::at0012|≥ 5 mmol/L|
+      gt0020|Bilirubin: 2|local::at0019|125 - 250 umol/L|
+      gt0018|PT ratio: 1.45
+      gt0021|Glasgow alcoholic hepatitis score: 8
+      gt0016|White Blood Cell Count: 1|local::at0008|< 15 * 10^9/L|
+      gt0019|PT ratio ordinal: 1|local::at0014|< 1.5|
+      gt0046|Day 84 survival rate: 1|local::at0007|High (79%)|
+      gt0045|Day 28 survival rate: 1|local::at0004|High (87%)|
+
+- id: GAHS 9, bilirubin 125 umol/L, inputs in default measurement unit
+  input:
+    1:
+      gt0003|Age: 50,a
+      gt0005|White cell count: 15,10*9/l
+      gt0007|Urea: 5,mmol/l
+      gt0009|Total bilirubin: 125,µmol/l
+      gt0011|PT: 16,s
+      gt0013|normal lab PT reference: 11,s
+  expected_output:
+    1:
+      gt0015|Age: 2|local::at0006|≥ 50 years|
+      gt0017|Urea: 2|local::at0012|≥ 5 mmol/L|
+      gt0020|Bilirubin: 2|local::at0019|125 - 250 umol/L|
+      gt0018|PT ratio: 1.45
+      gt0021|Glasgow alcoholic hepatitis score: 9
+      gt0016|White Blood Cell Count: 2|local::at0009|≥ 15 * 10^9/L|
+      gt0019|PT ratio ordinal: 1|local::at0014|< 1.5|
+      gt0046|Day 84 survival rate: 0|local::at0006|Low (40%)|
+      gt0045|Day 28 survival rate: 0|local::at0003|Low (46%)|
+
+- id: bilirubin 250 umol/L, PT ratio 1.5-2.0
+  input:
+    1:
+      gt0003|Age: 50,a
+      gt0005|White cell count: 15,10*9/l
+      gt0007|Urea: 5,mmol/l
+      gt0009|Total bilirubin: 250,µmol/l
+      gt0011|PT: 17,s
+      gt0013|normal lab PT reference: 11,s
+  expected_output:
+    1:
+      gt0015|Age: 2|local::at0006|≥ 50 years|
+      gt0017|Urea: 2|local::at0012|≥ 5 mmol/L|
+      gt0020|Bilirubin: 2|local::at0019|125 - 250 umol/L|
+      gt0018|PT ratio: 1.55
+      gt0021|Glasgow alcoholic hepatitis score: 10
+      gt0016|White Blood Cell Count: 2|local::at0009|≥ 15 * 10^9/L|
+      gt0019|PT ratio ordinal: 2|local::at0015|1.5 - 2.0|
+      gt0046|Day 84 survival rate: 0|local::at0006|Low (40%)|
+      gt0045|Day 28 survival rate: 0|local::at0003|Low (46%)|
+
+- id: bilirubin 251 umol/L, PT ratio 1.5-2.0
+  input:
+    1:
+      gt0003|Age: 50,a
+      gt0005|White cell count: 15,10*9/l
+      gt0007|Urea: 5,mmol/l
+      gt0009|Total bilirubin: 251,µmol/l
+      gt0011|PT: 20,s
+      gt0013|normal lab PT reference: 10,s
+  expected_output:
+    1:
+      gt0015|Age: 2|local::at0006|≥ 50 years|
+      gt0017|Urea: 2|local::at0012|≥ 5 mmol/L|
+      gt0020|Bilirubin: 3|local::at0020|> 250 umol/L|
+      gt0018|PT ratio: 2.00
+      gt0021|Glasgow alcoholic hepatitis score: 11
+      gt0016|White Blood Cell Count: 2|local::at0009|≥ 15 * 10^9/L|
+      gt0019|PT ratio ordinal: 2|local::at0015|1.5 - 2.0|
+      gt0046|Day 84 survival rate: 0|local::at0006|Low (40%)|
+      gt0045|Day 28 survival rate: 0|local::at0003|Low (46%)|
+
+- id: max GAHS score (12), inputs in default measurement unit
+  input:
+    1:
+      gt0003|Age: 50,a
+      gt0005|White cell count: 15,10*9/l
+      gt0007|Urea: 5,mmol/l
+      gt0009|Total bilirubin: 251,µmol/l
+      gt0011|PT: 21,s
+      gt0013|normal lab PT reference: 10,s
+  expected_output:
+    1:
+      gt0015|Age: 2|local::at0006|≥ 50 years|
+      gt0017|Urea: 2|local::at0012|≥ 5 mmol/L|
+      gt0020|Bilirubin: 3|local::at0020|> 250 umol/L|
+      gt0018|PT ratio: 2.10
+      gt0021|Glasgow alcoholic hepatitis score: 12
+      gt0016|White Blood Cell Count: 2|local::at0009|≥ 15 * 10^9/L|
+      gt0019|PT ratio ordinal: 3|local::at0016|> 2.0|
+      gt0046|Day 84 survival rate: 0|local::at0006|Low (40%)|
+      gt0045|Day 28 survival rate: 0|local::at0003|Low (46%)|
+
+
+- id: minimum GAHS score, urea and bilirubin in alternative measurement unit
+  input:
+    1:
+      gt0003|Age: 49,a
+      gt0005|White cell count: 14,10*9/l
+      gt0007|Urea: 14,mg/dl
+      gt0009|Total bilirubin: 7.3,mg/dl
+      gt0011|PT: 16,s
+      gt0013|normal lab PT reference: 11,s
+  expected_output:
+    1:
+      gt0015|Age: 1|local::at0005|< 50 years|
+      gt0017|Urea: 2|local::at0012|≥ 5 mmol/L|
+      gt0020|Bilirubin: 1|local::at0018|< 125 umol/L|
+      gt0018|PT ratio: 1.45
+      gt0021|Glasgow alcoholic hepatitis score: 6
+      gt0016|White Blood Cell Count: 1|local::at0008|< 15 * 10^9/L|
+      gt0019|PT ratio ordinal: 1|local::at0014|< 1.5|
+      gt0046|Day 84 survival rate: 1|local::at0007|High (79%)|
+      gt0045|Day 28 survival rate: 1|local::at0004|High (87%)|
+
+- id: in alternative measurement unit, urea <14mg/dL and bilirubin <7.31mg/dL
+  input:
+    1:
+      gt0003|Age: 50,a
+      gt0005|White cell count: 15,10*9/l
+      gt0007|Urea: 13.9,mg/dl
+      gt0009|Total bilirubin: 7.30,mg/dl
+      gt0011|PT: 21,s
+      gt0013|normal lab PT reference: 10,s
+  expected_output:
+    1:
+      gt0015|Age: 2|local::at0006|≥ 50 years|
+      gt0017|Urea: 1|local::at0011|< 5 mmol/L|
+      gt0020|Bilirubin: 1|local::at0018|< 125 umol/L|
+      gt0018|PT ratio: 2.10
+      gt0021|Glasgow alcoholic hepatitis score: 9
+      gt0016|White Blood Cell Count: 2|local::at0009|≥ 15 * 10^9/L|
+      gt0019|PT ratio ordinal: 3|local::at0016|> 2.0|
+      gt0046|Day 84 survival rate: 0|local::at0006|Low (40%)|
+      gt0045|Day 28 survival rate: 0|local::at0003|Low (46%)|
+
+- id: in alternative measurement unit, urea >=14mg/dL and bilirubin 7.31-14.62 mg/dL
+  input:
+    1:
+      gt0003|Age: 50,a
+      gt0005|White cell count: 15,10*9/l
+      gt0007|Urea: 14,mg/dl
+      gt0009|Total bilirubin: 7.31,mg/dl
+      gt0011|PT: 21,s
+      gt0013|normal lab PT reference: 10,s
+  expected_output:
+    1:
+      gt0015|Age: 2|local::at0006|≥ 50 years|
+      gt0017|Urea: 2|local::at0012|≥ 5 mmol/L|
+      gt0020|Bilirubin: 2|local::at0019|125 - 250 umol/L|
+      gt0018|PT ratio: 2.10
+      gt0021|Glasgow alcoholic hepatitis score: 11
+      gt0016|White Blood Cell Count: 2|local::at0009|≥ 15 * 10^9/L|
+      gt0019|PT ratio ordinal: 3|local::at0016|> 2.0|
+      gt0046|Day 84 survival rate: 0|local::at0006|Low (40%)|
+      gt0045|Day 28 survival rate: 0|local::at0003|Low (46%)|
+
+- id: in alternative measurement unit, urea >=14mg/dL and bilirubin 14.62 mg/dL
+  input:
+    1:
+      gt0003|Age: 50,a
+      gt0005|White cell count: 15,10*9/l
+      gt0007|Urea: 14,mg/dl
+      gt0009|Total bilirubin: 14.62,mg/dl
+      gt0011|PT: 21,s
+      gt0013|normal lab PT reference: 10,s
+  expected_output:
+    1:
+      gt0015|Age: 2|local::at0006|≥ 50 years|
+      gt0017|Urea: 2|local::at0012|≥ 5 mmol/L|
+      gt0020|Bilirubin: 2|local::at0019|125 - 250 umol/L|
+      gt0018|PT ratio: 2.10
+      gt0021|Glasgow alcoholic hepatitis score: 11
+      gt0016|White Blood Cell Count: 2|local::at0009|≥ 15 * 10^9/L|
+      gt0019|PT ratio ordinal: 3|local::at0016|> 2.0|
+      gt0046|Day 84 survival rate: 0|local::at0006|Low (40%)|
+      gt0045|Day 28 survival rate: 0|local::at0003|Low (46%)|
+
+- id: in alternative measurement unit, bilirubin >14.62 mg/dL
+  input:
+    1:
+      gt0003|Age: 50,a
+      gt0005|White cell count: 15,10*9/l
+      gt0007|Urea: 14,mg/dl
+      gt0009|Total bilirubin: 14.63,mg/dl
+      gt0011|PT: 21,s
+      gt0013|normal lab PT reference: 10,s
+  expected_output:
+    1:
+      gt0015|Age: 2|local::at0006|≥ 50 years|
+      gt0017|Urea: 2|local::at0012|≥ 5 mmol/L|
+      gt0020|Bilirubin: 3|local::at0020|> 250 umol/L|
+      gt0018|PT ratio: 2.10
+      gt0021|Glasgow alcoholic hepatitis score: 12
+      gt0016|White Blood Cell Count: 2|local::at0009|≥ 15 * 10^9/L|
+      gt0019|PT ratio ordinal: 3|local::at0016|> 2.0|
+      gt0046|Day 84 survival rate: 0|local::at0006|Low (40%)|
+      gt0045|Day 28 survival rate: 0|local::at0003|Low (46%)|


### PR DESCRIPTION
Based on Winner's work with the following changes:
- Changed description (use field) that now it includes how the score should be calculated.
- Modified assessment category names (that now includes percentages as well)
- Included unit checks for the bilirubin rules. I understand that μ sign should not be in the constant comparison but in the unit comparison it can be, otherwise the initial rule would allow a bilirubin value even without a unit.
- one of the rules name changed (it was Copy of ....)