### PR TITLE
COVID-GRAM Critical Illness Risk Score-Updated

### DIFF
--- a/gdl2/COVID-GRAM_Critical_Illness_Risk_Score_guideline.v1.gdl2.json
+++ b/gdl2/COVID-GRAM_Critical_Illness_Risk_Score_guideline.v1.gdl2.json
@@ -145,9 +145,9 @@
           "$gt0010|Cancer history|!=null",
           "$gt0011|Neutrophil-lymphocyte ratio (NLR)|!=null",
           "$gt0012|Lactate dehydrogenase|!=null",
-          "$gt0014|Direct Bilirubin|!=null",
+          "$gt0014|Direct Bilirubin, umol/l|!=null",
           "$gt0003|Age|.unit=='a'",
-          "$gt0014|Direct Bilirubin|.unit=='umol/l'"
+          "$gt0014|Direct Bilirubin, umol/l|.unit=='umol/l'"
         ],
         "then": [
           "$gt0019|COVID-GRAM Risk Score|.magnitude=round(($gt0005.value*27.1464)+($gt0003.magnitude*0.6139)+($gt0006.value*33.621)+($gt0007.value*14.0569)+($gt0008.value*34.4617)+($gt0009.value*10.3826)+($gt0010.value*31.2211)+($gt0011.magnitude*1.25)+($gt0012.magnitude*0.0534)+($gt0014.magnitude*3.0605))",
@@ -267,7 +267,7 @@
           },
           "gt0014": {
             "id": "gt0014",
-            "text": "Direct Bilirubin",
+            "text": "Direct Bilirubin, umol/l",
             "description": "The separate test for Direct Bilirubin (BR) (conjugated) is useful to estimate the measure for unconjugated BR by taking it away from Total BR"
           },
           "gt0017": {


### PR DESCRIPTION
Add unit, umol/l to the input title for Direct Bilirubin.